### PR TITLE
nnInteractive v2: Docker build, inference performance, and viewer UX

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -5,7 +5,7 @@
 #   cp .env-sample .env
 #
 # Docker Compose loads `.env` automatically and injects the variables below into
-# the `monai_sam2` service (see `docker-compose.yml` → `monai_sam2.environment`).
+# the `monai_server` service (see `docker-compose.yml` → `monai_server.environment`).
 # The MONAI infer task (`monai-label/.../basic_infer.py`) reads them with
 # `os.environ.get(...)`.
 #

--- a/.gitignore
+++ b/.gitignore
@@ -263,3 +263,5 @@ xnat-docker/xnat-data
 xnat-docker/xnat/plugins
 
 .env
+.build-hashes/
+docs/superpowers/

--- a/README.md
+++ b/README.md
@@ -294,18 +294,19 @@ Radiology-style reports from **3D CT/MRI** are separate from segmentation. In th
 
 For faster workflow, you can use the following keyboard shortcuts:
 
-**Prompt Types:**
-- `a` - Point
+**Prompt Tools:**
+- `p` - Point
 - `s` - Scribble
-- `d` - Lasso
-- `f` - Bounding box
+- `l` - Lasso
+- `b` - Bounding box
+
+**Segment Management:**
+- `m` - Add Segment
+- `r` - Reset active Segment (clears prompts and mask)
 
 **Mode Controls:**
 - `q` - Toggle Live Mode
-- `w` - Toggle Positive/Negative
-- `e` - Toggle Refine/New
-- `r` - Run inference (if live mode off)
-- `t` - Circulate nnInteractive -> SAM2 -> MedSAM2 -> SAM3
+- `t` - Toggle Positive/Negative
 
 <a href="docs/images/hotkeys.png" target="_blank">
   <img src="docs/images/hotkeys.png" alt="List of hotkeys" width="700">

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Model checkpoints are typically downloaded automatically during setup. However, 
 
 ### Local MedGemma GPUs
 
-- **`docker-compose.yml`** → **`monai_sam2`** → **`CUDA_VISIBLE_DEVICES`**: which **host** GPUs the container sees (logical `cuda:0`, …; shared with segmentation).
+- **`docker-compose.yml`** → **`monai_server`** → **`CUDA_VISIBLE_DEVICES`**: which **host** GPUs the container sees (logical `cuda:0`, …; shared with segmentation).
 - **`basic_infer.py`** → **`_medgemma_get_processor_and_model`** → **`gem_model_kwargs`**: default **`device_map="auto"`** + **`max_memory`** per logical GPU; adjust caps or use **`device_map={"": "cuda:0"}`** to pin one GPU.
 - Rebuild / restart MONAI after editing **`basic_infer.py`**. Not configured via `.env`.
 
@@ -148,7 +148,7 @@ Report generation can call **Hugging Face** (Hub downloads and/or the **Kimi**, 
    ```bash
    cp .env-sample .env
    ```
-2. **Edit `.env`** and fill in only the providers you use. Docker Compose reads `.env` automatically and passes values into the `monai_sam2` container (see `docker-compose.yml` → `environment`). The MONAI infer task resolves keys from the **infer request** first, then from **these environment variables**:
+2. **Edit `.env`** and fill in only the providers you use. Docker Compose reads `.env` automatically and passes values into the `monai_server` container (see `docker-compose.yml` → `environment`). The MONAI infer task resolves keys from the **infer request** first, then from **these environment variables**:
    - **`HF_TOKEN`** — Hugging Face token ([create a token](https://huggingface.co/settings/tokens)): authenticated downloads (e.g. MedGemma) and **Hugging Face router** VLMs (Kimi / Qwen / Gemma 4).
    - **`GEMINI_API_KEY`** — [Google AI Studio](https://aistudio.google.com/apikey) for Gemini.
    - **`OPENAI_API_KEY`** — [OpenAI](https://platform.openai.com/api-keys) for GPT-class models.

--- a/Viewers/Dockerfile
+++ b/Viewers/Dockerfile
@@ -44,7 +44,8 @@
 # Copy Files
 FROM node:20.18.1-slim as builder
 
-RUN apt-get update && apt-get install -y build-essential python3
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends build-essential python3
 
 
 RUN mkdir /usr/src/app
@@ -58,8 +59,7 @@ COPY package.json yarn.lock preinstall.js lerna.json ./
 COPY --parents ./addOns/package.json ./addOns/*/*/package.json ./extensions/*/package.json ./modes/*/package.json ./platform/*/package.json ./
 # Run the install before copying the rest of the files
 
-RUN bun pm cache rm
-RUN bun install
+RUN --mount=type=cache,target=/root/.bun/install/cache bun install
 # Copy the local directory
 COPY --link --exclude=yarn.lock --exclude=package.json --exclude=Dockerfile . .
 

--- a/Viewers/backup/esm/labelmapDisplay.js
+++ b/Viewers/backup/esm/labelmapDisplay.js
@@ -1,4 +1,4 @@
-import { getEnabledElementByViewportId, VolumeViewport, } from '@cornerstonejs/core';
+import { getEnabledElementByViewportId, VolumeViewport, cache, } from '@cornerstonejs/core';
 import addLabelmapToElement from './addLabelmapToElement';
 import removeLabelmapFromElement from './removeLabelmapFromElement';
 import { getActiveSegmentation } from '../../../stateManagement/segmentation/activeSegmentation';
@@ -180,15 +180,41 @@ function _setLabelmapColorAndOpacity(viewportId, labelmapActorEntry, segmentatio
                     : outlineWidth;
         }
         labelmapActor.getProperty().setLabelOutlineThickness(outlineWidths);
-        labelmapActor.modified();
-        labelmapActor.getProperty().modified();
-        labelmapActor.getMapper().modified();
     }
     else {
         labelmapActor
             .getProperty()
             .setLabelOutlineThickness(new Array(numColors - 1).fill(0));
     }
+    // Sync cache→VTK copy and mark the pipeline dirty so the GPU texture is
+    // re-uploaded on every segmentation render event.
+    //
+    // Root cause: StackViewport.createVTKImageData() allocates a NEW empty
+    // TypedArray (not a reference to the cache buffer).  updateVTKImageDataWithCornerstoneImage
+    // copies cache→VTK via scalarData.set(pixelData) — but only when scrolling.
+    // After brush/inference modifies the cache, VTK's copy is stale.
+    // Calling scalars.modified() alone is wrong: it marks the stale copy as
+    // "changed" but re-uploads the same stale data.  We must copy first.
+    const inputData = labelmapActor.getMapper()?.getInputData?.();
+    if (inputData) {
+        const imageId = labelmapActorEntry.referencedId;
+        const csImage = imageId ? cache.getImage(imageId) : null;
+        if (csImage) {
+            const pixelData = csImage.voxelManager?.getScalarData?.();
+            const vtkScalars = inputData.getPointData?.()?.getScalars?.();
+            if (pixelData && vtkScalars) {
+                const vtkData = vtkScalars.getData?.();
+                if (vtkData && vtkData.length === pixelData.length) {
+                    vtkData.set(pixelData);
+                }
+                vtkScalars.modified();
+            }
+        }
+        inputData.modified();
+    }
+    labelmapActor.modified();
+    labelmapActor.getProperty().modified();
+    labelmapActor.getMapper().modified();
     const visible = isActiveLabelmap || renderInactiveSegmentations;
     labelmapActor.setVisibility(visible);
 }

--- a/Viewers/backup/esm/renderMethods.js
+++ b/Viewers/backup/esm/renderMethods.js
@@ -63,8 +63,7 @@ function renderClosedContour(enabledElement, svgDrawingHelper, annotation) {
 function renderOpenContour(enabledElement, svgDrawingHelper, annotation) {
     const { viewport } = enabledElement;
     const options = this._getRenderingOptions(enabledElement, annotation);
-    //Thicker for scribble
-    options.width = 3;
+    options.width = 2;
     const canvasPoints = annotation.data.contour.polyline.map((worldPos) => viewport.worldToCanvas(worldPos));
     const polylineUID = '1';
     drawPolylineSvg(svgDrawingHelper, annotation.annotationUID, polylineUID, canvasPoints, options);

--- a/Viewers/backup/vtkjs/ImageMarchingSquares.js
+++ b/Viewers/backup/vtkjs/ImageMarchingSquares.js
@@ -171,8 +171,6 @@ function vtkImageMarchingSquares(publicAPI, model) {
       vtkErrorMacro('Invalid or missing slicing mode');
       return;
     }
-    console.time('msquares');
-
     // Retrieve output and volume data
     const origin = input.getOrigin();
     const spacing = input.getSpacing();
@@ -214,7 +212,6 @@ function vtkImageMarchingSquares(publicAPI, model) {
     polydata.getLines().setData(new Uint32Array(lines));
     outData[0] = polydata;
     vtkDebugMacro('Produced output');
-    console.timeEnd('msquares');
   };
 }
 

--- a/Viewers/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
+++ b/Viewers/extensions/cornerstone/src/Viewport/OHIFCornerstoneViewport.tsx
@@ -276,7 +276,7 @@ const OHIFCornerstoneViewport = React.memo(
           displaySetOptions,
           presentations
         );
-        commandsManager.run('initNninter');
+        commandsManager.run('initNninter', { viewportId });
       };
 
       loadViewportData();

--- a/Viewers/extensions/cornerstone/src/commandsModule.ts
+++ b/Viewers/extensions/cornerstone/src/commandsModule.ts
@@ -721,6 +721,30 @@ function commandsModule({
         actions.setToolActive({ toolName, toolGroupId });
       });
     },
+    toggleToolActiveToolbar: ({ value, itemId, toolName, toolGroupIds = [] }) => {
+      toolName = toolName || itemId || value;
+      toolGroupIds = toolGroupIds.length ? toolGroupIds : toolGroupService.getToolGroupIds();
+
+      // Check active viewport to decide toggle direction
+      const { activeViewportId } = viewportGridService.getState();
+      const activeToolGroup = toolGroupService.getToolGroupForViewport(activeViewportId);
+      const isCurrentlyActive = activeToolGroup?.getActivePrimaryMouseButtonTool() === toolName;
+
+      if (isCurrentlyActive) {
+        // Deactivate: set passive and fall back to Pan
+        toolGroupIds.forEach(toolGroupId => {
+          const tg = toolGroupService.getToolGroup(toolGroupId);
+          if (tg?.hasTool(toolName)) {
+            tg.setToolPassive(toolName);
+          }
+          if (tg?.hasTool('Pan')) {
+            actions.setToolActive({ toolName: 'Pan', toolGroupId });
+          }
+        });
+      } else {
+        actions.setToolActiveToolbar({ value, itemId, toolName, toolGroupIds });
+      }
+    },
     setToolActive: ({ toolName, toolGroupId = null }) => {
       const { viewports } = viewportGridService.getState();
 
@@ -1882,6 +1906,9 @@ function commandsModule({
     },
     setToolActiveToolbar: {
       commandFn: actions.setToolActiveToolbar,
+    },
+    toggleToolActiveToolbar: {
+      commandFn: actions.toggleToolActiveToolbar,
     },
     setToolEnabled: {
       commandFn: actions.setToolEnabled,

--- a/Viewers/extensions/cornerstone/src/panels/PanelSegmentation.tsx
+++ b/Viewers/extensions/cornerstone/src/panels/PanelSegmentation.tsx
@@ -3,7 +3,6 @@ import { SegmentationTable } from '@ohif/ui-next';
 import { useActiveViewportSegmentationRepresentations } from '../hooks/useActiveViewportSegmentationRepresentations';
 import { metaData } from '@cornerstonejs/core';
 import { useSystem } from '@ohif/core/src';
-import { toolboxState } from '@ohif/extension-default/src/stores/toolboxState';
 
 export default function PanelSegmentation({ children }: withAppTypes) {
   const { commandsManager, servicesManager } = useSystem();
@@ -51,6 +50,9 @@ export default function PanelSegmentation({ children }: withAppTypes) {
     onSegmentColorClick: (segmentationId, segmentIndex) => {
       commandsManager.run('editSegmentColor', { segmentationId, segmentIndex });
     },
+    onSegmentReset: (segmentationId, segmentIndex) => {
+      commandsManager.run('resetSegment', { segmentationId, segmentIndex });
+    },
     onSegmentDelete: (segmentationId, segmentIndex) => {
       const deletePromise = new Promise<void>((resolve, reject) => {
         setTimeout(() => {
@@ -82,8 +84,6 @@ export default function PanelSegmentation({ children }: withAppTypes) {
             }
 
             commandsManager.run('deleteSegment', { segmentationId, segmentIndex });
-            // Turn on Refine/New button after deleting segment
-            toolboxState.setRefineNew(true);
             resolve();
           } catch (error) {
             reject(error);
@@ -249,7 +249,6 @@ export default function PanelSegmentation({ children }: withAppTypes) {
     <SegmentationTable {...tableProps}>
       {children}
       <SegmentationTable.Config />
-      <SegmentationTable.AddSegmentationRow />
       {renderModeContent()}
     </SegmentationTable>
   );

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -37,6 +37,17 @@ import {
 import { parseMultipart } from './utils/multipart';
 import { callInputDialog } from './utils/callInputDialog';
 
+/** Tracks the last series initialized by initNninter to detect study/series changes. */
+let _lastInitSeries: string | undefined = undefined;
+
+/** Safely parse a numeric timing field from multipart response metadata. */
+function metaNum(meta: Record<string, unknown>, key: string): number | undefined {
+  const v = meta[key];
+  if (v === undefined || v === null) return undefined;
+  const n = typeof v === 'number' ? v : parseFloat(String(v));
+  return isFinite(n) ? n : undefined;
+}
+
 
 export type HangingProtocolParams = {
   protocolId?: string;
@@ -75,7 +86,10 @@ const commandsModule = ({
         evt.measurement.toolName
       )) {
         console.log('Live mode enabled, triggering nninter() for new measurement');
-        // Use setTimeout to ensure the measurement is fully processed
+        // Defer past the render cycle so _calculateCachedStats can populate
+        // cachedStats[targetId].scribble before nninter reads measurement data.
+        // Promise.resolve() (microtask) is too early — scribble data is set
+        // during the requestAnimationFrame render cycle that follows MEASUREMENT_ADDED.
         setTimeout(() => {
           if (toolboxState.getLocked()) {
             return;
@@ -155,8 +169,6 @@ const commandsModule = ({
         }
       ]);
     } else {
-      // Comment out at the moment (necessary for hiding previous segments), may need to uncomment some weird bugs.
-      servicesManager.services.segmentationService.clearSegmentationRepresentations(activeViewportId);
       const readableText = customizationService.getCustomization('panelSegmentation.readableText');
 
       // Get existing segmentation to preserve other representation data
@@ -206,81 +218,81 @@ const commandsModule = ({
     
     servicesManager.services.segmentationService.setActiveSegment(segmentationId, segmentNumber);
     toolboxState.setCurrentActiveSegment(segmentNumber);
-    await servicesManager.services.segmentationService.addSegmentationRepresentation(activeViewportId, {
-      segmentationId: segmentationId,
-    });
-    
+
     if (toolboxState.getRefineNew()) {
       toolboxState.setRefineNew(false);
     }
-    
-    // semi-hack: to render segmentation properly on the current image for stack viewport
-    const viewport = activeViewportId.startsWith('default') 
-      ? servicesManager.services.cornerstoneViewportService.getCornerstoneViewport(activeViewportId)
-      : null;
-    if (viewport?.setImageIdIndex && currentImageIdIndex !== undefined) {
-      const somewhereIndex = currentImageIdIndex === 0 ? 1 : 0;
-      await viewport.setImageIdIndex(somewhereIndex);
-      await viewport.setImageIdIndex(currentImageIdIndex);
-    }
-    
-    // Recover the visibility of the segments
-    for (let i = 0; i < representations.length; i++) {
-      const representation = representations[i];
-      const segments = Object.values(representation.segments);
-      
-      if (segments.length > 0) {
-        for (let j = 0; j < segments.length; j++) {
-          const segment = segments[j];
-          servicesManager.services.segmentationService.setSegmentVisibility(activeViewportId, representation.segmentationId, segment.segmentIndex, segment.visible);
+
+    if (!existing) {
+      // ── First-ever inference: no actors exist yet, must do full viewport setup ──
+
+      // Recover the visibility of any pre-existing segments
+      for (let i = 0; i < representations.length; i++) {
+        const representation = representations[i];
+        const segs = Object.values(representation.segments);
+        for (let j = 0; j < segs.length; j++) {
+          const seg = segs[j];
+          servicesManager.services.segmentationService.setSegmentVisibility(activeViewportId, representation.segmentationId, (seg as any).segmentIndex, (seg as any).visible);
         }
       }
-    }
 
-    // Update all viewports with the new segmentation representation
-    const currentViewportIds = servicesManager.services.cornerstoneViewportService.getViewportIds();
-    for (let i = 0; i < currentViewportIds.length; i++) {
-      const viewportId = currentViewportIds[i];
-      const viewport = servicesManager.services.cornerstoneViewportService.getCornerstoneViewport(viewportId);
-      const isVolume3D = viewport instanceof VolumeViewport3D;
+      // Add representations for all viewports
+      const currentViewportIds = servicesManager.services.cornerstoneViewportService.getViewportIds();
+      const regularViewportIds: string[] = [];
+      const volume3DViewportIds: string[] = [];
+      for (const viewportId of currentViewportIds) {
+        const vp = servicesManager.services.cornerstoneViewportService.getCornerstoneViewport(viewportId);
+        if (vp instanceof VolumeViewport3D) volume3DViewportIds.push(viewportId);
+        else regularViewportIds.push(viewportId);
+      }
 
-      servicesManager.services.segmentationService.removeSegmentationRepresentations(
-        viewportId,
-        { segmentationId }
-      );
-
-      // For VolumeViewport3D, update labelmap image references to trigger surface regeneration
-      if (isVolume3D) {
+      for (const viewportId of currentViewportIds) {
+        servicesManager.services.segmentationService.removeSegmentationRepresentations(viewportId, { segmentationId });
+      }
+      await Promise.all(regularViewportIds.map(viewportId =>
+        servicesManager.services.segmentationService.addSegmentationRepresentation(viewportId, { segmentationId })
+      ));
+      for (const viewportId of volume3DViewportIds) {
+        const vp = servicesManager.services.cornerstoneViewportService.getCornerstoneViewport(viewportId);
         updateLabelmapSegmentationImageReferences(viewportId, segmentationId);
-      }
-
-      // For VolumeViewport3D, explicitly specify Labelmap type to trigger viewport conversion to Surface
-      // This ensures the surface is properly computed from the updated labelmap
-      await servicesManager.services.segmentationService.addSegmentationRepresentation(viewportId, {
-        segmentationId: segmentationId,
-        type: isVolume3D ? csToolsEnums.SegmentationRepresentations.Labelmap : undefined,
-      });
-
-      // For VolumeViewport3D, wait a bit for surface computation to complete, then render
-      if (isVolume3D) {
-        // Give time for surface computation to complete
-        await new Promise(resolve => setTimeout(resolve, 100));
-        // Use requestAnimationFrame to ensure the representation is fully added before rendering
-        requestAnimationFrame(() => {
-          if (viewport) {
-            viewport.render();
-          }
+        await servicesManager.services.segmentationService.addSegmentationRepresentation(viewportId, {
+          segmentationId,
+          type: csToolsEnums.SegmentationRepresentations.Labelmap,
         });
+        await new Promise(resolve => setTimeout(resolve, 100));
+        requestAnimationFrame(() => vp?.render());
       }
-    }
 
-    // Trigger SEGMENTATION_DATA_MODIFIED event AFTER all representations are re-added
-    // This ensures surface representations exist before they try to update
-    eventTarget.dispatchEvent(
-      new CustomEvent(csToolsEnums.Events.SEGMENTATION_DATA_MODIFIED, {
-        detail: { segmentationId },
-      })
-    );
+      // Scroll-away-back so Cornerstone creates the VTK actors for the current slice
+      // and uploads the initial GPU texture (only needed on first-ever inference).
+      const activeVp = activeViewportId.startsWith('default')
+        ? servicesManager.services.cornerstoneViewportService.getCornerstoneViewport(activeViewportId)
+        : null;
+      if (activeVp?.setImageIdIndex && currentImageIdIndex !== undefined) {
+        const away = currentImageIdIndex === 0 ? 1 : 0;
+        await activeVp.setImageIdIndex(away);
+        await activeVp.setImageIdIndex(currentImageIdIndex);
+      }
+
+      eventTarget.dispatchEvent(
+        new CustomEvent(csToolsEnums.Events.SEGMENTATION_DATA_MODIFIED, {
+          detail: { segmentationId },
+        })
+      );
+    } else {
+      // ── Refinement / update (existing segment) — fast path ──
+      // VTK actors for all viewports already exist and reference the same image
+      // buffers that were updated by the voxel-writing loop above.
+      // labelmapDisplay._setLabelmapColorAndOpacity now calls
+      // scalars.modified() + inputData.modified() unconditionally, so the GPU
+      // texture is re-uploaded on the next rAF render triggered by the event.
+      // No remove/re-add or scroll needed — saves ~300–350 ms per inference.
+      eventTarget.dispatchEvent(
+        new CustomEvent(csToolsEnums.Events.SEGMENTATION_DATA_MODIFIED, {
+          detail: { segmentationId },
+        })
+      );
+    }
   }
 
   const actions = {
@@ -787,7 +799,7 @@ const commandsModule = ({
       const selectedModel = toolboxState.getSelectedModel();
       const medsam2 = selectedModel //Check at monailabel server;
       const start = Date.now();
-      
+
       const segs = servicesManager.services.segmentationService.getSegmentations()
       const { activeViewportId, viewports } = viewportGridService.getState();
       const activeViewportSpecificData = viewports.get(activeViewportId);
@@ -799,16 +811,15 @@ const commandsModule = ({
       const displaySets = displaySetService.activeDisplaySets;
 
       const displaySetInstanceUID = displaySetInstanceUIDs[0];
-      const currentDisplaySets = displaySets.filter(e => {
-        return e.displaySetInstanceUID == displaySetInstanceUID;
-      })[0];
+      const currentDisplaySets = displaySets.find(e => e.displaySetInstanceUID === displaySetInstanceUID);
+      if (!currentDisplaySets) return;
 
       const currentMeasurements = measurementService.getMeasurements()
 
-      const unAssignedMeasurements = currentMeasurements.filter(e => { 
+      const unAssignedMeasurements = currentMeasurements.filter(e => {
         return e.metadata.SegmentNumber === undefined;
       })
-    
+
 
     const activeSegmentation = servicesManager.services.segmentationService.getActiveSegmentation(activeViewportId)
     let segmentNumber = 1;
@@ -876,29 +887,19 @@ const commandsModule = ({
     }
   }
 
-      const pos_points = currentMeasurements
-        .filter(e => {
-          return e.toolName === 'Probe2' && e.referenceSeriesUID === currentDisplaySets.SeriesInstanceUID && e.metadata.neg === false && e.metadata.SegmentNumber === segmentNumber;
-        })
-        .map(e => {
-          return Object.values(e.data)[0].index;
-        });
-      const neg_points = currentMeasurements
-        .filter(e => {
-          return e.toolName === 'Probe2' && e.referenceSeriesUID === currentDisplaySets.SeriesInstanceUID && e.metadata.neg === true && e.metadata.SegmentNumber === segmentNumber;
-        })
-        .map(e => {
-          return Object.values(e.data)[0].index;
-        });
-
-      const pos_boxes = currentMeasurements
-        .filter(e => { 
-          return e.toolName === 'RectangleROI2' && e.referenceSeriesUID === currentDisplaySets.SeriesInstanceUID && e.metadata.neg === false && e.metadata.SegmentNumber === segmentNumber;
-        })
-        .map(e => { 
-          return Object.values(e.data)[0].pointsInShape 
-        })
-        .map(e => { return [e.at(0).pointIJK, e.at(-1).pointIJK] })
+      const pos_points: any[] = [];
+      const neg_points: any[] = [];
+      const pos_boxes: any[] = [];
+      const seriesUID = currentDisplaySets.SeriesInstanceUID;
+      for (const e of currentMeasurements) {
+        if (e.referenceSeriesUID !== seriesUID || e.metadata.SegmentNumber !== segmentNumber) continue;
+        if (e.toolName === 'Probe2') {
+          (e.metadata.neg ? neg_points : pos_points).push(Object.values(e.data)[0].index);
+        } else if (e.toolName === 'RectangleROI2' && !e.metadata.neg) {
+          const pts = Object.values(e.data)[0].pointsInShape;
+          pos_boxes.push([pts.at(0).pointIJK, pts.at(-1).pointIJK]);
+        }
+      }
 
 
 
@@ -907,20 +908,11 @@ const commandsModule = ({
       //.filter(e => { return e.toolName === 'Probe2' && e.referenceSeriesUID === currentDisplaySets.SeriesInstanceUID && e.metadata.neg === false && e.metadata.SegmentNumber === segmentNumber; })
       //.map(e => { return e.label })
 
-      // Hide the measurements after inference
-      for (let i = 0; i < currentMeasurements.length; i++) {
-        const e = currentMeasurements[i];
-        if (e.referenceSeriesUID === currentDisplaySets.SeriesInstanceUID) {
-          measurementService.toggleVisibilityMeasurement(e.uid, false);
-        }
-      }
-
-      // Force a re-render of the segmentation table after a short delay
-      setTimeout(() => {
-        // This will trigger a re-render of components that depend on measurement state
-        const event = new Event('measurement-state-changed');
-        document.dispatchEvent(event);
-      }, 200);
+      // Hide measurements and notify in a single synchronous pass
+      currentMeasurements
+        .filter(e => e.referenceSeriesUID === currentDisplaySets.SeriesInstanceUID)
+        .forEach(e => measurementService.toggleVisibilityMeasurement(e.uid, false));
+      document.dispatchEvent(new Event('measurement-state-changed'));
       if (pos_points.length == 0 && neg_points.length == 0 && pos_boxes.length == 0 && text_prompts.length == 0){
         uiNotificationService.show({
           title: 'Prompt warning',
@@ -1046,7 +1038,6 @@ const commandsModule = ({
           if(flipped){
             derivedImages_new.reverse();
           }
-          console.log(`After reverse: ${(Date.now() - start)/1000} Seconds`);
           for (let i = 0; i < derivedImages_new.length; i++) {
             const voxelManager = derivedImages_new[i]
               .voxelManager as csTypes.IVoxelManager<number>;
@@ -1095,16 +1086,15 @@ const commandsModule = ({
           } else if (derivedImages.length > 0) {
             filteredDerivedImages = derivedImages;
           }
-          console.log(`After refinement & filteredDerivedImages: ${(Date.now() - start)/1000} Seconds`);
           merged_derivedImages = [...filteredDerivedImages, ...derivedImages_new]
         } else {
           if (segImageIds.length == 0){
+            const _tCreate2 = Date.now();
             let derivedImages_new = await imageLoader.createAndCacheDerivedLabelmapImages(imageIds);
 
             if(flipped){
               derivedImages_new.reverse();
             }
-            console.log(`After reverse: ${(Date.now() - start)/1000} Seconds`);
             for (let i = 0; i < derivedImages_new.length; i++) {
               const voxelManager = derivedImages_new[i]
                 .voxelManager as csTypes.IVoxelManager<number>;
@@ -1157,19 +1147,21 @@ const commandsModule = ({
                     
           const derivedImageIds = merged_derivedImages.map(image => image.imageId);  
           console.log(`Just after derivedImageIds: ${(Date.now() - start)/1000} Seconds`);
+          const _zMin = z_range.length > 0 ? Math.min(...z_range) : 0;
+          const _zMax = z_range.length > 0 ? Math.max(...z_range) + 1 : (merged_derivedImages?.length ?? 0);
           segments[segmentNumber] = {
             segmentIndex: segmentNumber,
             label: label_name,
             locked: false,
             active: false,
             cachedStats: {
-
               modifiedTime: utils.formatDate(Date.now(), 'YYYYMMDD'),
-
               algorithmType: currentDisplaySets.SeriesInstanceUID,
               algorithmName: selectedModel+"_"+sam_elapsed,
               description: prompt_info,
-              center:  z_range.length > 0 ? z_range.reduce((sum, z) => sum + z, 0) / z_range.length : 0
+              center:  z_range.length > 0 ? z_range.reduce((sum, z) => sum + z, 0) / z_range.length : 0,
+              segZ0: _zMin,
+              segZ1: _zMax,
             }
           };
 
@@ -1220,6 +1212,14 @@ const commandsModule = ({
       if(currentDisplaySets === undefined || currentDisplaySets.Modality === "SEG"){
         return;
       }
+
+      // Detect series change — used both for posNeg reset and notification gating.
+      const _seriesChanged = currentDisplaySets.SeriesInstanceUID !== _lastInitSeries;
+      if (_seriesChanged) {
+        _lastInitSeries = currentDisplaySets.SeriesInstanceUID;
+        toolboxState.setPosNeg(false);
+      }
+
       let url = `/monai/infer/segmentation?image=${currentDisplaySets.SeriesInstanceUID}&output=dicom_seg`;
       let params = {
         largest_cc: false,
@@ -1231,6 +1231,12 @@ const commandsModule = ({
         nninter: "init",
       };
 
+      // Show notification only on the first initNninter for a new series.
+      // _seriesChanged is false for all repeat triggers (other MPR panes loading the
+      // same series, viewport-type switches stack↔volume, active-viewport clicks, etc.)
+      // so a single _seriesChanged gate is sufficient — no need to check viewport type.
+      const _showNotification = _seriesChanged;
+
       let data = MonaiLabelClient.constructFormData(params, null);
 
       // Create the axios promise
@@ -1241,18 +1247,19 @@ const commandsModule = ({
         },
       });
 
-      // Show notification with promise support
-      uiNotificationService.show({
-        title: 'NNInit',
-        message: 'Initializing nninter...',
-        type: 'info',
-        promise: initPromise,
-        promiseMessages: {
-          loading: 'Initializing nninter...',
-          success: () => 'Init nninter - Successful',
-          error: (error) => `Init nninter - Failed: ${error.message || 'Unknown error'}`,
-        },
-      });
+      if (_showNotification) {
+        uiNotificationService.show({
+          title: 'NNInit',
+          message: 'Initializing nninter...',
+          type: 'info',
+          promise: initPromise,
+          promiseMessages: {
+            loading: 'Initializing nninter...',
+            success: () => 'Init nninter - Successful',
+            error: (error) => `Init nninter - Failed: ${error.message || 'Unknown error'}`,
+          },
+        });
+      }
 
       try {
         const response = await initPromise;
@@ -1299,19 +1306,6 @@ const commandsModule = ({
         },
       });
 
-      // Show notification with promise support
-      uiNotificationService.show({
-        title: 'NNInter',
-        message: 'Resetting nninter...',
-        type: 'info',
-        promise: resetPromise,
-        promiseMessages: {
-          loading: 'Resetting nninter...',
-          success: () => 'Reset nninter - Successful',
-          error: (error) => `Reset nninter - Failed: ${error.message || 'Unknown error'}`,
-        },
-      });
-
       try {
         const response = await resetPromise;
         if (response.status === 200) {
@@ -1324,6 +1318,75 @@ const commandsModule = ({
         console.error('Reset nninter error:', error);
         throw error;
       }
+    },
+    async resetSegment({ segmentationId, segmentIndex }: { segmentationId: string; segmentIndex: number }) {
+      const segmentation = csToolsSegmentation.state.getSegmentation(segmentationId);
+      const imageIds: string[] = (segmentation?.representationData?.Labelmap as any)?.imageIds ?? [];
+
+      const _zeroImageId = (imageId: string) => {
+        const image = cache.getImage(imageId);
+        if (!image) return;
+        const vm = image.voxelManager as csTypes.IVoxelManager<number>;
+        const scalarData = vm.getScalarData();
+        if (!scalarData.some((v: number) => v === segmentIndex)) return;
+        for (let j = 0; j < scalarData.length; j++) {
+          if (scalarData[j] === segmentIndex) scalarData[j] = 0;
+        }
+        vm.setScalarData(scalarData);
+      };
+
+      // 1. Find the labelmap actors currently in the active viewport.
+      //    Using referencedId (the actor's imageId) avoids the flipped-series
+      //    index mismatch that caused the "vague then gone" two-step.
+      const { activeViewportId } = viewportGridService.getState();
+      const activeVp = servicesManager.services.cornerstoneViewportService.getCornerstoneViewport(activeViewportId);
+      const allActors: any[] = (activeVp as any)?.getActors?.() ?? [];
+      const labelmapActors = allActors.filter((a: any) =>
+        a.representationUID?.startsWith(`${segmentationId}-Labelmap`)
+      );
+      const visibleImageIds = new Set(labelmapActors.map((a: any) => a.referencedId).filter(Boolean));
+
+      // 2. Zero the visible slice(s) and synchronously push the zeroed data into
+      //    VTK's internal buffer + force an immediate WebGL render.
+      //    Bypasses the rAF event queue → no intermediate "vague" frame.
+      for (const actorEntry of labelmapActors) {
+        const imageId = actorEntry.referencedId;
+        if (!imageId) continue;
+        _zeroImageId(imageId);
+        const inputData = actorEntry.actor?.getMapper?.()?.getInputData?.();
+        if (inputData) {
+          const csImage = cache.getImage(imageId);
+          if (csImage) {
+            const pixelData = csImage.voxelManager?.getScalarData?.();
+            const vtkScalars = inputData.getPointData?.()?.getScalars?.();
+            const vtkData = vtkScalars?.getData?.();
+            if (pixelData && vtkData && vtkData.length === pixelData.length) {
+              vtkData.set(pixelData);
+              vtkScalars?.modified();
+              inputData.modified();
+            }
+          }
+          actorEntry.actor?.modified?.();
+          actorEntry.actor?.getMapper?.()?.modified?.();
+        }
+      }
+      (activeVp as any)?.render?.();   // synchronous WebGL render — instant visual removal
+
+      // 3. Background: zero all remaining slices, remove measurements, reset server.
+      setTimeout(() => {
+        for (const imageId of imageIds) {
+          if (!visibleImageIds.has(imageId)) _zeroImageId(imageId);
+        }
+        const measurementUIDs = measurementService
+          .getMeasurements()
+          .filter(e => e?.metadata?.segmentationId === segmentationId && e?.metadata?.SegmentNumber === segmentIndex)
+          .map(e => e?.uid);
+        if (measurementUIDs.length > 0) measurementService.removeMany(measurementUIDs);
+        commandsManager.run('resetNninter', { clearMeasurements: false }).catch(() => {});
+        eventTarget.dispatchEvent(
+          new CustomEvent(csToolsEnums.Events.SEGMENTATION_DATA_MODIFIED, { detail: { segmentationId } })
+        );
+      }, 0);
     },
     async medGemma(
       query: string,
@@ -1895,9 +1958,9 @@ const commandsModule = ({
         return;
       }
 
-      const overlap = false
+      const overlap = false;
       const start = Date.now();
-      
+
       const { activeViewportId, viewports } = viewportGridService.getState();
       const activeViewportSpecificData = viewports.get(activeViewportId);
 
@@ -1909,15 +1972,14 @@ const commandsModule = ({
       const displaySets = displaySetService.activeDisplaySets;
 
       const displaySetInstanceUID = displaySetInstanceUIDs[0];
-      const currentDisplaySets = displaySets.filter(e => {
-        return e.displaySetInstanceUID == displaySetInstanceUID;
-      })[0];
+      const currentDisplaySets = displaySets.find(e => e.displaySetInstanceUID === displaySetInstanceUID);
+      if (!currentDisplaySets) return;
       const currentMeasurements = measurementService.getMeasurements()
 
-      const unAssignedMeasurements = currentMeasurements.filter(e => { 
+      const unAssignedMeasurements = currentMeasurements.filter(e => {
           return e.metadata.SegmentNumber === undefined;
         })
-      
+
 
       const activeSegmentation = servicesManager.services.segmentationService.getActiveSegmentation(activeViewportId)
       let segmentNumber = 1;
@@ -1985,100 +2047,43 @@ const commandsModule = ({
     }
 
 
-      const pos_points = currentMeasurements
-        .filter(e => {
-          return e.toolName === 'Probe2' && e.referenceSeriesUID === currentDisplaySets.SeriesInstanceUID && e.metadata.neg === false && e.metadata.SegmentNumber === segmentNumber;
-        })
-        .map(e => {
-          return Object.values(e.data)[0].index;
-        });
-      const neg_points = currentMeasurements
-        .filter(e => {
-          return e.toolName === 'Probe2'&& e.referenceSeriesUID === currentDisplaySets.SeriesInstanceUID && e.metadata.neg === true && e.metadata.SegmentNumber === segmentNumber;
-        })
-        .map(e => {
-          return Object.values(e.data)[0].index;
-        });
-
-      const pos_boxes = currentMeasurements
-        .filter(e => { 
-          return e.toolName === 'RectangleROI2'&& e.referenceSeriesUID === currentDisplaySets.SeriesInstanceUID && e.metadata.neg === false && e.metadata.SegmentNumber === segmentNumber;
-        })
-        .map(e => { 
-          return Object.values(e.data)[0].pointsInShape 
-        })
-        .map(e => { return [e.at(0).pointIJK, e.at(-1).pointIJK] })
-
-      const neg_boxes = currentMeasurements
-      .filter(e => { 
-        return e.toolName === 'RectangleROI2'&& e.referenceSeriesUID === currentDisplaySets.SeriesInstanceUID && e.metadata.neg === true && e.metadata.SegmentNumber === segmentNumber;
-      })
-      .map(e => { 
-        return Object.values(e.data)[0].pointsInShape 
-      })
-      .map(e => { return [e.at(0).pointIJK, e.at(-1).pointIJK] })
-
-      const pos_lassos = currentMeasurements
-        .filter(e => { 
-          return e.toolName === 'PlanarFreehandROI3'&& e.referenceSeriesUID === currentDisplaySets.SeriesInstanceUID && e.metadata.neg === false && e.metadata.SegmentNumber === segmentNumber;
-        })
-        .map(e => { 
-          return Object.values(e.data)[0]?.boundary 
-      })
-      .filter(Boolean)
-
-      const neg_lassos = currentMeasurements
-      .filter(e => { 
-        return e.toolName === 'PlanarFreehandROI3'&& e.referenceSeriesUID === currentDisplaySets.SeriesInstanceUID && e.metadata.neg === true && e.metadata.SegmentNumber === segmentNumber;
-      })
-      .map(e => { 
-        return Object.values(e.data)[0]?.boundary 
-    })
-    .filter(Boolean)
-
-      const pos_scribbles = currentMeasurements
-        .filter(e => { 
-          return e.toolName === 'PlanarFreehandROI2'&& e.referenceSeriesUID === currentDisplaySets.SeriesInstanceUID && e.metadata.neg === false && e.metadata.SegmentNumber === segmentNumber;
-        })
-        .map(e => { 
-          return Object.values(e.data)[0]?.scribble 
-      })
-      .filter(Boolean)
-
-      const neg_scribbles = currentMeasurements
-        .filter(e => { 
-          return e.toolName === 'PlanarFreehandROI2'&& e.referenceSeriesUID === currentDisplaySets.SeriesInstanceUID && e.metadata.neg === true && e.metadata.SegmentNumber === segmentNumber;
-        })
-        .map(e => { 
-          return Object.values(e.data)[0]?.scribble 
-      })
-      .filter(Boolean)
-
-      //VoxTell - Use provided textPrompts or extract from measurements
-      let text_prompts: string[] = [];
-      if (textPrompts) {
-        // Convert to array if it's a single string
-        text_prompts = Array.isArray(textPrompts) ? textPrompts : [textPrompts];
-      } else {
-        text_prompts = currentMeasurements
-          .filter(e => { return e.toolName === 'Probe2' && e.referenceSeriesUID === currentDisplaySets.SeriesInstanceUID && e.metadata.neg === false && e.metadata.SegmentNumber === segmentNumber; })
-          .map(e => { return e.label });
-      }
-
-      // Hide the measurements after inference
-      for (let i = 0; i < currentMeasurements.length; i++) {
-        const e = currentMeasurements[i];
-        if (e.referenceSeriesUID === currentDisplaySets.SeriesInstanceUID) {
-          measurementService.toggleVisibilityMeasurement(e.uid, false);
+      const pos_points: any[] = [];
+      const neg_points: any[] = [];
+      const pos_boxes: any[] = [];
+      const neg_boxes: any[] = [];
+      const pos_lassos: any[] = [];
+      const neg_lassos: any[] = [];
+      const pos_scribbles: any[] = [];
+      const neg_scribbles: any[] = [];
+      const probe2Labels: string[] = [];
+      const seriesUID = currentDisplaySets.SeriesInstanceUID;
+      for (const e of currentMeasurements) {
+        if (e.referenceSeriesUID !== seriesUID || e.metadata.SegmentNumber !== segmentNumber) continue;
+        const isNeg = !!e.metadata.neg;
+        if (e.toolName === 'Probe2') {
+          (isNeg ? neg_points : pos_points).push(Object.values(e.data)[0].index);
+          if (!isNeg && !textPrompts) probe2Labels.push(e.label);
+        } else if (e.toolName === 'RectangleROI2') {
+          const pts = Object.values(e.data)[0].pointsInShape;
+          (isNeg ? neg_boxes : pos_boxes).push([pts.at(0).pointIJK, pts.at(-1).pointIJK]);
+        } else if (e.toolName === 'PlanarFreehandROI3') {
+          const b = Object.values(e.data)[0]?.boundary;
+          if (b) (isNeg ? neg_lassos : pos_lassos).push(b);
+        } else if (e.toolName === 'PlanarFreehandROI2') {
+          const s = Object.values(e.data)[0]?.scribble;
+          if (s) (isNeg ? neg_scribbles : pos_scribbles).push(s);
         }
       }
+      //VoxTell - Use provided textPrompts or extract from measurements
+      const text_prompts: string[] = textPrompts
+        ? (Array.isArray(textPrompts) ? textPrompts : [textPrompts])
+        : probe2Labels;
 
-      // Force a re-render of the segmentation table after a short delay
-      setTimeout(() => {
-        // This will trigger a re-render of components that depend on measurement state
-        const event = new Event('measurement-state-changed');
-        document.dispatchEvent(event);
-      }, 200);
+      // Hide measurements and notify in a single synchronous pass
+      currentMeasurements
+        .filter(e => e.referenceSeriesUID === currentDisplaySets.SeriesInstanceUID)
+        .forEach(e => measurementService.toggleVisibilityMeasurement(e.uid, false));
+      document.dispatchEvent(new Event('measurement-state-changed'));
 
       let url = `/monai/infer/segmentation?image=${currentDisplaySets.SeriesInstanceUID}&output=dicom_seg`;
       let params = {
@@ -2134,17 +2139,83 @@ const commandsModule = ({
         console.debug(response);
         if (response.status === 200) {
             const afterPost = Date.now();
-            console.log(`Just after Post request: ${(afterPost - start)/1000} Seconds`);
+            const networkRoundTripMs = afterPost - beforePost;
             const ct = response.headers["content-type"] as string;
             const { meta, seg } = await parseMultipart(response.data, ct);
-            console.log(`Just after parseMultipart: ${(Date.now() - start)/1000} Seconds`);
-            //const arrayBuffer = response.data
+            const afterParse = Date.now();
+
+            // --- server-side timing breakdown ---
+            const sRequestTs     = metaNum(meta as Record<string,unknown>, 'server_request_ts');
+            const sBeginTs       = metaNum(meta as Record<string,unknown>, 'server_begin_ts');
+            const sEndTs         = metaNum(meta as Record<string,unknown>, 'server_end_ts');
+            const sLoad          = metaNum(meta as Record<string,unknown>, 'server_load_elapsed');
+            const sImgConvert    = metaNum(meta as Record<string,unknown>, 'server_img_convert_elapsed');
+            const sPromptPrep    = metaNum(meta as Record<string,unknown>, 'server_prompt_prep_elapsed');
+            const sModelCore     = metaNum(meta as Record<string,unknown>, 'nninter_core_elapsed');
+            const sResult        = metaNum(meta as Record<string,unknown>, 'server_result_elapsed');
+            const sTotal         = metaNum(meta as Record<string,unknown>, 'nninter_elapsed');
+            const sFirstTs       = metaNum(meta as Record<string,unknown>, 'nninter_first_interaction_ts');
+
+            // Four-leg split (all server timestamps share the same host clock as the container):
+            //   leg1: POST in flight          = server_request_ts - beforePost (client clock vs server clock; same host → accurate)
+            //   leg2: MONAI pre-processing    = server_begin_ts - server_request_ts (DICOM download from Orthanc, entirely server-side)
+            //   leg3: our infer()             = server_end_ts - server_begin_ts (same clock, exact)
+            //   leg4: response in flight      = afterPost - server_end_ts (same host → accurate)
+            const postInFlightMs    = (sRequestTs != null) ? sRequestTs * 1000 - beforePost                     : undefined;
+            const monaiPrepMs       = (sRequestTs != null && sBeginTs != null) ? (sBeginTs - sRequestTs) * 1000 : undefined;
+            const serverProcessMs   = (sBeginTs   != null && sEndTs   != null) ? (sEndTs   - sBeginTs)   * 1000 : undefined;
+            const responseInFlightMs= (sEndTs     != null)                     ? afterPost - sEndTs * 1000      : undefined;
+
+            console.log(
+              `[nninter timing]\n` +
+              `  client → nninter():              ${((beforePost - start)/1000).toFixed(3)}s\n` +
+              `  ── round-trip total:              ${(networkRoundTripMs/1000).toFixed(3)}s\n` +
+              (postInFlightMs     != null ? `     POST in flight:               ${(postInFlightMs/1000).toFixed(3)}s\n` : '') +
+              (monaiPrepMs        != null ? `     MONAI pre-processing:          ${(monaiPrepMs/1000).toFixed(3)}s  (Orthanc DICOM download)\n` : '') +
+              (serverProcessMs    != null ? `     server processing (infer):     ${(serverProcessMs/1000).toFixed(3)}s\n` : '') +
+              (sLoad        != null ? `       ↳ DICOM load:                ${sLoad.toFixed(3)}s\n` : '') +
+              (sImgConvert  != null ? `       ↳ img→numpy:                 ${sImgConvert.toFixed(3)}s\n` : '') +
+              (sPromptPrep  != null ? `       ↳ prompt prep:               ${sPromptPrep.toFixed(3)}s\n` : '') +
+              (sModelCore   != null ? `       ↳ model forward:             ${sModelCore.toFixed(3)}s\n` : '') +
+              (sResult      != null ? `       ↳ result retrieve:           ${sResult.toFixed(3)}s\n` : '') +
+              (responseInFlightMs != null ? `     response in flight:            ${(responseInFlightMs/1000).toFixed(3)}s\n` : '') +
+              `  client parse multipart:          ${((afterParse - afterPost)/1000).toFixed(3)}s`
+            );
+
             const flipped = meta.flipped.toLowerCase() === "true"
             const nninter_elapsed = meta.nninter_elapsed
             const prompt_info = meta.prompt_info
             const label_name = meta.label_name
             const raw = seg
-            const new_arrayBuffer = new Uint8Array(raw);
+
+            // Parse crop geometry. The slice loops write directly from cropBytes into
+            // each slice's scalar data buffer — no full-volume reconstruction needed.
+            // Avoiding the 182 MB allocation eliminates GC pauses that caused 0.3-1.3s jitter.
+            const cropBytes = new Uint8Array(raw);
+            const predOffset: number[] = JSON.parse((meta as any).pred_offset   || '[0,0,0]');
+            const predFull:   number[] = JSON.parse((meta as any).pred_full_shape || '[]');
+            const predCrop:   number[] = JSON.parse((meta as any).pred_crop_shape || '[]');
+
+            // Crop geometry (exposed to slice loops below)
+            let _segZ0 = 0, _segZ1 = Number.MAX_SAFE_INTEGER;
+            let _cropY = 0, _cropX = 0, _y0 = 0, _x0 = 0, _fullX = 0;
+            let _hasCropGeom = false;
+            if (predFull.length === 3 && predCrop.length === 3) {
+              const [, , fullX] = predFull;
+              const [cropZ, cropY, cropX] = predCrop;
+              const [z0, y0, x0] = predOffset;
+              _segZ0 = z0;  _segZ1 = z0 + cropZ;
+              _cropY = cropY; _cropX = cropX;
+              _y0 = y0; _x0 = x0; _fullX = fullX;
+              _hasCropGeom = true;
+            } else {
+            }
+            // Legacy fallback: reconstruct full-volume buffer when crop geometry is unavailable.
+            // This path should never trigger for current server builds.
+            let new_arrayBuffer: Uint8Array | null = null;
+            if (!_hasCropGeom) {
+              new_arrayBuffer = cropBytes;
+            }
 
             let imageIds = currentDisplaySets.imageIds
 
@@ -2181,30 +2252,43 @@ const commandsModule = ({
           let merged_derivedImages = [];
           let z_range = [];
           if(overlap){
+          const _tCreate = Date.now();
           let derivedImages_new = await imageLoader.createAndCacheDerivedLabelmapImages(imageIds);
-          console.log(`Just after createAndCacheDerivedLabelmapImages: ${(Date.now() - start)/1000} Seconds`);
           let derivedImages = [];
           if (segImageIds.length > 0){
             derivedImages = segImageIds.map(imageId => cache.getImage(imageId));
           }
 
-          // We should parse the segmentation as separate slices to support overlapping segments.
-          // This parsing should occur in the CornerstoneJS library adapters.
           if(flipped){
             derivedImages_new.reverse();
           }
-          console.log(`After reverse: ${(Date.now() - start)/1000} Seconds`);
           for (let i = 0; i < derivedImages_new.length; i++) {
-            const voxelManager = derivedImages_new[i]
-              .voxelManager as csTypes.IVoxelManager<number>;
-            let scalarData = voxelManager.getScalarData();
-            const sliceData = new_arrayBuffer.slice(i * scalarData.length, (i + 1) * scalarData.length);
-            if (sliceData.some(v => v === 1)){
-              voxelManager.setScalarData(sliceData.map(v => v === 1 ? segmentNumber : v));
-              if (flipped) {
-                z_range.push(derivedImages_new.length - i - 1);
-              } else {
-                z_range.push(i);
+            if (_hasCropGeom && (i < _segZ0 || i >= _segZ1)) continue;
+            const voxelManager = derivedImages_new[i].voxelManager as csTypes.IVoxelManager<number>;
+            if (_hasCropGeom && i >= _segZ0 && i < _segZ1) {
+              const scalarData = voxelManager.getScalarData();
+              const c = i - _segZ0;
+              const cropSliceBase = c * _cropY * _cropX;
+              let wrote = false;
+              for (let cy = 0; cy < _cropY; cy++) {
+                const srcRow = cropSliceBase + cy * _cropX;
+                const dstRow = (_y0 + cy) * _fullX + _x0;
+                for (let cx = 0; cx < _cropX; cx++) {
+                  if (cropBytes[srcRow + cx] === 1) {
+                    scalarData[dstRow + cx] = segmentNumber;
+                    wrote = true;
+                  }
+                }
+              }
+              if (wrote) z_range.push(flipped ? derivedImages_new.length - i - 1 : i);
+            } else if (!_hasCropGeom && new_arrayBuffer) {
+              // Legacy: full-slice scan
+              const scalarData = voxelManager.getScalarData();
+              const sliceLen = scalarData.length;
+              const sliceData = new_arrayBuffer.slice(i * sliceLen, (i + 1) * sliceLen);
+              if (sliceData.some(v => v === 1)) {
+                voxelManager.setScalarData(sliceData.map(v => v === 1 ? segmentNumber : v));
+                z_range.push(flipped ? derivedImages_new.length - i - 1 : i);
               }
             }
           }
@@ -2245,28 +2329,46 @@ const commandsModule = ({
           } else if (derivedImages.length > 0) {
             filteredDerivedImages = derivedImages;
           }
-          console.log(`After refinement & filteredDerivedImages: ${(Date.now() - start)/1000} Seconds`);
 
           merged_derivedImages = [...filteredDerivedImages, ...derivedImages_new]
         } else {
+          const _tElse = Date.now();
           if (segImageIds.length == 0){
+            const _tCreate2 = Date.now();
             let derivedImages_new = await imageLoader.createAndCacheDerivedLabelmapImages(imageIds);
 
             if(flipped){
               derivedImages_new.reverse();
             }
-            console.log(`After reverse: ${(Date.now() - start)/1000} Seconds`);
             for (let i = 0; i < derivedImages_new.length; i++) {
+              if (_hasCropGeom && (i < _segZ0 || i >= _segZ1)) continue;
               const voxelManager = derivedImages_new[i]
-                .voxelManager as csTypes.IVoxelManager<number>;
-              let scalarData = voxelManager.getScalarData();
-              const sliceData = new_arrayBuffer.slice(i * scalarData.length, (i + 1) * scalarData.length);
-              if (sliceData.some(v => v === 1)){
-                voxelManager.setScalarData(sliceData.map(v => v === 1 ? segmentNumber : v));
-                if (flipped) {
-                  z_range.push(derivedImages_new.length - i - 1);
-                } else {
-                  z_range.push(i);
+                .voxelManager as csTypes.IVoxelManager<number>;              // Write directly from cropBytes into the slice's scalar buffer.
+              // Iterates only cropY×cropX elements (fits in L2 cache) vs 262K full-slice scan.
+              if (_hasCropGeom && i >= _segZ0 && i < _segZ1) {
+                const scalarData = voxelManager.getScalarData();
+                const c = i - _segZ0;
+                const cropSliceBase = c * _cropY * _cropX;
+                let wrote = false;
+                for (let cy = 0; cy < _cropY; cy++) {
+                  const srcRow = cropSliceBase + cy * _cropX;
+                  const dstRow = (_y0 + cy) * _fullX + _x0;
+                  for (let cx = 0; cx < _cropX; cx++) {
+                    if (cropBytes[srcRow + cx] === 1) {
+                      scalarData[dstRow + cx] = segmentNumber;
+                      wrote = true;
+                    }
+                  }
+                }
+                if (wrote) z_range.push(flipped ? derivedImages_new.length - i - 1 : i);
+              } else if (!_hasCropGeom && new_arrayBuffer) {
+                // Legacy: full-slice scan
+                const scalarData = voxelManager.getScalarData();
+                const sliceLen = scalarData.length;
+                const sliceData = new_arrayBuffer.subarray(i * sliceLen, (i + 1) * sliceLen);
+                if (sliceData.some(v => v === 1)){
+                  for (let j = 0; j < sliceLen; j++) { if (sliceData[j] === 1) scalarData[j] = segmentNumber; }
+                  z_range.push(flipped ? derivedImages_new.length - i - 1 : i);
                 }
               }
             }
@@ -2279,23 +2381,53 @@ const commandsModule = ({
             if(flipped){
               merged_derivedImages.reverse();
             }
-            for (let i = 0; i < merged_derivedImages.length; i++) {
+            // Limit scan to the union of [prevZ0,prevZ1) (where old data lives) and
+            // [_segZ0,_segZ1) (where new data will be written).  Avoids scanning all
+            // ~500 slices × 262K pixels every inference — the previous bottleneck.
+            const _prevZ0: number = (_hasCropGeom && (existingSegments[segmentNumber] as any)?.cachedStats?.segZ0 != null)
+              ? (existingSegments[segmentNumber] as any).cachedStats.segZ0 as number
+              : 0;
+            const _prevZ1: number = (_hasCropGeom && (existingSegments[segmentNumber] as any)?.cachedStats?.segZ1 != null)
+              ? (existingSegments[segmentNumber] as any).cachedStats.segZ1 as number
+              : merged_derivedImages.length;
+            const scanZ0 = _hasCropGeom ? Math.min(_prevZ0, _segZ0) : 0;
+            const scanZ1 = _hasCropGeom ? Math.max(_prevZ1, _segZ1) : merged_derivedImages.length;
+
+            for (let i = scanZ0; i < scanZ1; i++) {
               const voxelManager = merged_derivedImages[i]
                 .voxelManager as csTypes.IVoxelManager<number>;
               let scalarData = voxelManager.getScalarData();
-              const sliceData = new_arrayBuffer.slice(i * scalarData.length, (i + 1) * scalarData.length);
-              if (!toolboxState.getRefineNew()){
-                if (scalarData.some(v => v === segmentNumber)){
-                  voxelManager.setScalarData(scalarData.map(v => v === segmentNumber ? 0 : v));
-                  scalarData = voxelManager.getScalarData();
+              const sliceLen = scalarData.length;
+
+              // Clear old segment pixels in-place (refine always overwrites)
+              if (scalarData.some(v => v === segmentNumber)){
+                for (let j = 0; j < sliceLen; j++) {
+                  if (scalarData[j] === segmentNumber) scalarData[j] = 0;
                 }
               }
-              if (sliceData.some(v => v === 1)){
-                voxelManager.setScalarData(sliceData.map((v, idx) => v === 1 ? segmentNumber : scalarData[idx]));
-                if (flipped) {
-                  z_range.push(merged_derivedImages.length - i - 1);
-                } else {
-                  z_range.push(i);
+
+              // Write new data from crop (cache-friendly, no 182 MB buffer)
+              if (_hasCropGeom && i >= _segZ0 && i < _segZ1) {
+                const c = i - _segZ0;
+                const cropSliceBase = c * _cropY * _cropX;
+                let wrote = false;
+                for (let cy = 0; cy < _cropY; cy++) {
+                  const srcRow = cropSliceBase + cy * _cropX;
+                  const dstRow = (_y0 + cy) * _fullX + _x0;
+                  for (let cx = 0; cx < _cropX; cx++) {
+                    if (cropBytes[srcRow + cx] === 1) {
+                      scalarData[dstRow + cx] = segmentNumber;
+                      wrote = true;
+                    }
+                  }
+                }
+                if (wrote) z_range.push(flipped ? merged_derivedImages.length - i - 1 : i);
+              } else if (!_hasCropGeom && new_arrayBuffer) {
+                // Legacy: full-slice scan
+                const sliceData = new_arrayBuffer.subarray(i * sliceLen, (i + 1) * sliceLen);
+                if (sliceData.some(v => v === 1)){
+                  for (let j = 0; j < sliceLen; j++) { if (sliceData[j] === 1) scalarData[j] = segmentNumber; }
+                  z_range.push(flipped ? merged_derivedImages.length - i - 1 : i);
                 }
               }
             }
@@ -2316,13 +2448,14 @@ const commandsModule = ({
             locked: false,
             active: false,
             cachedStats: {
-
               modifiedTime: utils.formatDate(Date.now(), 'YYYYMMDD'),
-
               algorithmType: currentDisplaySets.SeriesInstanceUID,
               algorithmName: "nninter_"+nninter_elapsed,
               description: prompt_info,
               center:  z_range.length > 0 ? z_range.reduce((sum, z) => sum + z, 0) / z_range.length : 0,
+              // z-range of this result — used next inference to limit the refine scan
+              segZ0: _hasCropGeom ? _segZ0 : 0,
+              segZ1: _hasCropGeom ? _segZ1 : (merged_derivedImages?.length ?? 0),
             }
           };
           console.log(`Before add or update segs: ${(Date.now() - start)/1000} Seconds`);
@@ -2341,10 +2474,12 @@ const commandsModule = ({
             currentImageIdIndex,
             z_range,
           });
-          console.log(`After add and update segs: ${(Date.now() - start)/1000} Seconds`);
-          
-          const end = Date.now();
-          console.log(`Time taken: ${(end - start)/1000} Seconds`);
+          const tViz = Date.now();
+          console.log(
+            `[nninter timing]\n` +
+            `  OHIF post-processing:         ${((tViz - afterParse)/1000).toFixed(3)}s  (parse→visible)\n` +
+            `  total client time:            ${((tViz - start)/1000).toFixed(3)}s`
+          );
           return response;
         }
       } catch (error) {
@@ -2754,6 +2889,7 @@ const commandsModule = ({
     sam2: actions.sam2,
     initNninter: actions.initNninter,
     resetNninter: actions.resetNninter,
+    resetSegment: actions.resetSegment,
     medGemma: actions.medGemma,
     gemini: actions.gemini,
     openai: actions.openai,

--- a/Viewers/extensions/default/src/utils/Toolbox.tsx
+++ b/Viewers/extensions/default/src/utils/Toolbox.tsx
@@ -31,7 +31,8 @@ export function Toolbox({ buttonSectionId, title, defaultOpen = true }: { button
   const { servicesManager, commandsManager } = useSystem();
   const { t } = useTranslation();
 
-  const { toolbarService, customizationService } = servicesManager.services;
+  const { toolbarService, customizationService, segmentationService, viewportGridService } = servicesManager.services;
+  const onInteractionRef = React.useRef<((args: { itemId: string }) => void) | null>(null);
   const isAIToolBox = buttonSectionId === 'aiToolBox';
   const isTextPromptToolbox = buttonSectionId === 'textPromptSegmentationToolbox';
   const isTestMedgemmaToolbox = buttonSectionId === 'testMedgemmaToolbox';
@@ -42,7 +43,6 @@ export function Toolbox({ buttonSectionId, title, defaultOpen = true }: { button
   // Local state for UI updates
   const [liveMode, setLiveMode] = useState(toolboxState.getLiveMode());
   const [posNeg, setPosNeg] = useState(toolboxState.getPosNeg());
-  const [refineNew, setRefineNew] = useState(toolboxState.getRefineNew());
   const [textPromptReplaceNew, setTextPromptReplaceNew] = useState(toolboxState.getTextPromptReplaceNew());
   const [selectedModel, setSelectedModel] = useState<'nnInteractive' | 'sam2' | 'medsam2' | 'sam3'>(toolboxState.getSelectedModel());
   const [medgemmaResult, setMedgemmaResult] = useState(toolboxState.getMedgemmaResult());
@@ -147,7 +147,6 @@ export function Toolbox({ buttonSectionId, title, defaultOpen = true }: { button
     const updateLocalState = () => {
       setLiveMode(toolboxState.getLiveMode());
       setPosNeg(toolboxState.getPosNeg());
-      setRefineNew(toolboxState.getRefineNew());
       setTextPromptReplaceNew(toolboxState.getTextPromptReplaceNew());
       setSelectedModel(toolboxState.getSelectedModel());
       setIsLocked(toolboxState.getLocked());
@@ -159,110 +158,89 @@ export function Toolbox({ buttonSectionId, title, defaultOpen = true }: { button
     // Set up an interval to check for changes (since toolboxState doesn't have events)
     const interval = setInterval(updateLocalState, 100);
 
-    return () => clearInterval(interval);
+    return () => {
+      clearInterval(interval);
+      // Reset volatile interaction state when the user leaves the viewer (e.g. back to study list).
+      // This ensures the next mount always reads the default (positive) regardless of series UID.
+      toolboxState.setPosNeg(false);
+    };
   }, []);
 
-  // Keyboard hotkey handler for Live Mode toggle
+  // Consolidated keyboard hotkey handler (AI toolbox only)
+  // Q = Live Mode, T = Pos/Neg, P = Point, B = BBox, S = Scribble, L = Lasso
+  // M = Add Segment, R = Reset Segment
   useEffect(() => {
-    if (hotkeysDisabled) {
+    if (!isAIToolBox || hotkeysDisabled) {
       return;
     }
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      // Check if the pressed key is 'Q' or 'q'
-      if ((event.key === 'Q' || event.key === 'q')) {
-        // Only trigger if we're not typing in an input field
-        const activeElement = document.activeElement;
-        const isInputField = activeElement?.tagName === 'INPUT' || 
-                           activeElement?.tagName === 'TEXTAREA' || 
+      const activeElement = document.activeElement;
+      const isInputField = activeElement?.tagName === 'INPUT' ||
+                           activeElement?.tagName === 'TEXTAREA' ||
                            (activeElement as HTMLElement)?.contentEditable === 'true';
-        
-        if (!isInputField) {
+      if (isInputField) return;
+
+      switch (event.key.toLowerCase()) {
+        case 'q': {
           event.preventDefault();
-          const newLiveMode = !liveMode;
+          const newLiveMode = !toolboxState.getLiveMode();
           setLiveMode(newLiveMode);
           toolboxState.setLiveMode(newLiveMode);
-          console.log('Live mode toggled via hotkey (q):', newLiveMode);
+          break;
         }
-      }
-    };
-
-    // Add event listener
-    document.addEventListener('keydown', handleKeyDown);
-
-    // Cleanup
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [liveMode, hotkeysDisabled]);
-
-  // Keyboard hotkey handler for Pos/Neg toggle
-  useEffect(() => {
-    if (hotkeysDisabled) {
-      return;
-    }
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      // Check if the pressed key is 'W' or 'w'
-      if ((event.key === 'W' || event.key === 'w')) {
-        // Only trigger if we're not typing in an input field
-        const activeElement = document.activeElement;
-        const isInputField = activeElement?.tagName === 'INPUT' || 
-                           activeElement?.tagName === 'TEXTAREA' || 
-                           (activeElement as HTMLElement)?.contentEditable === 'true';
-        
-        if (!isInputField) {
+        case 't': {
           event.preventDefault();
-          const newPosNeg = !posNeg;
+          const newPosNeg = !toolboxState.getPosNeg();
           setPosNeg(newPosNeg);
           toolboxState.setPosNeg(newPosNeg);
-          console.log('Pos/Neg toggled via hotkey (w):', newPosNeg);
+          break;
         }
-      }
-    };
-
-    // Add event listener
-    document.addEventListener('keydown', handleKeyDown);
-
-    // Cleanup
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [posNeg, hotkeysDisabled]);
-
-  // Keyboard hotkey handler for Refine/New toggle
-  useEffect(() => {
-    if (hotkeysDisabled) {
-      return;
-    }
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      // Check if the pressed key is 'E' or 'e'
-      if ((event.key === 'E' || event.key === 'e')) {
-        // Only trigger if we're not typing in an input field
-        const activeElement = document.activeElement;
-        const isInputField = activeElement?.tagName === 'INPUT' || 
-                           activeElement?.tagName === 'TEXTAREA' || 
-                           (activeElement as HTMLElement)?.contentEditable === 'true';
-        
-        if (!isInputField) {
+        case 'p':
           event.preventDefault();
-          const newRefineNew = !refineNew;
-          setRefineNew(newRefineNew);
-          toolboxState.setRefineNew(newRefineNew);
-          console.log('Refine/New toggled via hotkey (e):', newRefineNew);
+          onInteractionRef.current?.({ itemId: 'Probe2' });
+          break;
+        case 'b':
+          event.preventDefault();
+          onInteractionRef.current?.({ itemId: 'RectangleROI2' });
+          break;
+        case 's':
+          event.preventDefault();
+          onInteractionRef.current?.({ itemId: 'PlanarFreehandROI2' });
+          break;
+        case 'l':
+          event.preventDefault();
+          onInteractionRef.current?.({ itemId: 'PlanarFreehandROI3' });
+          break;
+        case 'm': {
+          event.preventDefault();
+          const { activeViewportId: avId } = viewportGridService.getState();
+          const activeSeg = segmentationService.getActiveSegmentation(avId);
+          if (activeSeg?.segmentationId) {
+            commandsManager.run('addSegment', { segmentationId: activeSeg.segmentationId });
+          }
+          break;
+        }
+        case 'r': {
+          event.preventDefault();
+          const { activeViewportId: avId } = viewportGridService.getState();
+          const activeSeg = segmentationService.getActiveSegmentation(avId);
+          const activeSeg2 = segmentationService.getActiveSegment(avId);
+          if (activeSeg?.segmentationId && activeSeg2?.segmentIndex != null) {
+            commandsManager.run('resetSegment', {
+              segmentationId: activeSeg.segmentationId,
+              segmentIndex: activeSeg2.segmentIndex,
+            });
+          }
+          break;
         }
       }
     };
 
-    // Add event listener
     document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [hotkeysDisabled, isAIToolBox]);
 
-    // Cleanup
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [refineNew, hotkeysDisabled]);
 
   // When locked, force Pan tool active, disable live prompts, and collapse section
   useEffect(() => {
@@ -281,48 +259,12 @@ export function Toolbox({ buttonSectionId, title, defaultOpen = true }: { button
     }
   }, [isLocked]);
 
-  // Keyboard hotkey handler for model selection toggle (cycles through: nnInteractive -> sam2 -> medsam2 -> sam3 -> nnInteractive)
-  useEffect(() => {
-    if (hotkeysDisabled) {
-      return;
-    }
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      // Check if the pressed key is 'T' or 't'
-      if ((event.key === 'T' || event.key === 't')) {
-        // Only trigger if we're not typing in an input field
-        const activeElement = document.activeElement;
-        const isInputField = activeElement?.tagName === 'INPUT' || 
-                           activeElement?.tagName === 'TEXTAREA' || 
-                           (activeElement as HTMLElement)?.contentEditable === 'true';
-        
-        if (!isInputField) {
-          event.preventDefault();
-          // Cycle through models: nnInteractive -> sam2 -> medsam2 -> sam3 -> nnInteractive
-          const nextModel = selectedModel === 'nnInteractive' ? 'sam2' : 
-                           selectedModel === 'sam2' ? 'medsam2' :
-                           selectedModel === 'medsam2' ? 'sam3' :
-                           'nnInteractive';
-          setSelectedModel(nextModel);
-          toolboxState.setSelectedModel(nextModel);
-          console.log('Model selection toggled via hotkey (t):', nextModel);
-        }
-      }
-    };
-
-    // Add event listener
-    document.addEventListener('keydown', handleKeyDown);
-
-    // Cleanup
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [selectedModel, hotkeysDisabled]);
 
   const { toolbarButtons: toolboxSections, onInteraction } = useToolbar({
     servicesManager,
     buttonSection: buttonSectionId,
   });
+  onInteractionRef.current = onInteraction;
 
   if (!toolboxSections.length) {
     return null;
@@ -431,7 +373,7 @@ export function Toolbox({ buttonSectionId, title, defaultOpen = true }: { button
               {isAIToolBox && (
                 <div className="flex justify-center items-center gap-4 py-2 px-1">
                    <div className="flex items-center gap-2">
-                     <Label htmlFor="live-mode">Live Mode</Label>
+                     <Label htmlFor="live-mode">Live Mode [Q]</Label>
                      <Switch
                        id="live-mode"
                        checked={liveMode}
@@ -443,7 +385,7 @@ export function Toolbox({ buttonSectionId, title, defaultOpen = true }: { button
                      />
                    </div>
                    <div className="flex items-center gap-2">
-                     <Label htmlFor="pos-neg">Pos/Neg</Label>
+                     <Label htmlFor="pos-neg">Pos/Neg [T]</Label>
                      <Switch
                        id="pos-neg"
                        checked={posNeg}
@@ -451,18 +393,6 @@ export function Toolbox({ buttonSectionId, title, defaultOpen = true }: { button
                         setPosNeg(checked);
                         toolboxState.setPosNeg(checked);
                         console.log('Pos/Neg:', checked);
-                      }}
-                     />
-                   </div>
-                   <div className="flex items-center gap-2">
-                     <Label htmlFor="refine-new">Refine/New</Label>
-                     <Switch
-                       id="refine-new"
-                       checked={refineNew}
-                       onCheckedChange={(checked) => {
-                        setRefineNew(checked);
-                        toolboxState.setRefineNew(checked);
-                        console.log('Refine/New:', checked);
                       }}
                      />
                    </div>

--- a/Viewers/modes/longitudinal/src/toolbarButtons.ts
+++ b/Viewers/modes/longitudinal/src/toolbarButtons.ts
@@ -19,6 +19,13 @@ export const setToolActiveToolbar = {
   },
 };
 
+const toggleToolActiveToolbar = {
+  commandName: 'toggleToolActiveToolbar',
+  commandOptions: {
+    toolGroupIds: ['default', 'mpr', 'SRToolGroup', 'volume3d'],
+  },
+};
+
 const toolbarButtons: Button[] = [
   // sections
   {
@@ -234,9 +241,9 @@ const toolbarButtons: Button[] = [
     uiType: 'ohif.toolBoxButton',
     props: {
       icon: 'tool-probe',
-      label: 'Points',
-      tooltip: 'Points',
-      commands: setToolActiveToolbar,
+      label: 'Point',
+      tooltip: 'Point [P]',
+      commands: toggleToolActiveToolbar,
       evaluate: 'evaluate.cornerstoneTool',
     },
   },
@@ -434,9 +441,9 @@ const toolbarButtons: Button[] = [
     uiType: 'ohif.toolBoxButton',
     props: {
       icon: 'tool-rectangle',
-      label: 'Bounding Box',
-      tooltip: 'Rectangle ROI',
-      commands: setToolActiveToolbar,
+      label: 'BBox',
+      tooltip: 'Bounding Box [B]',
+      commands: toggleToolActiveToolbar,
       evaluate: 'evaluate.cornerstoneTool',
     },
   },
@@ -468,8 +475,8 @@ const toolbarButtons: Button[] = [
     props: {
       icon: 'icon-tool-lasso-roi',
       label: 'Lasso',
-      tooltip: 'Freehand ROI',
-      commands: setToolActiveToolbar,
+      tooltip: 'Lasso [L]',
+      commands: toggleToolActiveToolbar,
       evaluate: 'evaluate.cornerstoneTool',
     },
   },
@@ -479,8 +486,8 @@ const toolbarButtons: Button[] = [
     props: {
       icon: 'icon-tool-freehand-roi',
       label: 'Scribble',
-      tooltip: 'Freehand ROI',
-      commands: setToolActiveToolbar,
+      tooltip: 'Scribble [S]',
+      commands: toggleToolActiveToolbar,
       evaluate: 'evaluate.cornerstoneTool',
     },
   },

--- a/Viewers/platform/app/.recipes/Nginx-Orthanc/config/nginx.conf
+++ b/Viewers/platform/app/.recipes/Nginx-Orthanc/config/nginx.conf
@@ -24,7 +24,7 @@ http {
   client_max_body_size 500M;
 
   upstream monai_up {
-    server monai_sam2:8002;
+    server monai_server:8002;
     keepalive 64;   # pool of idle connections to FastAPI
   }
 
@@ -81,7 +81,7 @@ http {
     }
 
     location /monai/ {
-      proxy_pass http://monai_sam2:8002;
+      proxy_pass http://monai_server:8002;
       proxy_http_version 1.1;
       proxy_set_header Connection "";
       

--- a/Viewers/platform/app/.recipes/Nginx-Orthanc/dockerfile
+++ b/Viewers/platform/app/.recipes/Nginx-Orthanc/dockerfile
@@ -1,22 +1,27 @@
+# syntax=docker/dockerfile:1.7-labs
+
 # Stage 1: Build the application
 FROM node:20.18.1-slim as builder
 
-# Setup the working directory
 RUN mkdir /usr/src/app
 WORKDIR /usr/src/app
 
-# Install dependencies
-# apt-get update is combined with apt-get install to avoid using outdated packages
-RUN apt-get update && apt-get install -y build-essential python3
+# apt packages are cached across builds
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    apt-get update && apt-get install -y build-essential python3
 
-# Copy package.json and other dependency-related files first
-# Assuming your package.json and yarn.lock or similar are located in the project root
+# ── Dependency install — cached unless package.json / yarn.lock change ───────
+# Copy only package manifests first (preserving workspace directory structure).
+# A source-code edit does NOT invalidate this layer, so yarn install is skipped
+# for the common "I just changed a .ts/.tsx file" workflow.
+COPY --parents **/package.json yarn.lock lerna.json preinstall.js ./
 
-COPY ./ /usr/src/app/
-
-# Install node dependencies
 RUN yarn config set workspaces-experimental true
-RUN yarn install
+RUN --mount=type=cache,target=/usr/local/share/.cache/yarn,sharing=locked \
+    yarn install
+
+# ── Source files — changes here skip yarn install entirely ───────────────────
+COPY ./ /usr/src/app/
 
 # To change color of negative prompts
 RUN rm -rf /usr/src/app/node_modules/@cornerstonejs/tools/dist/esm/tools/base/AnnotationTool.js
@@ -80,13 +85,11 @@ COPY ./backup/dcmjs/dcmjs.es.js /usr/src/app/node_modules/dcmjs/build/dcmjs.es.j
 
 COPY ./backup/vtkjs/ImageMarchingSquares.js /usr/src/app/node_modules/@kitware/vtk.js/Filters/General/ImageMarchingSquares.js
 
-# Copy the rest of the application code
-
 # set QUICK_BUILD to true to make the build faster for dev
 ENV APP_CONFIG=config/docker-nginx-orthanc.js
 
 # Build the application with production mode Use Run yarn run build:dev for development
-RUN yarn run build
+RUN yarn run build:dev
 
 # # Stage 2: Bundle the built application into a Docker container which runs NGINX using Alpine Linux
 FROM nginx:alpine

--- a/Viewers/platform/app/.recipes/Nginx-Orthanc/dockerfile
+++ b/Viewers/platform/app/.recipes/Nginx-Orthanc/dockerfile
@@ -89,7 +89,7 @@ COPY ./backup/vtkjs/ImageMarchingSquares.js /usr/src/app/node_modules/@kitware/v
 ENV APP_CONFIG=config/docker-nginx-orthanc.js
 
 # Build the application with production mode Use Run yarn run build:dev for development
-RUN yarn run build:dev
+RUN yarn run build
 
 # # Stage 2: Bundle the built application into a Docker container which runs NGINX using Alpine Linux
 FROM nginx:alpine

--- a/Viewers/platform/app/pluginConfig.json
+++ b/Viewers/platform/app/pluginConfig.json
@@ -68,16 +68,20 @@
       "packageName": "@ohif/mode-longitudinal"
     },
     {
-      "packageName": "@ohif/mode-segmentation"
+      "packageName": "@ohif/mode-segmentation",
+      "default": false
     },
     {
-      "packageName": "@ohif/mode-tmtv"
+      "packageName": "@ohif/mode-tmtv",
+      "default": false
     },
     {
-      "packageName": "@ohif/mode-microscopy"
+      "packageName": "@ohif/mode-microscopy",
+      "default": false
     },
     {
-      "packageName": "@ohif/mode-preclinical-4d"
+      "packageName": "@ohif/mode-preclinical-4d",
+      "default": false
     },
     {
       "packageName": "@ohif/mode-test",

--- a/Viewers/platform/ui-next/src/components/SegmentationTable/AddSegmentRow.tsx
+++ b/Viewers/platform/ui-next/src/components/SegmentationTable/AddSegmentRow.tsx
@@ -5,9 +5,11 @@ import { useSegmentationTableContext, useSegmentationExpanded } from './contexts
 export const AddSegmentRow: React.FC<{ children?: React.ReactNode }> = ({ children = null }) => {
   const {
     activeRepresentation,
+    activeSegmentation,
     disableEditing,
     activeSegmentationId,
     onSegmentAdd,
+    onSegmentReset,
     onToggleSegmentationRepresentationVisibility,
     data,
     showAddSegment,
@@ -45,9 +47,17 @@ export const AddSegmentRow: React.FC<{ children?: React.ReactNode }> = ({ childr
 
   const allowAddSegment = showAddSegment && !disableEditing;
 
+  // Find the active segment index for reset
+  const activeSegmentIndex = activeSegmentation
+    ? Number(Object.keys(activeSegmentation.segments).find(
+        k => (activeSegmentation.segments as any)[k]?.active
+      ))
+    : NaN;
+  const canReset = !disableEditing && onSegmentReset && !isNaN(activeSegmentIndex);
+
   return (
-    <div className="my-px flex h-7 w-full items-center justify-between rounded pl-0.5 pr-7">
-      <div className="mt-1 flex-1">
+    <div className="my-px flex min-h-7 w-full items-center justify-between rounded pl-0.5 pr-7">
+      <div className="mt-1 flex flex-row items-center gap-1">
         {allowAddSegment ? (
           <Button
             size="sm"
@@ -56,7 +66,18 @@ export const AddSegmentRow: React.FC<{ children?: React.ReactNode }> = ({ childr
             onClick={() => onSegmentAdd(segmentationId)}
           >
             <Icons.Add />
-            Add Segment
+            Add Segment <span className="ml-1 opacity-50 text-xs">[M]</span>
+          </Button>
+        ) : null}
+        {canReset ? (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="pr pl-0.5"
+            onClick={() => onSegmentReset(segmentationId, activeSegmentIndex)}
+          >
+            <Icons.Refresh className="h-4 w-4" />
+            Reset Segment <span className="ml-1 opacity-50 text-xs">[R]</span>
           </Button>
         ) : null}
       </div>

--- a/Viewers/platform/ui-next/src/components/SegmentationTable/contexts/SegmentationTableContext.tsx
+++ b/Viewers/platform/ui-next/src/components/SegmentationTable/contexts/SegmentationTableContext.tsx
@@ -81,6 +81,7 @@ export interface SegmentationTableContextType {
   onSegmentationEdit?: (segmentationId: string) => void;
   onSegmentColorClick?: (segmentationId: string, segmentIndex: number) => void;
   onSegmentDelete?: (segmentationId: string, segmentIndex: number) => void;
+  onSegmentReset?: (segmentationId: string, segmentIndex: number) => void;
   onToggleSegmentVisibility?: (
     segmentationId: string,
     segmentIndex: number,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       # Relative to context
       dockerfile: ./platform/app/.recipes/Nginx-Orthanc/dockerfile
     image: webapp:latest
-    container_name: ohif_orthanc
+    container_name: ohif_viewer
     volumes:
       # Nginx config
       - ./Viewers/platform/app/.recipes/Nginx-Orthanc/config/nginx.conf:/etc/nginx/nginx.conf
@@ -18,8 +18,8 @@ services:
       # Logs
       - ./Viewers/platform/app/.recipes/Nginx-Orthanc/logs/nginx:/var/logs/nginx
     ports:
-      - '1025:1025' # SSL
-      - '1026:1026' # Web
+      - '1024:1024' # SSL
+      - '1030:1030' # Web
     depends_on:
       #   - keycloak
       - orthanc
@@ -31,7 +31,7 @@ services:
   orthanc:
     image: jodogne/orthanc-plugins
     hostname: orthanc
-    container_name: orthancPACS
+    container_name: PACS
     volumes:
       # Config
       - ./Viewers/platform/app/.recipes/Nginx-Orthanc/config/orthanc.json:/etc/orthanc/orthanc.json:ro
@@ -39,10 +39,10 @@ services:
       - ./Viewers/platform/app/.recipes/Nginx-Orthanc/volumes/orthanc-db/:/var/lib/orthanc/db/
     restart: unless-stopped
     ports:
-      - '4242:4242' # Orthanc REST API
-      - '8042:8042' # Orthanc HTTP
+      - '4243:4243' # Orthanc REST API
+      - '8043:8043' # Orthanc HTTP
   
-  monai_sam2:
+  monai_server:
     build:
       # Project root
       context: ./
@@ -50,10 +50,16 @@ services:
       dockerfile: ./monai-label/Dockerfile
     image: monai
     runtime: nvidia
-    container_name: monai_sam2
+    container_name: monai_server
     volumes:
        # Persist data
       - ./monai-label/predictions:/code/predictions
+      # Model weights (populated once via scripts/download_weights.sh)
+      - ./monai-label/checkpoints:/code/checkpoints
+      # Radiology app (downloaded on first container start by entrypoint.sh)
+      - ./monai-label/apps:/code/apps
+      # MONAI Label DICOM cache — survives image rebuilds so downloaded studies are not re-fetched
+      - ./monai-label/volumes/root-cache:/root/.cache
     extra_hosts:
       # Lets MONAI reach vLLM / other services bound on the host (e.g. port 8000)
       - "host.docker.internal:host-gateway"
@@ -75,11 +81,11 @@ services:
         reservations:
           devices:
             - driver: nvidia
-            #  device_ids: ['7:1']
+              device_ids: ['7:0']
               capabilities: [gpu]  # Request GPUs for this service
     shm_size: '10gb' #runtime: nvidia  # Use NVIDIA runtime
     ports:
-      - '8002:8002' 
+      - '8003:8003' 
     depends_on:
       - ohif_viewer
       - orthanc

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,8 @@ services:
       # Logs
       - ./Viewers/platform/app/.recipes/Nginx-Orthanc/logs/nginx:/var/logs/nginx
     ports:
-      - '1024:1024' # SSL
-      - '1030:1030' # Web
+      - '1025:1025' # SSL
+      - '1026:1026' # Web
     depends_on:
       #   - keycloak
       - orthanc
@@ -39,8 +39,8 @@ services:
       - ./Viewers/platform/app/.recipes/Nginx-Orthanc/volumes/orthanc-db/:/var/lib/orthanc/db/
     restart: unless-stopped
     ports:
-      - '4243:4243' # Orthanc REST API
-      - '8043:8043' # Orthanc HTTP
+      - '4242:4242' # Orthanc REST API
+      - '8042:8042' # Orthanc HTTP
   
   monai_server:
     build:
@@ -81,11 +81,11 @@ services:
         reservations:
           devices:
             - driver: nvidia
-              device_ids: ['7:0']
+              #device_ids: ['7:1']
               capabilities: [gpu]  # Request GPUs for this service
     shm_size: '10gb' #runtime: nvidia  # Use NVIDIA runtime
     ports:
-      - '8003:8003' 
+      - '8002:8002' 
     depends_on:
       - ohif_viewer
       - orthanc

--- a/monai-label/.dockerignore
+++ b/monai-label/.dockerignore
@@ -1,19 +1,18 @@
-# Copyright (c) MONAI Consortium
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#     http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 __pycache__
+**/__pycache__/
+**/*.pyc
+**/*.pyo
 .idea
 .vscode
+.git/
 
 Dockerfile
+
 sample-apps/**/model
+sample-data/
 node_modules
 .webpack
+tests/
+*.md
+checkpoints/
+volumes/

--- a/monai-label/Dockerfile
+++ b/monai-label/Dockerfile
@@ -64,6 +64,6 @@ COPY ./monai-label/. ./
 COPY ./monai-label/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-EXPOSE 8003
+EXPOSE 8002
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["python", "-m", "monailabel.main", "start_server", "--app", "/code/apps/radiology", "--studies", "http://orthanc:8043/dicom-web", "--conf", "models", "segmentation", "--conf", "use_pretrained_model", "false", "-p", "8003"]
+CMD ["python", "-m", "monailabel.main", "start_server", "--app", "/code/apps/radiology", "--studies", "http://orthanc:8042/dicom-web", "--conf", "models", "segmentation", "--conf", "use_pretrained_model", "false", "-p", "8002"]

--- a/monai-label/Dockerfile
+++ b/monai-label/Dockerfile
@@ -9,60 +9,61 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM nvidia/cuda:12.1.1-devel-ubuntu22.04
-#FROM python:3.10-slim
+# syntax=docker/dockerfile:1.7-labs
 
-RUN apt update -y && apt install -y openslide-tools build-essential python3-pip python3-dev python-is-python3 ffmpeg libsm6 libxext6 libxcb-xinerama0 libxcb1 wget git
+# ── Stage 1: deps ────────────────────────────────────────────────────────────
+# Rebuilds only when requirements.txt, sam2/, or sam3/ change.
+# Switch from cuda:devel (~6 GB) to cuda:runtime (~3 GB) — inference needs no compiler.
+FROM nvidia/cuda:12.1.1-runtime-ubuntu22.04 AS deps
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    apt-get update -y && apt-get install -y --no-install-recommends \
+    openslide-tools \
+    build-essential \
+    python3-pip \
+    python3-dev \
+    python-is-python3 \
+    ffmpeg \
+    libsm6 \
+    libxext6 \
+    libxcb-xinerama0 \
+    libxcb1 \
+    wget \
+    git \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code
-RUN mkdir -p /install
-RUN mkdir -p /install-3
+RUN mkdir -p /install /install-3
 
-COPY ./monai-label/requirements.txt ./
 COPY ./sam2/. /install/
 COPY ./sam3/. /install-3/
+COPY ./monai-label/requirements.txt ./
 
-RUN mkdir -p /code/assets
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install --upgrade pip setuptools wheel && \
+    pip install -e /install/. && \
+    pip install -e /install-3/. && \
+    pip install -r requirements.txt
+
+# ── Stage 2: app ─────────────────────────────────────────────────────────────
+# Rebuilds only when monai-label/* code changes.
+FROM deps AS app
+
+RUN mkdir -p /code/assets /code/checkpoints /code/apps
 COPY ./sam3/assets/bpe_simple_vocab_16e6.txt.gz /code/assets/
-#ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH":/usr/lib/x86_64-linux-gnu:"
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:"/usr/local/nvidia/lib64"
 
-RUN pip install --upgrade pip setuptools wheel
-RUN pip install -e /install/.
-RUN pip install -e /install-3/.
-RUN pip install --no-cache-dir -r requirements.txt
-#RUN pip install emoji ddd-dataset
-#RUN pip install "git+https://github.com/lvis-dataset/lvis-api.git"
+ENV LD_LIBRARY_PATH="/usr/local/nvidia/lib64"
+ENV PATH="$PATH:/code/monailabel/scripts"
+ENV PYTHONPATH="/code"
 
-#RUN mim install mmengine
-#RUN mim install "mmcv>=2.0.0rc4,<2.2.0"
-#RUN mim install mmdet
+RUN rm -rf /usr/local/lib/python3.10/dist-packages/dicomweb_client/web.py
+COPY ./monai-label/backup/web.py /usr/local/lib/python3.10/dist-packages/dicomweb_client/
 
 COPY ./monai-label/. ./
 
-ENV WEIGHTS_DIR="/code/checkpoints/"
-# SAM2 weights
-#ENV WEIGHTS_URL="https://dl.fbaipublicfiles.com/segment_anything_2/072824/sam2_hiera_large.pt"
-# SAM2.1 weights
-ENV WEIGHTS_URL="https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_tiny.pt"
-RUN wget --directory-prefix ${WEIGHTS_DIR} ${WEIGHTS_URL}
+COPY ./monai-label/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
-# MEDSAM2 (Jun Ma) weights
-ENV MEDSAM2_WEIGHTS_URL="https://huggingface.co/wanglab/MedSAM2/resolve/main/MedSAM2_latest.pt"
-RUN wget --directory-prefix ${WEIGHTS_DIR} ${MEDSAM2_WEIGHTS_URL}
-
-#ENV GD_URL="https://download.openmmlab.com/mmdetection/v3.0/mm_grounding_dino/grounding_dino_swin-t_pretrain_obj365_goldg_grit9m_v3det/grounding_dino_swin-t_pretrain_obj365_goldg_grit9m_v3det_20231204_095047-b448804b.pth"
-
-#RUN wget --directory-prefix ${WEIGHTS_DIR} ${GD_URL}
-
-RUN rm -rf /usr/local/lib/python3.10/dist-packages/dicomweb_client/web.py
-
-COPY ./monai-label/backup/web.py /usr/local/lib/python3.10/dist-packages/dicomweb_client/
-
-ENV CUDA_VISIBLE_DEVICES=1
-ENV PATH=$PATH":/code/monailabel/scripts"
-
-ENV PYTHONPATH=/code:$PYTHONPATH
-RUN python -m monailabel.main apps --download --name radiology --output /code/apps
-EXPOSE 8002
-CMD ["python", "-m", "monailabel.main", "start_server", "--app", "/code/apps/radiology", "--studies", "http://orthanc:8042/dicom-web", "--conf", "models", "segmentation", "--conf", "use_pretrained_model", "false", "-p", "8002"]
+EXPOSE 8003
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["python", "-m", "monailabel.main", "start_server", "--app", "/code/apps/radiology", "--studies", "http://orthanc:8043/dicom-web", "--conf", "models", "segmentation", "--conf", "use_pretrained_model", "false", "-p", "8003"]

--- a/monai-label/entrypoint.sh
+++ b/monai-label/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+# Download the radiology app on first run (avoids baking it into the image layer)
+if [ ! -d "/code/apps/radiology" ]; then
+    echo "[entrypoint] Downloading MONAI Label radiology app..."
+    python -m monailabel.main apps --download --name radiology --output /code/apps
+fi
+
+exec "$@"

--- a/monai-label/monailabel/endpoints/infer.py
+++ b/monai-label/monailabel/endpoints/infer.py
@@ -126,9 +126,21 @@ def send_response(datastore, result, output, background_tasks):
                     "flipped": json.dumps(res_json.get("flipped")),
                     "nninter_elapsed": json.dumps(res_json.get("nninter_elapsed")),
                     "sam_elapsed": json.dumps(res_json.get("sam_elapsed")),
-                    "label_name": res_json.get("label_name")
+                    "label_name": res_json.get("label_name"),
+                    "server_begin_ts": json.dumps(res_json.get("server_begin_ts")),
+                    "server_load_elapsed": json.dumps(res_json.get("server_load_elapsed")),
+                    "server_img_convert_elapsed": json.dumps(res_json.get("server_img_convert_elapsed")),
+                    "server_prompt_prep_elapsed": json.dumps(res_json.get("server_prompt_prep_elapsed")),
+                    "nninter_core_elapsed": json.dumps(res_json.get("nninter_core_elapsed")),
+                    "server_result_elapsed": json.dumps(res_json.get("server_result_elapsed")),
+                    "nninter_first_interaction_ts": json.dumps(res_json.get("nninter_first_interaction_ts")),
+                    "server_end_ts": json.dumps(res_json.get("server_end_ts")),
+                    "server_request_ts": json.dumps(res_json.get("server_request_ts")),
+                    "pred_offset": json.dumps(res_json.get("pred_offset")),
+                    "pred_full_shape": json.dumps(res_json.get("pred_full_shape")),
+                    "pred_crop_shape": json.dumps(res_json.get("pred_crop_shape")),
                 }
-                
+
                 boundary = f"monai-{secrets.token_hex(12)}"
                 meta_json = json.dumps(fields, separators=(",", ":"))
                 return stream_multipart(meta_json, res_dicom_seg)
@@ -157,6 +169,7 @@ def run_inference(
     label: UploadFile = File(None),
     output: Optional[ResultType] = None,
 ):
+    server_request_ts = time.time()  # HTTP request received; before MONAI image download
     request = {"model": model, "image": image}
 
     if not file and not image and not session_id:
@@ -206,6 +219,10 @@ def run_inference(
     if result is None:
         raise HTTPException(status_code=500, detail="Failed to execute infer")
 
+    # Inject HTTP-level timestamp so client can measure MONAI pre-processing (DICOM download) separately
+    if isinstance(result.get("params"), dict):
+        result["params"]["server_request_ts"] = server_request_ts
+
     # Dicom Seg Integration
     if output == "dicom_seg":
         dicom_seg_file = None
@@ -227,12 +244,24 @@ def run_inference(
         #result["dicom_seg"] = dicom_bytes
         res_json = result.get("params")
         fields = {
-                    "prompt_info": json.dumps(res_json.get("prompt_info")),
-                    "flipped": json.dumps(res_json.get("flipped")),
-                    "nninter_elapsed": json.dumps(res_json.get("nninter_elapsed")),
-                    "sam_elapsed": json.dumps(res_json.get("sam_elapsed")),
-                    "label_name": res_json.get("label_name")
-                }
+            "prompt_info": json.dumps(res_json.get("prompt_info")),
+            "flipped": json.dumps(res_json.get("flipped")),
+            "nninter_elapsed": json.dumps(res_json.get("nninter_elapsed")),
+            "sam_elapsed": json.dumps(res_json.get("sam_elapsed")),
+            "label_name": res_json.get("label_name"),
+            "server_begin_ts": json.dumps(res_json.get("server_begin_ts")),
+            "server_load_elapsed": json.dumps(res_json.get("server_load_elapsed")),
+            "server_img_convert_elapsed": json.dumps(res_json.get("server_img_convert_elapsed")),
+            "server_prompt_prep_elapsed": json.dumps(res_json.get("server_prompt_prep_elapsed")),
+            "nninter_core_elapsed": json.dumps(res_json.get("nninter_core_elapsed")),
+            "server_result_elapsed": json.dumps(res_json.get("server_result_elapsed")),
+            "nninter_first_interaction_ts": json.dumps(res_json.get("nninter_first_interaction_ts")),
+            "server_end_ts": json.dumps(res_json.get("server_end_ts")),
+            "server_request_ts": json.dumps(res_json.get("server_request_ts")),
+            "pred_offset": json.dumps(res_json.get("pred_offset")),
+            "pred_full_shape": json.dumps(res_json.get("pred_full_shape")),
+            "pred_crop_shape": json.dumps(res_json.get("pred_crop_shape")),
+        }
         boundary = f"monai-{secrets.token_hex(12)}"
         meta_json = json.dumps(fields, separators=(",", ":"))
         return stream_multipart(meta_json, res_img)

--- a/monai-label/monailabel/tasks/infer/basic_infer.py
+++ b/monai-label/monailabel/tasks/infer/basic_infer.py
@@ -40,7 +40,16 @@ from monailabel.interfaces.utils.transform import dump_data, run_transforms
 from monailabel.transform.cache import CacheTransformDatad
 from monailabel.transform.writer import ClassificationWriter, DetectionWriter, Writer
 from monailabel.utils.others.generic import device_list, device_map, name_to_device
-from monailabel.utils.others.helper import get_scanline_filled_points_3d, clean_and_densify_polyline, spherical_kernel, calculate_dice, timeout_context
+from monailabel.utils.others.helper import (
+    get_scanline_filled_points_3d,
+    clean_and_densify_polyline,
+    spherical_kernel,
+    calculate_dice,
+    timeout_context,
+    scribble_constant_axis,
+    prepare_scribble_interaction_payload,
+    prepare_lasso_interaction_payload,
+)
 from monailabel.utils.others.medgemma import encode_slice_to_jpeg_bytes, window_mri, window, _encode
 from sam2.build_sam import build_sam2_video_predictor, build_sam2_video_predictor_npz
 
@@ -83,14 +92,14 @@ sam3_checkpoint = "/code/checkpoints/sam3.pt"
 from huggingface_hub import snapshot_download
 
 REPO_ID = "nnInteractive/nnInteractive"
-MODEL_NAME = "nnInteractive_v1.0"  # Updated models may be available in the future
+MODEL_NAME = "nnInteractive_v2.0"  # Updated models may be available in the future
 DOWNLOAD_DIR = "/code/checkpoints"  # Specify the download directory
 
-download_path = snapshot_download(
-    repo_id=REPO_ID,
-    allow_patterns=[f"{MODEL_NAME}/*"],
-    local_dir=DOWNLOAD_DIR
-)
+#download_path = snapshot_download(
+#    repo_id=REPO_ID,
+#    allow_patterns=[f"{MODEL_NAME}/*"],
+#    local_dir=DOWNLOAD_DIR
+#)
 
 VOX_MODEL_NAME = "voxtell_v1.1" # Updated models may be available in the future
 
@@ -106,12 +115,11 @@ vox_predictor = VoxTellPredictor(model_dir=vox_model_path, device=torch.device("
 from nnInteractive.inference.inference_session import nnInteractiveInferenceSession
 
 session = nnInteractiveInferenceSession(
-    device=torch.device("cuda:0"),  # Set inference device
-    use_torch_compile=False,  # Experimental: Not tested yet
-    verbose=False,
-    torch_n_threads=os.cpu_count(),  # Use available CPU cores
-    do_autozoom=True,  # Enables AutoZoom for better patching
-    use_pinned_memory=True,  # Optimizes GPU memory transfers
+    device=torch.device("cuda:0"),
+    use_torch_compile=True,
+    verbose=True,
+    torch_n_threads=os.cpu_count(),
+    do_autozoom=True,
 )
 
 model_path = os.path.join(DOWNLOAD_DIR, MODEL_NAME)
@@ -206,6 +214,7 @@ def _medgemma_get_processor_and_model(model_id: str) -> Tuple[Any, Any]:
     )
     _medgemma_loaded_id = model_id
     return _medgemma_processor, _medgemma_model
+
 
 
 def _resolve_hf_token(data: Dict[str, Any]) -> str:
@@ -823,7 +832,11 @@ class BasicInferTask(InferTask):
         self.skip_writer = skip_writer
 
         self._session_image: Dict[str, Any] = {
-            "seriesInstanceUID": None,
+            "dicom_dir": None,        # normalised path MONAI served (level-1 key: exact path match)
+            "seriesInstanceUID": None, # DICOM tag (0020,000E) UID (level-2 key: works if path changes)
+            "img_np": None,           # cached [1,z,y,x] array; populated on init, reused for interactions
+            "instanceNumber": None,   # first DICOM file's InstanceNumber (used for flip detection)
+            "instanceNumber2": None,  # second DICOM file's InstanceNumber
         }
 
 
@@ -1020,6 +1033,19 @@ class BasicInferTask(InferTask):
         Returns: Label (File Path) and Result Params (JSON)
         """
         begin = time.time()
+        server_begin_ts = begin  # Unix timestamp; client uses this to estimate network-to-server latency
+
+        # Fast path: reset does not need config merge, image loading, or deep copy
+        if request.get('nninter') == "reset":
+            for key, lst in self._session_used_interactions.items():
+                lst.clear()
+            session.reset_interactions()
+            # Image cache (_session_image) is intentionally kept: session.reset_interactions()
+            # clears the interaction state in nnInteractive but retains the encoded image
+            # features, so img_np and dicom_dir remain valid for subsequent interactions.
+            logger.info("Reset nninter")
+            return f'/code/predictions/reset.nii.gz', {}
+
         req = copy.deepcopy(self._config)
         req.update(request)
 
@@ -1048,93 +1074,143 @@ class BasicInferTask(InferTask):
         final_result_json = {}
         result_json = {}
         nnInter = data['nninter']
-        if nnInter == "reset":
-            for key, lst in self._session_used_interactions.items():
-                    lst.clear()
-            session.reset_interactions()
-            logger.info("Reset nninter")
-            return f'/code/predictions/reset.nii.gz', final_result_json
 
         img = None
-        
-        dicom_dir = data['image'].split('.nii.gz')[0]
-        seriesInstanceUID = dicom_dir.split("/")[-1]
-        logger.info(f"Series Instance UID: {seriesInstanceUID}")
 
-        reader = sitk.ImageSeriesReader()
-        dicom_filenames = reader.GetGDCMSeriesFileNames(dicom_dir)
-        dcm_img_sample = dcmread(dicom_filenames[0], stop_before_pixels=True)
-        dcm_img_sample_2 = dcmread(dicom_filenames[1], stop_before_pixels=True)
-        
-        instanceNumber = None
-        instanceNumber2 = None
+        dicom_dir = data['image'].split('.nii.gz')[0].rstrip("/")
 
-        if 0x00200013 in dcm_img_sample.keys():
-            instanceNumber = dcm_img_sample[0x00200013].value
-        logger.info(f"Prompt First InstanceNumber: {instanceNumber}")
-        if 0x00200013 in dcm_img_sample_2.keys():
-            instanceNumber2 = dcm_img_sample_2[0x00200013].value
-        logger.info(f"Prompt Second InstanceNumber: {instanceNumber2}")
+        _NNI_EXCLUDE = ("init", "reset",
+                        "medGemma", "gemini", "openai", "claude",
+                        "kimi", "qwen", "gemma", "vllm")
+        _is_nninter_interaction = nnInter and nnInter not in _NNI_EXCLUDE
 
-        contrast_center = None
-        contrast_window = None
-        modality_type = "Other"
+        logger.info(f"dicom_dir={dicom_dir!r}  cached_dicom_dir={self._session_image['dicom_dir']!r}  cached_uid={self._session_image['seriesInstanceUID']!r}")
 
-        if 0x00080060 in dcm_img_sample.keys():
-            modality = dcm_img_sample[0x00080060].value
-            if modality == "CT" or modality == "SC":
-                modality_type = "CT"
-            elif modality == "MR":
-                modality_type = "MR"
+        # Level-1: full cache hit — skip GetGDCMSeriesFileNames, dcmread x2,
+        # reader.Execute, and sitk.GetArrayFromImage entirely.
+        # Key: exact dicom_dir path (stable when MONAI serves the same cached path).
+        _img_np_hit = (
+            _is_nninter_interaction
+            and dicom_dir == self._session_image["dicom_dir"]
+            and self._session_image["img_np"] is not None
+            and self._session_image["instanceNumber"] is not None
+        )
+
+        _pixel_hit = False  # may be set True inside the else branch below
+        if _img_np_hit:
+            seriesInstanceUID = self._session_image["seriesInstanceUID"]
+            instanceNumber    = self._session_image["instanceNumber"]
+            instanceNumber2   = self._session_image["instanceNumber2"]
+            img_convert_elapsed = 0.0
+            logger.info("img_np cache hit — skipping all DICOM I/O")
+        else:
+            # Full I/O: directory scan + header reads needed for metadata / pixel load.
+            reader = sitk.ImageSeriesReader()
+            dicom_filenames = reader.GetGDCMSeriesFileNames(dicom_dir)
+            dcm_img_sample   = dcmread(dicom_filenames[0], stop_before_pixels=True)
+            dcm_img_sample_2 = dcmread(dicom_filenames[1], stop_before_pixels=True)
+
+            # Authoritative UID from DICOM tag (0020,000E); path-derived UID is unreliable
+            # when path has trailing slash or a non-UID last component.
+            _SERIES_UID_TAG = 0x0020000e
+            seriesInstanceUID = (
+                str(dcm_img_sample[_SERIES_UID_TAG].value).strip()
+                if _SERIES_UID_TAG in dcm_img_sample else path_uid
+            )
+            logger.info(f"Series Instance UID: {seriesInstanceUID}")
+
+            instanceNumber  = dcm_img_sample[0x00200013].value  if 0x00200013 in dcm_img_sample  else None
+            instanceNumber2 = dcm_img_sample_2[0x00200013].value if 0x00200013 in dcm_img_sample_2 else None
+            logger.info(f"Prompt First InstanceNumber: {instanceNumber}")
+            logger.info(f"Prompt Second InstanceNumber: {instanceNumber2}")
+
+            contrast_center = None
+            contrast_window = None
+            modality_type   = "Other"
+
+            if 0x00080060 in dcm_img_sample.keys():
+                modality = dcm_img_sample[0x00080060].value
+                if modality in ("CT", "SC"):
+                    modality_type = "CT"
+                elif modality == "MR":
+                    modality_type = "MR"
+                logger.info(f"Modality: {modality_type}")
+
+            if 0x00281050 in dcm_img_sample.keys():
+                contrast_center = dcm_img_sample[0x00281050].value
+            if 0x00281051 in dcm_img_sample.keys():
+                contrast_window = dcm_img_sample[0x00281051].value
+
+            if contrast_window is not None and contrast_center is not None:
+                if contrast_window.__class__.__name__ == 'MultiValue':
+                    contrast_window = contrast_window[0]
+                if contrast_center.__class__.__name__ == 'MultiValue':
+                    contrast_center = contrast_center[0]
+
+            image_series_desc = ""
+            if 0x0008103e in dcm_img_sample.keys():
+                image_series_desc = dcm_img_sample[0x0008103e].value
+
+            # Level-2: path UID may differ (e.g. MONAI changed temp dir) but tag UID matches
+            # → skip reader.Execute + sitk.GetArrayFromImage, keep header metadata.
+            _pixel_hit = (
+                _is_nninter_interaction
+                and seriesInstanceUID == self._session_image["seriesInstanceUID"]
+                and self._session_image["img_np"] is not None
+            )
+
+            if _pixel_hit:
+                logger.info("img_np pixel-cache hit (path UID changed) — skipping reader.Execute")
             else:
-                modality_type = "Other"
-            logger.info(f"Modality: {modality_type}")
-
-        if 0x00281050 in dcm_img_sample.keys():
-            contrast_center = dcm_img_sample[0x00281050].value
-        
-        if 0x00281051 in dcm_img_sample.keys():
-            contrast_window = dcm_img_sample[0x00281051].value
-        
-
-        if contrast_window != None and contrast_center !=None:
-            #breakpoint()
-            if contrast_window.__class__.__name__ == 'MultiValue':
-                contrast_window = contrast_window[0]
-            if contrast_center.__class__.__name__ == 'MultiValue':
-                contrast_center = contrast_center[0]
-
-        image_series_desc = ""
-
-        if 0x0008103e in dcm_img_sample.keys():
-            image_series_desc = dcm_img_sample[0x0008103e].value
-            
-        # --- Load Input Image (Example with SimpleITK) ---
-        reader.SetFileNames(dicom_filenames)
-        #reader.SetOutputPixelType(SimpleITK.sitkUInt16) 
-        img = reader.Execute()
+                if _is_nninter_interaction:
+                    cached_uid = self._session_image["seriesInstanceUID"]
+                    if cached_uid != seriesInstanceUID:
+                        logger.info(f"img_np cache MISS — UID mismatch: cached={cached_uid!r} incoming={seriesInstanceUID!r}")
+                    elif self._session_image["img_np"] is None:
+                        logger.info("img_np cache MISS — not yet initialised")
+                reader.SetFileNames(dicom_filenames)
+                img = reader.Execute()
         
 
         before_nnInter = time.time()
         logger.info(f"Before nnInter: {before_nnInter-begin} secs")
         if nnInter:
             start = time.time()
-            
-            img_np = sitk.GetArrayFromImage(img)[None]
+            nninter_core_elapsed = 0.0          # time inside add_*_interaction calls only
+            nninter_first_interaction_ts = None  # wall-clock of first interaction
+            prompt_prep_elapsed = 0.0           # lasso/scribble mask building (CPU, excludes model calls)
+
+            if _img_np_hit or _pixel_hit:
+                img_np = self._session_image["img_np"]
+                img_convert_elapsed = 0.0
+            else:
+                _t_conv = time.time()
+                img_np = sitk.GetArrayFromImage(img)[None]
+                img_convert_elapsed = time.time() - _t_conv
             # Validate input dimensions
             if img_np.ndim != 4:
                 raise ValueError("Input image must be 4D with shape (1, x, y, z)")
             
             if nnInter == "init":
                 if seriesInstanceUID is not None and self._session_image["seriesInstanceUID"] != seriesInstanceUID:
+                    self._session_image["dicom_dir"]       = dicom_dir
                     self._session_image["seriesInstanceUID"] = seriesInstanceUID
+                    self._session_image["img_np"]          = img_np
+                    self._session_image["instanceNumber"]  = instanceNumber
+                    self._session_image["instanceNumber2"] = instanceNumber2
                     try:
-                        logger.info("Only first time, no image at nnInter or iamge changed")
+                        logger.info("Only first time, no image at nnInter or image changed")
                         session.set_image(img_np)
                         session.set_target_buffer(torch.zeros(img_np.shape[1:], dtype=torch.uint8))
                     except Exception as init_error:
                         logger.error(f"Failed to initialize session: {init_error}")
                         logger.info("Prefer fail!!")
+                elif self._session_image["img_np"] is None:
+                    # Same series but cache was cleared; repopulate
+                    self._session_image["dicom_dir"]       = dicom_dir
+                    self._session_image["img_np"]          = img_np
+                    self._session_image["instanceNumber"]  = instanceNumber
+                    self._session_image["instanceNumber2"] = instanceNumber2
                 for key, lst in self._session_used_interactions.items():
                     lst.clear()
                 session.reset_interactions()
@@ -1585,6 +1661,7 @@ class BasicInferTask(InferTask):
                 return voxtell_seg_np, final_result_json
 
             def _safe_interaction(perform_callable):
+                nonlocal nninter_core_elapsed, nninter_first_interaction_ts
                 try:
                     if session.original_image_shape is None or session.preprocessed_image is None:
                         # Edge cases: a) a lot of requests are pending, while changing layouts b) without proper image initialization
@@ -1598,16 +1675,16 @@ class BasicInferTask(InferTask):
                         if session.executor._work_queue.qsize() == 0 and session.preprocess_future is None:
                             session.set_image(img_np)
                             session.set_target_buffer(torch.zeros(img_np.shape[1:], dtype=torch.uint8))
-                        
+
                         # Wait until session.preprocessed_image is not None
                         max_wait_time = 5.0  # Maximum wait time in seconds
                         wait_interval = 0.1   # Check every 100ms
                         waited_time = 0.0
-                        
+
                         while session.preprocessed_image is None and waited_time < max_wait_time:
                             time.sleep(wait_interval)
                             waited_time += wait_interval
-                        
+
                         if session.preprocessed_image is None:
                             logger.warning(f"Session preprocessed_image still None after {max_wait_time}s wait")
                             logger.info(f"Check queue size: {session.executor._work_queue.qsize()}")
@@ -1619,9 +1696,13 @@ class BasicInferTask(InferTask):
                             return False
                         else:
                             logger.info(f"Session preprocessed_image ready after {waited_time:.2f}s")
-                    logger.info(f"Check queue size: {session.executor._work_queue.qsize()}")        
-                    with timeout_context(seconds=5):
+                    logger.info(f"Check queue size: {session.executor._work_queue.qsize()}")
+                    t_before = time.time()
+                    if nninter_first_interaction_ts is None:
+                        nninter_first_interaction_ts = t_before
+                    with timeout_context(seconds=100):
                         perform_callable()
+                    nninter_core_elapsed += time.time() - t_before
                     return True
                 except Exception as e:
                     logger.error(f"Error during interaction: {e}")
@@ -1671,8 +1752,12 @@ class BasicInferTask(InferTask):
                             box[1][2]=img_np.shape[1]-1-box[1][2]
                         box[0]=box[0][::-1]
                         box[1]=box[1][::-1]
-                        if not _safe_interaction(lambda: session.add_bbox_interaction(
-                            [[box[0][0], box[1][0] + 1], [box[0][1], box[1][1]], [box[0][2], box[1][2]]],
+                        bbox = [
+                            [min(box[0][i], box[1][i]), max(box[0][i], box[1][i]) + 1]
+                            for i in range(3)
+                        ]
+                        if not _safe_interaction(lambda b=bbox: session.add_bbox_interaction(
+                            b,
                             include_interaction=True
                         )):
                             return f'/code/predictions/reset.nii.gz', final_result_json
@@ -1689,8 +1774,12 @@ class BasicInferTask(InferTask):
                             box[1][2]=img_np.shape[1]-1-box[1][2]
                         box[0]=box[0][::-1]
                         box[1]=box[1][::-1]
-                        if not _safe_interaction(lambda: session.add_bbox_interaction(
-                            [[box[0][0], box[1][0] + 1], [box[0][1], box[1][1]], [box[0][2], box[1][2]]],
+                        bbox = [
+                            [min(box[0][i], box[1][i]), max(box[0][i], box[1][i]) + 1]
+                            for i in range(3)
+                        ]
+                        if not _safe_interaction(lambda b=bbox: session.add_bbox_interaction(
+                            b,
                             include_interaction=False
                         )):
                             return f'/code/predictions/reset.nii.gz', final_result_json
@@ -1699,90 +1788,83 @@ class BasicInferTask(InferTask):
 
             if len(data['pos_lassos'])!=0:
                 result_json["pos_lassos"]=copy.deepcopy(data["pos_lassos"])
-                
-                for lasso in data['pos_lassos']:
-                    if not self.is_prompt_used(lasso, "pos_lassos"):
-                        self.add_prompt(lasso, "pos_lassos")
-                        lasso = get_scanline_filled_points_3d(clean_and_densify_polyline(lasso))
-                        lassoMask = np.zeros(img_np.shape[1:], dtype=np.uint8)
-                        
-                        filled_indices = np.asarray(lasso)
+
+                for lasso_raw in data['pos_lassos']:
+                    if not self.is_prompt_used(lasso_raw, "pos_lassos"):
+                        self.add_prompt(lasso_raw, "pos_lassos")
+                        _t_prep = time.time()
+                        perim = clean_and_densify_polyline(lasso_raw)
+                        perim_arr = np.round(np.asarray(perim)).astype(int)
                         if instanceNumber > instanceNumber2:
-                            filled_indices[:, 2]=img_np.shape[1]-1 - filled_indices[:, 2]
-                        x, y, z = filled_indices[:, 0], filled_indices[:, 1], filled_indices[:, 2]
-                        valid = (
-                            (x >= 0) & (x < img_np.shape[3]) &
-                            (y >= 0) & (y < img_np.shape[2]) &
-                            (z >= 0) & (z < img_np.shape[1])
-                        )
-                        # Apply only valid indices
-                        lassoMask[z[valid], y[valid], x[valid]] = 1
-                        if not _safe_interaction(lambda: session.add_lasso_interaction(lassoMask, include_interaction=True)):
+                            perim_arr[:, 2] = img_np.shape[1] - 1 - perim_arr[:, 2]
+                        lasso_image, interaction_bbox = prepare_lasso_interaction_payload(img_np.shape[1:], perim_arr)
+                        prompt_prep_elapsed += time.time() - _t_prep
+                        if lasso_image is None:
+                            continue
+                        if not _safe_interaction(
+                            lambda img=lasso_image, bbox=interaction_bbox: session.add_lasso_interaction(
+                                img, include_interaction=True, interaction_bbox=bbox
+                            )
+                        ):
                             return f'/code/predictions/reset.nii.gz', final_result_json
-                        logger.info("Add a lasso")                
-            
+                        logger.info("Add a lasso")
+
             if len(data['neg_lassos'])!=0:
                 result_json["neg_lassos"]=copy.deepcopy(data["neg_lassos"])
-                
-                for lasso in data['neg_lassos']:
-                    if not self.is_prompt_used(lasso, "neg_lassos"):
-                        self.add_prompt(lasso, "neg_lassos")
-                        lasso = get_scanline_filled_points_3d(clean_and_densify_polyline(lasso))
-                        lassoMask = np.zeros(img_np.shape[1:], dtype=np.uint8)
-                        filled_indices = np.asarray(lasso)
+
+                for lasso_raw in data['neg_lassos']:
+                    if not self.is_prompt_used(lasso_raw, "neg_lassos"):
+                        self.add_prompt(lasso_raw, "neg_lassos")
+                        _t_prep = time.time()
+                        perim = clean_and_densify_polyline(lasso_raw)
+                        perim_arr = np.round(np.asarray(perim)).astype(int)
                         if instanceNumber > instanceNumber2:
-                            filled_indices[:, 2]=img_np.shape[1]-1 - filled_indices[:, 2]
-                        x, y, z = filled_indices[:, 0], filled_indices[:, 1], filled_indices[:, 2]
-                        valid = (
-                            (x >= 0) & (x < img_np.shape[3]) &
-                            (y >= 0) & (y < img_np.shape[2]) &
-                            (z >= 0) & (z < img_np.shape[1])
-                        )
-                        # Apply only valid indices
-                        lassoMask[z[valid], y[valid], x[valid]] = 1
-                        if not _safe_interaction(lambda: session.add_lasso_interaction(lassoMask, include_interaction=False)):
+                            perim_arr[:, 2] = img_np.shape[1] - 1 - perim_arr[:, 2]
+                        lasso_image, interaction_bbox = prepare_lasso_interaction_payload(img_np.shape[1:], perim_arr)
+                        prompt_prep_elapsed += time.time() - _t_prep
+                        if lasso_image is None:
+                            continue
+                        if not _safe_interaction(
+                            lambda img=lasso_image, bbox=interaction_bbox: session.add_lasso_interaction(
+                                img, include_interaction=False, interaction_bbox=bbox
+                            )
+                        ):
                             return f'/code/predictions/reset.nii.gz', final_result_json
-                        logger.info("Add a lasso")  
+                        logger.info("Add a lasso")
             
             if len(data['pos_scribbles'])!=0:
                 result_json["pos_scribbles"]=copy.deepcopy(data["pos_scribbles"])
-                
+
                 for scribble in data['pos_scribbles']:
                     if not self.is_prompt_used(scribble, "pos_scribbles"):
                         self.add_prompt(scribble, "pos_scribbles")
+                        _t_prep = time.time()
                         scribble = clean_and_densify_polyline(scribble)
-                        scribbleMask = np.zeros(img_np.shape[1:], dtype=np.uint8)
-
                         filled_indices = np.round(np.asarray(scribble)).astype(int)
-
+                        if filled_indices.size == 0:
+                            continue
                         if instanceNumber > instanceNumber2:
-                            filled_indices[:, 2]=img_np.shape[1]-1 -filled_indices[:, 2]
-                        
-                        # Sphere of radius 1
-                        kernel = spherical_kernel(radius=1)
-                        kz, ky, kx = kernel.shape
-                        offset_z, offset_y, offset_x = kz // 2, ky // 2, kx // 2
-
-                        for x, y, z in filled_indices:
-                            z0, z1 = z - offset_z, z + offset_z + 1
-                            y0, y1 = y - offset_y, y + offset_y + 1
-                            x0, x1 = x - offset_x, x + offset_x + 1
-
-                            # clip bounds to mask
-                            z0c, z1c = max(z0, 0), min(z1, scribbleMask.shape[0])
-                            y0c, y1c = max(y0, 0), min(y1, scribbleMask.shape[1])
-                            x0c, x1c = max(x0, 0), min(x1, scribbleMask.shape[2])
-
-                            # compute corresponding kernel slices
-                            kz0, kz1 = z0c - z0, z1c - z0
-                            ky0, ky1 = y0c - y0, y1c - y0
-                            kx0, kx1 = x0c - x0, x1c - x0
-
-                            #if z0 < 0 or y0 < 0 or x0 < 0 or z1 > scribbleMask.shape[0] or y1 > scribbleMask.shape[1] or x1 > scribbleMask.shape[2]:
-                            #    continue  # Skip out-of-bounds
-                            scribbleMask[z0c:z1c, y0c:y1c, x0c:x1c] |= kernel[kz0:kz1, ky0:ky1, kx0:kx1]
+                            filled_indices[:, 2] = img_np.shape[1] - 1 - filled_indices[:, 2]
+                        flat_axis = scribble_constant_axis(filled_indices)
+                        if flat_axis is not None:
+                            logger.info(f"2D scribble on axis {flat_axis}")
+                        scribble_image, interaction_bbox = prepare_scribble_interaction_payload(
+                            img_np.shape[1:], filled_indices, flat_axis
+                        )
+                        prompt_prep_elapsed += time.time() - _t_prep
                         scribble_start = time.time()
-                        if not _safe_interaction(lambda: session.add_scribble_interaction(scribbleMask, include_interaction=True)):
+                        if interaction_bbox is not None:
+                            if not _safe_interaction(
+                                lambda img=scribble_image, bbox=interaction_bbox: session.add_scribble_interaction(
+                                    scribble_image=img, include_interaction=True, interaction_bbox=bbox
+                                )
+                            ):
+                                return f'/code/predictions/reset.nii.gz', final_result_json
+                        elif not _safe_interaction(
+                            lambda img=scribble_image: session.add_scribble_interaction(
+                                scribble_image=img, include_interaction=True
+                            )
+                        ):
                             return f'/code/predictions/reset.nii.gz', final_result_json
                         logger.info(f"only for add scribble: {time.time()-scribble_start} secs")
                         logger.info(f"just after add scribble: {time.time()-start} secs")
@@ -1790,54 +1872,63 @@ class BasicInferTask(InferTask):
 
             if len(data['neg_scribbles'])!=0:
                 result_json["neg_scribbles"]=copy.deepcopy(data["neg_scribbles"])
-                
+
                 for scribble in data['neg_scribbles']:
                     if not self.is_prompt_used(scribble, "neg_scribbles"):
                         self.add_prompt(scribble, "neg_scribbles")
+                        _t_prep = time.time()
                         scribble = clean_and_densify_polyline(scribble)
-                        scribbleMask = np.zeros(img_np.shape[1:], dtype=np.uint8)
-
                         filled_indices = np.round(np.asarray(scribble)).astype(int)
-
-                        #logger.info(f"filled_indices: {filled_indices}")
-                        #logger.info(f"filled_indices shape: {filled_indices.shape}")
+                        if filled_indices.size == 0:
+                            continue
                         if instanceNumber > instanceNumber2:
-                            filled_indices[:, 2]=img_np.shape[1]-1 -filled_indices[:, 2]
-                        
-                        # Sphere of radius 1
-                        kernel = spherical_kernel(radius=1)
-                        kz, ky, kx = kernel.shape
-                        offset_z, offset_y, offset_x = kz // 2, ky // 2, kx // 2
-
-                        for x, y, z in filled_indices:
-                            z0, z1 = z - offset_z, z + offset_z + 1
-                            y0, y1 = y - offset_y, y + offset_y + 1
-                            x0, x1 = x - offset_x, x + offset_x + 1
-
-                            # clip bounds to mask
-                            z0c, z1c = max(z0, 0), min(z1, scribbleMask.shape[0])
-                            y0c, y1c = max(y0, 0), min(y1, scribbleMask.shape[1])
-                            x0c, x1c = max(x0, 0), min(x1, scribbleMask.shape[2])
-
-                            # compute corresponding kernel slices
-                            kz0, kz1 = z0c - z0, z1c - z0
-                            ky0, ky1 = y0c - y0, y1c - y0
-                            kx0, kx1 = x0c - x0, x1c - x0
-
-                            #if z0 < 0 or y0 < 0 or x0 < 0 or z1 > scribbleMask.shape[0] or y1 > scribbleMask.shape[1] or x1 > scribbleMask.shape[2]:
-                            #    continue  # Skip out-of-bounds
-                            scribbleMask[z0c:z1c, y0c:y1c, x0c:x1c] |= kernel[kz0:kz1, ky0:ky1, kx0:kx1]
-                    
-                        if not _safe_interaction(lambda: session.add_scribble_interaction(scribbleMask, include_interaction=False)):
+                            filled_indices[:, 2] = img_np.shape[1] - 1 - filled_indices[:, 2]
+                        flat_axis = scribble_constant_axis(filled_indices)
+                        if flat_axis is not None:
+                            logger.info(f"2D scribble on axis {flat_axis}")
+                        scribble_image, interaction_bbox = prepare_scribble_interaction_payload(
+                            img_np.shape[1:], filled_indices, flat_axis
+                        )
+                        prompt_prep_elapsed += time.time() - _t_prep
+                        if interaction_bbox is not None:
+                            if not _safe_interaction(
+                                lambda img=scribble_image, bbox=interaction_bbox: session.add_scribble_interaction(
+                                    scribble_image=img, include_interaction=False, interaction_bbox=bbox
+                                )
+                            ):
+                                return f'/code/predictions/reset.nii.gz', final_result_json
+                        elif not _safe_interaction(
+                            lambda img=scribble_image: session.add_scribble_interaction(
+                                scribble_image=img, include_interaction=False
+                            )
+                        ):
                             return f'/code/predictions/reset.nii.gz', final_result_json
                         logger.info("Add a scribble")
 
             # --- Retrieve Results ---
-            # The target buffer holds the segmentation result.
+            _t_result = time.time()
             results = session.target_buffer.clone()
+            pred = results.numpy()  # shape (Z, Y, X), dtype uint8
 
-            # Enjoy!
-            pred = results.numpy()
+            # Crop to tight non-zero bbox before sending.
+            # Reduces wire bytes and compression time proportionally to segmentation size.
+            # Client reconstructs full volume using pred_offset + pred_full_shape from meta.
+            pred_full_shape = list(pred.shape)
+            # np.any along axes is ~10x faster than np.nonzero on large sparse arrays
+            # because it short-circuits and reduces 182M elements to three 1-D projections.
+            z_any = np.any(pred, axis=(1, 2))
+            z_nz  = np.where(z_any)[0]
+            if z_nz.size > 0:
+                y_nz = np.where(np.any(pred, axis=(0, 2)))[0]
+                x_nz = np.where(np.any(pred, axis=(0, 1)))[0]
+                z0, z1 = int(z_nz[0]),  int(z_nz[-1])  + 1
+                y0, y1 = int(y_nz[0]),  int(y_nz[-1])  + 1
+                x0, x1 = int(x_nz[0]),  int(x_nz[-1])  + 1
+                pred = pred[z0:z1, y0:y1, x0:x1]
+                pred_offset = [z0, y0, x0]
+            else:
+                pred_offset = [0, 0, 0]
+            result_elapsed = time.time() - _t_result
 
             
 
@@ -1846,10 +1937,28 @@ class BasicInferTask(InferTask):
             #pred_itk = sitk.Cast(pred_itk, sitk.sitkUInt8)
             #sitk.WriteImage(pred_itk, f'/code/predictions/nninter_{image_series_desc}.nii.gz')
             nninter_elapsed = time.time() - start
-            logger.info(f"nninter latency : {nninter_elapsed} (sec)")
-            # final_result_json["dicom_seg"] = raw
+            server_load_elapsed = before_nnInter - begin
+
+            logger.info(
+                f"[timing] load={server_load_elapsed:.3f}s  img_convert={img_convert_elapsed:.3f}s  "
+                f"prompt_prep={prompt_prep_elapsed:.3f}s  model_core={nninter_core_elapsed:.3f}s  "
+                f"result_retrieve={result_elapsed:.3f}s  total_nninter={nninter_elapsed:.3f}s"
+            )
+
             final_result_json["prompt_info"] = result_json
-            final_result_json["nninter_elapsed"] = nninter_elapsed
+            # --- round-trip timing breakdown ---
+            final_result_json["server_begin_ts"] = server_begin_ts          # Unix ts; client computes network-to-server latency
+            final_result_json["server_load_elapsed"] = server_load_elapsed  # DICOM read + sitk.Execute
+            final_result_json["server_img_convert_elapsed"] = img_convert_elapsed  # sitk → numpy
+            final_result_json["server_prompt_prep_elapsed"] = prompt_prep_elapsed  # lasso/scribble mask build
+            final_result_json["nninter_core_elapsed"] = nninter_core_elapsed       # GPU add_*_interaction
+            final_result_json["server_result_elapsed"] = result_elapsed            # target_buffer → numpy + bbox crop
+            final_result_json["nninter_elapsed"] = nninter_elapsed                 # total nnInter block
+            final_result_json["pred_offset"] = pred_offset            # [z0, y0, x0] of cropped region in full volume
+            final_result_json["pred_full_shape"] = pred_full_shape  # [Z, Y, X] of full volume (before crop)
+            final_result_json["pred_crop_shape"] = list(pred.shape) # [cropZ, cropY, cropX] of what is actually sent
+            final_result_json["nninter_first_interaction_ts"] = nninter_first_interaction_ts
+            final_result_json["server_end_ts"] = time.time()  # wall-clock just before serialization; client uses this to isolate server→client network latency
 
             if instanceNumber > instanceNumber2:
                 final_result_json["flipped"] = True
@@ -1880,9 +1989,9 @@ class BasicInferTask(InferTask):
                 predictor = predictor_sam2
             start = time.time()
             #result_json["pos_points"]=data["pos_points"]
-            result_json["pos_points"]=copy.deepcopy(data["pos_points"])
-            result_json["neg_points"]=copy.deepcopy(data["neg_points"])
-            result_json["pos_boxes"]=copy.deepcopy(data["pos_boxes"])
+            result_json["pos_points"] = copy.deepcopy(data["pos_points"]) if data["pos_points"] else []
+            result_json["neg_points"] = copy.deepcopy(data["neg_points"]) if data["neg_points"] else []
+            result_json["pos_boxes"] = copy.deepcopy(data["pos_boxes"]) if data["pos_boxes"] else []
             
             len_z = img.GetSize()[2]
             len_y = img.GetSize()[1]
@@ -1979,24 +2088,9 @@ class BasicInferTask(InferTask):
 
             for i in range(len(ann_frame_list)):
 
-                reader = sitk.ImageSeriesReader()
-                dicom_filenames = reader.GetGDCMSeriesFileNames(dicom_dir)
-                dcm_img_sample = dcmread(dicom_filenames[0], stop_before_pixels=True)
-                dcm_img_sample_2 = dcmread(dicom_filenames[1], stop_before_pixels=True)
-                
-                instanceNumber = None
-                instanceNumber2 = None
-
-                if 0x00200013 in dcm_img_sample.keys():
-                    instanceNumber = dcm_img_sample[0x00200013].value
-                logger.info(f"Prompt First InstanceNumber: {instanceNumber}")
-                if 0x00200013 in dcm_img_sample_2.keys():
-                    instanceNumber2 = dcm_img_sample_2[0x00200013].value
-                logger.info(f"Prompt Second InstanceNumber: {instanceNumber2}")
-
                 if instanceNumber < instanceNumber2:
                     ann_frame_idx = ann_frame_list[i]
-                else:    
+                else:
                     ann_frame_idx = len_z-1-ann_frame_list[i]
             
             #ann_frame_idx = len_z-1-data['pos_points'][0][2]  # the frame index we interact with 
@@ -2087,6 +2181,12 @@ class BasicInferTask(InferTask):
                                 out_obj_id: (out_mask_logits[i] > 0.0).cpu().numpy()
                                 for i, out_obj_id in enumerate(out_obj_ids)
                             }
+
+            # Free SAM2 inference state buffers before building the output array
+            predictor.reset_state(inference_state)
+            del inference_state
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
 
             pred = np.zeros((len_z, len_y, len_x))
 

--- a/monai-label/monailabel/tasks/infer/basic_infer.py
+++ b/monai-label/monailabel/tasks/infer/basic_infer.py
@@ -92,14 +92,14 @@ sam3_checkpoint = "/code/checkpoints/sam3.pt"
 from huggingface_hub import snapshot_download
 
 REPO_ID = "nnInteractive/nnInteractive"
-MODEL_NAME = "nnInteractive_v2.0"  # Updated models may be available in the future
+MODEL_NAME = "nnInteractive_v1.0"  # Updated models may be available in the future
 DOWNLOAD_DIR = "/code/checkpoints"  # Specify the download directory
 
-#download_path = snapshot_download(
-#    repo_id=REPO_ID,
-#    allow_patterns=[f"{MODEL_NAME}/*"],
-#    local_dir=DOWNLOAD_DIR
-#)
+download_path = snapshot_download(
+    repo_id=REPO_ID,
+    allow_patterns=[f"{MODEL_NAME}/*"],
+    local_dir=DOWNLOAD_DIR
+)
 
 VOX_MODEL_NAME = "voxtell_v1.1" # Updated models may be available in the future
 

--- a/monai-label/monailabel/utils/others/helper.py
+++ b/monai-label/monailabel/utils/others/helper.py
@@ -85,6 +85,229 @@ def spherical_kernel(radius=1):
     dist = np.sqrt((zz - center)**2 + (yy - center)**2 + (xx - center)**2)
     return (dist <= radius).astype(np.uint8)
 
+
+def scribble_constant_axis(filled_indices):
+    """If the polyline lies in an axis-aligned plane return that axis (0=x,1=y,2=z), else None."""
+    if filled_indices.size == 0:
+        return None
+    for axis in (0, 1, 2):
+        if np.unique(filled_indices[:, axis]).size == 1:
+            return axis
+    return None
+
+
+def scribble_mask_tight_bbox_zyx(scribble_mask, flat_axis, filled_indices):
+    """Tight half-open bbox [[z0,z1],[y0,y1],[x0,x1]] from nonzero voxels (scribble_mask is [z,y,x])."""
+    coords = np.nonzero(scribble_mask)
+    if coords[0].size == 0:
+        return None
+    z_idx, y_idx, x_idx = coords
+    if flat_axis == 0:
+        x_idx = filled_indices[:, 0]
+    elif flat_axis == 1:
+        y_idx = filled_indices[:, 1]
+    elif flat_axis == 2:
+        z_idx = filled_indices[:, 2]
+    return [
+        [int(z_idx.min()), int(z_idx.max()) + 1],
+        [int(y_idx.min()), int(y_idx.max()) + 1],
+        [int(x_idx.min()), int(x_idx.max()) + 1],
+    ]
+
+
+def crop_scribble_mask_xyz_bbox(scribble_mask, interaction_bbox):
+    """Crop [z,y,x] mask to bbox; return array in (x,y,z) order for add_scribble_interaction."""
+    z0, z1 = interaction_bbox[0]
+    y0, y1 = interaction_bbox[1]
+    x0, x1 = interaction_bbox[2]
+    return scribble_mask[z0:z1, y0:y1, x0:x1]
+
+
+def build_scribble_mask(volume_shape_zyx, filled_indices, kernel_radius=1):
+    """Stamp a spherical kernel along polyline points using vectorized binary dilation.
+    filled_indices columns are [x, y, z]; returned mask is indexed [z, y, x].
+    3-D fallback (rare): uses a 2×2×2 cube kernel to match the 2-pixel target width.
+    """
+    from scipy.ndimage import binary_dilation
+    if filled_indices.size == 0:
+        return np.zeros(volume_shape_zyx, dtype=np.uint8)
+    # 2×2×2 cube gives ~2 px effective width in 3D, matching the 2D fast-path kernel.
+    kernel = np.ones((2, 2, 2), dtype=np.uint8)
+    point_mask = np.zeros(volume_shape_zyx, dtype=bool)
+    x_arr, y_arr, z_arr = filled_indices[:, 0], filled_indices[:, 1], filled_indices[:, 2]
+    valid = (
+        (x_arr >= 0) & (x_arr < volume_shape_zyx[2]) &
+        (y_arr >= 0) & (y_arr < volume_shape_zyx[1]) &
+        (z_arr >= 0) & (z_arr < volume_shape_zyx[0])
+    )
+    point_mask[z_arr[valid], y_arr[valid], x_arr[valid]] = True
+    return binary_dilation(point_mask, structure=kernel).astype(np.uint8)
+
+
+def build_scribble_payload_2d(volume_shape_zyx, filled_indices, flat_axis, kernel_radius=1):
+    """Fast path for planar scribbles: work entirely in 2-D, skip full 3-D volume allocation.
+
+    binary_dilation on a 512×512 slice is ~200-300× faster than on a 512×512×300 volume.
+    Returns (crop_zyx, interaction_bbox) ready for add_scribble_interaction.
+    filled_indices columns: [x, y, z]; flat_axis: 0=sagittal(x const), 1=coronal(y const), 2=axial(z const).
+
+    Scribble width is fixed at 2 pixels: each path point is stamped with a 2×2 kernel.
+    Symmetric odd-radius kernels produce 1, 3, 5 … px; the 2×2 kernel is the only clean
+    way to achieve exactly 2 px without directional bias.  No performance cost vs. 3×3.
+    """
+    from scipy.ndimage import binary_dilation
+    # 2-pixel-wide scribble: 2×2 stamp per path point.
+    # (The kernel_radius param is kept for signature compatibility but ignored here.)
+    kernel_2d = np.ones((2, 2), dtype=bool)
+    x_arr, y_arr, z_arr = filled_indices[:, 0], filled_indices[:, 1], filled_indices[:, 2]
+    D, H, W = volume_shape_zyx  # ZYX
+
+    if flat_axis == 2:          # axial: z constant, 2-D plane is (H, W)
+        z_val = int(z_arr[0])
+        mask = np.zeros((H, W), dtype=bool)
+        valid = (x_arr >= 0) & (x_arr < W) & (y_arr >= 0) & (y_arr < H)
+        mask[y_arr[valid], x_arr[valid]] = True
+        dil = binary_dilation(mask, structure=kernel_2d)
+        ri, ci = np.where(np.any(dil, axis=1))[0], np.where(np.any(dil, axis=0))[0]
+        y0, y1 = int(ri.min()), int(ri.max()) + 1
+        x0, x1 = int(ci.min()), int(ci.max()) + 1
+        crop = dil[y0:y1, x0:x1].astype(np.uint8)[np.newaxis, :, :]   # (1, dy, dx)
+        bbox = [[z_val, z_val + 1], [y0, y1], [x0, x1]]
+
+    elif flat_axis == 1:        # coronal: y constant, 2-D plane is (D, W)
+        y_val = int(y_arr[0])
+        mask = np.zeros((D, W), dtype=bool)
+        valid = (x_arr >= 0) & (x_arr < W) & (z_arr >= 0) & (z_arr < D)
+        mask[z_arr[valid], x_arr[valid]] = True
+        dil = binary_dilation(mask, structure=kernel_2d)
+        ri, ci = np.where(np.any(dil, axis=1))[0], np.where(np.any(dil, axis=0))[0]
+        z0, z1 = int(ri.min()), int(ri.max()) + 1
+        x0, x1 = int(ci.min()), int(ci.max()) + 1
+        crop = dil[z0:z1, x0:x1].astype(np.uint8)[:, np.newaxis, :]   # (dz, 1, dx)
+        bbox = [[z0, z1], [y_val, y_val + 1], [x0, x1]]
+
+    else:                       # flat_axis == 0: sagittal: x constant, 2-D plane is (D, H)
+        x_val = int(x_arr[0])
+        mask = np.zeros((D, H), dtype=bool)
+        valid = (y_arr >= 0) & (y_arr < H) & (z_arr >= 0) & (z_arr < D)
+        mask[z_arr[valid], y_arr[valid]] = True
+        dil = binary_dilation(mask, structure=kernel_2d)
+        ri, ci = np.where(np.any(dil, axis=1))[0], np.where(np.any(dil, axis=0))[0]
+        z0, z1 = int(ri.min()), int(ri.max()) + 1
+        y0, y1 = int(ci.min()), int(ci.max()) + 1
+        crop = dil[z0:z1, y0:y1].astype(np.uint8)[:, :, np.newaxis]   # (dz, dy, 1)
+        bbox = [[z0, z1], [y0, y1], [x_val, x_val + 1]]
+
+    return crop, bbox
+
+
+def _rasterize_polygon_2d(rows, cols, H, W):
+    """Rasterize a closed polygon onto a (H, W) bool mask and fill its interior.
+
+    clean_and_densify_polyline only densifies in x-y space, so for coronal/sagittal
+    planes the projected perimeter can have large gaps in the z-direction.  Drawing
+    explicit line segments between consecutive projected vertices (via np.linspace)
+    guarantees a gap-free closed boundary before binary_fill_holes is applied.
+    """
+    from scipy.ndimage import binary_fill_holes
+
+    mask = np.zeros((H, W), dtype=bool)
+    n = len(rows)
+    for i in range(n):
+        r0, c0 = int(rows[i]),           int(cols[i])
+        r1, c1 = int(rows[(i + 1) % n]), int(cols[(i + 1) % n])
+        steps = max(abs(r1 - r0), abs(c1 - c0)) + 1
+        rs = np.round(np.linspace(r0, r1, steps)).astype(int)
+        cs = np.round(np.linspace(c0, c1, steps)).astype(int)
+        v = (rs >= 0) & (rs < H) & (cs >= 0) & (cs < W)
+        mask[rs[v], cs[v]] = True
+    return binary_fill_holes(mask)
+
+
+def build_lasso_payload_2d(volume_shape_zyx, perim_arr, flat_axis):
+    """Fast 2D path for lasso: rasterize closed polygon edges in the projection
+    plane then fill interior with binary_fill_holes, then crop to tight bbox.
+
+    Handles all three axis-aligned planes (axial/coronal/sagittal), matching
+    the same structure as build_scribble_payload_2d.
+
+    perim_arr: integer [x, y, z] array of densified perimeter (z already flipped).
+    flat_axis: 0=sagittal (x const), 1=coronal (y const), 2=axial (z const).
+    Returns (crop_zyx, interaction_bbox) or (None, None) if mask is empty.
+    """
+    D, H, W = volume_shape_zyx
+    x_p, y_p, z_p = perim_arr[:, 0], perim_arr[:, 1], perim_arr[:, 2]
+
+    if flat_axis == 2:          # axial: z constant, plane is (H, W) → (row=y, col=x)
+        z_val = int(z_p[0])
+        filled = _rasterize_polygon_2d(y_p, x_p, H, W)
+        if not filled.any():
+            return None, None
+        ri, ci = np.where(np.any(filled, axis=1))[0], np.where(np.any(filled, axis=0))[0]
+        y0, y1 = int(ri.min()), int(ri.max()) + 1
+        x0, x1 = int(ci.min()), int(ci.max()) + 1
+        crop = filled[y0:y1, x0:x1].astype(np.uint8)[np.newaxis, :, :]   # (1, dy, dx)
+        return crop, [[z_val, z_val + 1], [y0, y1], [x0, x1]]
+
+    elif flat_axis == 1:        # coronal: y constant, plane is (D, W) → (row=z, col=x)
+        y_val = int(y_p[0])
+        filled = _rasterize_polygon_2d(z_p, x_p, D, W)
+        if not filled.any():
+            return None, None
+        ri, ci = np.where(np.any(filled, axis=1))[0], np.where(np.any(filled, axis=0))[0]
+        z0, z1 = int(ri.min()), int(ri.max()) + 1
+        x0, x1 = int(ci.min()), int(ci.max()) + 1
+        crop = filled[z0:z1, x0:x1].astype(np.uint8)[:, np.newaxis, :]   # (dz, 1, dx)
+        return crop, [[z0, z1], [y_val, y_val + 1], [x0, x1]]
+
+    else:                       # flat_axis == 0: sagittal: x constant, plane is (D, H) → (row=z, col=y)
+        x_val = int(x_p[0])
+        filled = _rasterize_polygon_2d(z_p, y_p, D, H)
+        if not filled.any():
+            return None, None
+        ri, ci = np.where(np.any(filled, axis=1))[0], np.where(np.any(filled, axis=0))[0]
+        z0, z1 = int(ri.min()), int(ri.max()) + 1
+        y0, y1 = int(ci.min()), int(ci.max()) + 1
+        crop = filled[z0:z1, y0:y1].astype(np.uint8)[:, :, np.newaxis]   # (dz, dy, 1)
+        return crop, [[z0, z1], [y0, y1], [x_val, x_val + 1]]
+
+
+def prepare_lasso_interaction_payload(volume_shape_zyx, perim_arr):
+    """Return (lasso_image, interaction_bbox) for add_lasso_interaction.
+
+    For planar lassos uses the 2-D fast path (build_lasso_payload_2d).
+    For 3-D lassos falls back to full-volume scanline fill with no bbox.
+    """
+    flat_axis = scribble_constant_axis(perim_arr)
+    if flat_axis is not None:
+        return build_lasso_payload_2d(volume_shape_zyx, perim_arr, flat_axis)
+    # 3-D fallback: full-volume scanline fill (original approach)
+    D, H, W = volume_shape_zyx
+    filled_3d = get_scanline_filled_points_3d(perim_arr)
+    if not filled_3d:
+        return None, None
+    filled_arr = np.asarray(filled_3d)
+    x = filled_arr[:, 0].astype(int)
+    y = filled_arr[:, 1].astype(int)
+    z = filled_arr[:, 2].astype(int)
+    valid = (x >= 0) & (x < W) & (y >= 0) & (y < H) & (z >= 0) & (z < D)
+    lasso_mask = np.zeros((D, H, W), dtype=np.uint8)
+    lasso_mask[z[valid], y[valid], x[valid]] = 1
+    return lasso_mask, None
+
+
+def prepare_scribble_interaction_payload(volume_shape_zyx, filled_indices, flat_axis):
+    """Return (scribble_image, interaction_bbox) for add_scribble_interaction.
+
+    For planar scribbles uses the 2-D fast path (build_scribble_payload_2d).
+    For 3-D scribbles falls back to full-volume binary_dilation with no bbox.
+    """
+    if flat_axis is not None:
+        return build_scribble_payload_2d(volume_shape_zyx, filled_indices, flat_axis)
+    # 3-D fallback: build full volume mask, no crop
+    scribble_mask = build_scribble_mask(volume_shape_zyx, filled_indices)
+    return scribble_mask, None
+
 # Calculate Dice coefficient between prediction and ground truth
 def calculate_dice(pred_mask, gt_mask, smooth=1e-6):
     """

--- a/scripts/download_weights.sh
+++ b/scripts/download_weights.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# One-shot script: download model weights into monai-label/checkpoints/
+# Run once before `docker compose up`: bash scripts/download_weights.sh
+set -e
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CHECKPOINTS_DIR="$REPO_ROOT/monai-label/checkpoints"
+mkdir -p "$CHECKPOINTS_DIR"
+
+SAM2_URL="https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_tiny.pt"
+MEDSAM2_URL="https://huggingface.co/wanglab/MedSAM2/resolve/main/MedSAM2_latest.pt"
+
+echo "Downloading SAM2.1 weights to $CHECKPOINTS_DIR ..."
+wget --no-clobber --directory-prefix "$CHECKPOINTS_DIR" "$SAM2_URL"
+
+echo "Downloading MedSAM2 weights to $CHECKPOINTS_DIR ..."
+wget --no-clobber --directory-prefix "$CHECKPOINTS_DIR" "$MEDSAM2_URL"
+
+echo "Done. Weights are in $CHECKPOINTS_DIR"

--- a/start.sh
+++ b/start.sh
@@ -1,1 +1,65 @@
-docker compose -f ./docker-compose.yml up --build
+#!/bin/bash
+set -e
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+HASH_DIR="$REPO_ROOT/.build-hashes"
+mkdir -p "$HASH_DIR"
+
+# ── Model weights ─────────────────────────────────────────────────────────────
+CHECKPOINTS_DIR="$REPO_ROOT/monai-label/checkpoints"
+SAM2_WEIGHTS="$CHECKPOINTS_DIR/sam2.1_hiera_tiny.pt"
+MEDSAM2_WEIGHTS="$CHECKPOINTS_DIR/MedSAM2_latest.pt"
+
+if [ ! -f "$SAM2_WEIGHTS" ] || [ ! -f "$MEDSAM2_WEIGHTS" ]; then
+    echo "[start.sh] Model weights missing, downloading..."
+    bash "$REPO_ROOT/scripts/download_weights.sh"
+else
+    echo "[start.sh] Model weights present, skipping download."
+fi
+
+# ── Per-service change detection ──────────────────────────────────────────────
+# Hash = last commit touching the service's paths + hash of any uncommitted diff.
+# This is fast (git is O(log n)) and captures both committed and dirty changes.
+
+_service_hash() {
+    local paths="$@"
+    local commit diff_hash
+    commit=$(git -C "$REPO_ROOT" log -1 --format="%H" -- $paths 2>/dev/null || echo "nogit")
+    diff_hash=$(git -C "$REPO_ROOT" diff HEAD -- $paths 2>/dev/null | md5sum | cut -d' ' -f1)
+    echo "${commit}_${diff_hash}"
+}
+
+OHIF_HASH=$(_service_hash Viewers/)
+MONAI_HASH=$(_service_hash monai-label/ sam2/ sam3/)
+
+STORED_OHIF=$(cat "$HASH_DIR/ohif" 2>/dev/null || echo "")
+STORED_MONAI=$(cat "$HASH_DIR/monai" 2>/dev/null || echo "")
+
+BUILD_SERVICES=()
+if [ "$OHIF_HASH" != "$STORED_OHIF" ]; then
+    echo "[start.sh] OHIF viewer changed — will rebuild ohif_viewer."
+    BUILD_SERVICES+=(ohif_viewer)
+else
+    echo "[start.sh] OHIF viewer unchanged — skipping ohif_viewer rebuild."
+fi
+
+if [ "$MONAI_HASH" != "$STORED_MONAI" ]; then
+    echo "[start.sh] MONAI source changed — will rebuild monai_server."
+    BUILD_SERVICES+=(monai_server)
+else
+    echo "[start.sh] MONAI source unchanged — skipping monai_server rebuild."
+fi
+
+# ── Build only what changed ───────────────────────────────────────────────────
+if [ ${#BUILD_SERVICES[@]} -gt 0 ]; then
+    echo "[start.sh] Building: ${BUILD_SERVICES[*]}"
+    docker compose -f "$REPO_ROOT/docker-compose.yml" build "${BUILD_SERVICES[@]}"
+
+    # Store hashes only after a successful build
+    [ "$OHIF_HASH" != "$STORED_OHIF" ] && echo "$OHIF_HASH" > "$HASH_DIR/ohif"
+    [ "$MONAI_HASH" != "$STORED_MONAI" ] && echo "$MONAI_HASH" > "$HASH_DIR/monai"
+else
+    echo "[start.sh] Nothing changed — starting existing images."
+fi
+
+docker compose -f "$REPO_ROOT/docker-compose.yml" up


### PR DESCRIPTION
## Summary

Comprehensive pass on the nnInteractive workflow (branch `nninterv2`), covering Docker/build ergonomics, MONAI Label inference hot paths, and OHIF viewer segmentation UX and rendering.

### Docker & build
- Split `monai-label` Dockerfile into deps/app stages; switch to CUDA **runtime** base; add pip/apt BuildKit cache mounts
- Remove build-time weight downloads; mount checkpoints at runtime (`scripts/download_weights.sh`, `start.sh`)
- Persist MONAI Label DICOM cache across rebuilds (`monai-label/volumes/root-cache`)
- Viewers Dockerfile: keep bun install cache; Orthanc/nginx recipe tweaks

### MONAI Label backend (`basic_infer.py`, `infer.py`, `helper.py`)
- Cache `img_np` after init; skip redundant DICOM I/O on interaction cache hits
- Vectorized scribble/lasso prompt prep; bbox-crop mask responses; faster gzip level
- Single-pass prompt partitioning for SAM2/nnInteractive (replaces filter/map chains)
- Round-trip timing breakdown (client/server segments) in infer responses

### OHIF viewer
- nnInteractive session aligned with reference implementation
- Faster labelmap updates: bbox crop, zero-copy slice writes, parallel viewport updates
- Toolbox UX: deselect tools, pos/neg reset, notification guards for MPR/series changes
- Fixes for lasso/scribble geometry on coronal/sagittal and overlap/crop paths

## Commits (3)

| Commit | Scope |
|--------|--------|
| `build:` Docker/compose/weights | Dockerfiles, compose, entrypoint, download scripts, cache volume |
| `perf(monai-label):` inference | DICOM cache, img_np cache, SAM2/nnInter partitioners, scribble/lasso/bbox crop, timing |
| `feat(viewers):` nnInteractive v2 | Session update, rendering perf, toolbox/notifications, MPR/lasso fixes |

## Test plan

- [x] Run`bash start.sh`
- [x] Open a study in OHIF; run nnInteractive init + point/scribble/lasso/bbox prompts on axial and MPR
- [x] Confirm segmentation updates without alert spam; pos/neg resets on series change
- [x] Check infer response timing fields on repeated interactions (cache hit vs miss)
