### PR TITLE
feed2: MPR UX, segment management, and nnInteractive performance

### DIFF
--- a/Viewers/extensions/cornerstone/src/panels/PanelSegmentation.tsx
+++ b/Viewers/extensions/cornerstone/src/panels/PanelSegmentation.tsx
@@ -1,12 +1,16 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { SegmentationTable } from '@ohif/ui-next';
 import { useActiveViewportSegmentationRepresentations } from '../hooks/useActiveViewportSegmentationRepresentations';
 import { metaData } from '@cornerstonejs/core';
 import { useSystem } from '@ohif/core/src';
+import { toolboxState } from '@ohif/extension-default/src/stores/toolboxState';
+
+const AI_PROMPT_TOOLS = ['Probe2', 'RectangleROI2', 'PlanarFreehandROI2', 'PlanarFreehandROI3'];
 
 export default function PanelSegmentation({ children }: withAppTypes) {
   const { commandsManager, servicesManager } = useSystem();
   const { customizationService, displaySetService, measurementService, uiNotificationService } = servicesManager.services;
+  const [promptsVisible, setPromptsVisible] = useState(toolboxState.getPromptsVisible());
 
   const { segmentationsWithRepresentations, disabled } =
     useActiveViewportSegmentationRepresentations({
@@ -37,6 +41,10 @@ export default function PanelSegmentation({ children }: withAppTypes) {
     },
     onSegmentAdd: segmentationId => {
       commandsManager.run('addSegment', { segmentationId });
+      // Always start a new segment in positive (include) mode
+      if (toolboxState.getPosNeg()) {
+        toolboxState.setPosNeg(false);
+      }
     },
     onSegmentClick: (segmentationId, segmentIndex) => {
       commandsManager.run('setActiveSegmentAndCenter', { segmentationId, segmentIndex });
@@ -130,6 +138,16 @@ export default function PanelSegmentation({ children }: withAppTypes) {
     onSegmentationDelete: segmentationId => {
       commandsManager.run('deleteSegmentation', { segmentationId });
     },
+    onTogglePromptsVisibility: () => {
+      const next = !toolboxState.getPromptsVisible();
+      toolboxState.setPromptsVisible(next);
+      setPromptsVisible(next);
+      const uids = measurementService
+        .getMeasurements()
+        .filter(m => AI_PROMPT_TOOLS.includes(m.toolName))
+        .map(m => m.uid);
+      measurementService.toggleVisibilityMeasurementMany(uids, next);
+    },
     setFillAlpha: ({ type }, value) => {
       commandsManager.run('setFillAlpha', { type, value });
     },
@@ -191,6 +209,7 @@ export default function PanelSegmentation({ children }: withAppTypes) {
     onSegmentationAdd,
     showAddSegment,
     renderInactiveSegmentations: handlers.getRenderInactiveSegmentations(),
+    promptsVisible,
     ...handlers,
   };
 

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -908,11 +908,13 @@ const commandsModule = ({
       //.filter(e => { return e.toolName === 'Probe2' && e.referenceSeriesUID === currentDisplaySets.SeriesInstanceUID && e.metadata.neg === false && e.metadata.SegmentNumber === segmentNumber; })
       //.map(e => { return e.label })
 
-      // Hide measurements and notify in a single synchronous pass
-      currentMeasurements
-        .filter(e => e.referenceSeriesUID === currentDisplaySets.SeriesInstanceUID)
-        .forEach(e => measurementService.toggleVisibilityMeasurement(e.uid, false));
-      document.dispatchEvent(new Event('measurement-state-changed'));
+      // Hide measurements after inference unless user has set prompts to always-show
+      if (!toolboxState.getPromptsVisible()) {
+        currentMeasurements
+          .filter(e => e.referenceSeriesUID === currentDisplaySets.SeriesInstanceUID)
+          .forEach(e => measurementService.toggleVisibilityMeasurement(e.uid, false));
+        document.dispatchEvent(new Event('measurement-state-changed'));
+      }
       if (pos_points.length == 0 && neg_points.length == 0 && pos_boxes.length == 0 && text_prompts.length == 0){
         uiNotificationService.show({
           title: 'Prompt warning',
@@ -1985,6 +1987,7 @@ const commandsModule = ({
       let segmentNumber = 1;
       let segments: { [segmentIndex: string]: cstTypes.Segment } = {};
       let segmentationId = `${csUtils.uuidv4()}`
+      let _needsReset = false; // set true when switching segments; folded into inference POST
       if (activeSegmentation !== undefined){
         segments = activeSegmentation.segments;
       if (Object.values(segments).length > 0) {
@@ -2008,8 +2011,8 @@ const commandsModule = ({
               e.metadata.segmentationId = activeSegmentation.segmentationId;
             }
             segmentNumber = activeSegment.segmentIndex;
-            if (toolboxState.getCurrentActiveSegment() !== segmentNumber){
-              await commandsManager.run('resetNninter');
+            _needsReset = toolboxState.getCurrentActiveSegment() !== segmentNumber;
+            if (_needsReset) {
               toolboxState.setCurrentActiveSegment(segmentNumber);
             }
           } else {
@@ -2079,11 +2082,13 @@ const commandsModule = ({
         ? (Array.isArray(textPrompts) ? textPrompts : [textPrompts])
         : probe2Labels;
 
-      // Hide measurements and notify in a single synchronous pass
-      currentMeasurements
-        .filter(e => e.referenceSeriesUID === currentDisplaySets.SeriesInstanceUID)
-        .forEach(e => measurementService.toggleVisibilityMeasurement(e.uid, false));
-      document.dispatchEvent(new Event('measurement-state-changed'));
+      // Hide measurements after inference unless user has set prompts to always-show
+      if (!toolboxState.getPromptsVisible()) {
+        currentMeasurements
+          .filter(e => e.referenceSeriesUID === currentDisplaySets.SeriesInstanceUID)
+          .forEach(e => measurementService.toggleVisibilityMeasurement(e.uid, false));
+        document.dispatchEvent(new Event('measurement-state-changed'));
+      }
 
       let url = `/monai/infer/segmentation?image=${currentDisplaySets.SeriesInstanceUID}&output=dicom_seg`;
       let params = {
@@ -2104,6 +2109,7 @@ const commandsModule = ({
         neg_scribbles: neg_scribbles,
         texts: text_prompts,
         nninter: true,
+        nninter_reset_first: _needsReset,
       };
 
       let data = MonaiLabelClient.constructFormData(params, null);
@@ -2336,10 +2342,12 @@ const commandsModule = ({
           if (segImageIds.length == 0){
             const _tCreate2 = Date.now();
             let derivedImages_new = await imageLoader.createAndCacheDerivedLabelmapImages(imageIds);
+            console.log(`[nninter] createAndCache: ${((Date.now()-_tCreate2)/1000).toFixed(3)}s (${imageIds.length} slices)`);
 
             if(flipped){
               derivedImages_new.reverse();
             }
+            const _tWrite2 = Date.now();
             for (let i = 0; i < derivedImages_new.length; i++) {
               if (_hasCropGeom && (i < _segZ0 || i >= _segZ1)) continue;
               const voxelManager = derivedImages_new[i]
@@ -2375,39 +2383,64 @@ const commandsModule = ({
             if(flipped){
               derivedImages_new.reverse();
             }
+            console.log(`[nninter] pixel write (first): ${((Date.now()-_tWrite2)/1000).toFixed(3)}s`);
             merged_derivedImages = derivedImages_new
           } else {
+            const _tCacheGet = Date.now();
             merged_derivedImages = segImageIds.map(imageId => cache.getImage(imageId));
+            console.log(`[nninter] cache.getImage (refine): ${((Date.now()-_tCacheGet)/1000).toFixed(3)}s`);
             if(flipped){
               merged_derivedImages.reverse();
             }
-            // Limit scan to the union of [prevZ0,prevZ1) (where old data lives) and
-            // [_segZ0,_segZ1) (where new data will be written).  Avoids scanning all
-            // ~500 slices × 262K pixels every inference — the previous bottleneck.
-            const _prevZ0: number = (_hasCropGeom && (existingSegments[segmentNumber] as any)?.cachedStats?.segZ0 != null)
-              ? (existingSegments[segmentNumber] as any).cachedStats.segZ0 as number
-              : 0;
-            const _prevZ1: number = (_hasCropGeom && (existingSegments[segmentNumber] as any)?.cachedStats?.segZ1 != null)
-              ? (existingSegments[segmentNumber] as any).cachedStats.segZ1 as number
-              : merged_derivedImages.length;
-            const scanZ0 = _hasCropGeom ? Math.min(_prevZ0, _segZ0) : 0;
-            const scanZ1 = _hasCropGeom ? Math.max(_prevZ1, _segZ1) : merged_derivedImages.length;
 
-            for (let i = scanZ0; i < scanZ1; i++) {
-              const voxelManager = merged_derivedImages[i]
-                .voxelManager as csTypes.IVoxelManager<number>;
-              let scalarData = voxelManager.getScalarData();
-              const sliceLen = scalarData.length;
+            // ── Pass 1: Clear old pixels ─────────────────────────────────────
+            // Use dirtySlices (exact indices that have pixels) when available.
+            // Falls back to the range-based scan on first refinement or old data.
+            const _prevDirtySlices = (existingSegments[segmentNumber] as any)
+              ?.cachedStats?.dirtySlices as number[] | undefined;
+            const _tClear = Date.now();
 
-              // Clear old segment pixels in-place (refine always overwrites)
-              if (scalarData.some(v => v === segmentNumber)){
-                for (let j = 0; j < sliceLen; j++) {
-                  if (scalarData[j] === segmentNumber) scalarData[j] = 0;
+            const _prevCachedStats = (existingSegments[segmentNumber] as any)?.cachedStats;
+            const _hasPrevData = _prevDirtySlices?.length ||
+              _prevCachedStats?.segZ0 != null || _prevCachedStats?.segZ1 != null;
+
+            if (_prevDirtySlices?.length) {
+              // Fast path: only touch slices that actually contain pixels (~20-50 vs 500+)
+              for (const origIdx of _prevDirtySlices) {
+                const arrIdx = flipped ? (merged_derivedImages.length - 1 - origIdx) : origIdx;
+                const vm = merged_derivedImages[arrIdx]?.voxelManager as csTypes.IVoxelManager<number>;
+                if (!vm) continue;
+                const sd = vm.getScalarData();
+                for (let j = 0; j < sd.length; j++) {
+                  if (sd[j] === segmentNumber) sd[j] = 0;
                 }
               }
+              console.log(`[nninter] clear (${_prevDirtySlices.length} dirty slices): ${((Date.now()-_tClear)/1000).toFixed(3)}s`);
+            } else if (_hasPrevData) {
+              // Fallback: bounding-box range scan (dirtySlices not yet stored, e.g. first run after migration)
+              const _prevZ0: number = (_hasCropGeom && _prevCachedStats?.segZ0 != null)
+                ? _prevCachedStats.segZ0 as number : 0;
+              const _prevZ1: number = (_hasCropGeom && _prevCachedStats?.segZ1 != null)
+                ? _prevCachedStats.segZ1 as number : merged_derivedImages.length;
+              const scanZ0 = _hasCropGeom ? Math.min(_prevZ0, _segZ0) : 0;
+              const scanZ1 = _hasCropGeom ? Math.max(_prevZ1, _segZ1) : merged_derivedImages.length;
+              for (let i = scanZ0; i < scanZ1; i++) {
+                const sd = (merged_derivedImages[i].voxelManager as csTypes.IVoxelManager<number>).getScalarData();
+                for (let j = 0; j < sd.length; j++) {
+                  if (sd[j] === segmentNumber) sd[j] = 0;
+                }
+              }
+              console.log(`[nninter] clear fallback (${scanZ1-scanZ0} slices): ${((Date.now()-_tClear)/1000).toFixed(3)}s`);
+            } else {
+              // Brand-new segment — nothing to clear, skip entirely
+              console.log(`[nninter] clear skipped (new segment)`);
+            }
 
-              // Write new data from crop (cache-friendly, no 182 MB buffer)
-              if (_hasCropGeom && i >= _segZ0 && i < _segZ1) {
+            // ── Pass 2: Write new pixels from crop only ───────────────────────
+            const _tWrite3 = Date.now();
+            if (_hasCropGeom) {
+              for (let i = _segZ0; i < _segZ1; i++) {
+                const scalarData = (merged_derivedImages[i].voxelManager as csTypes.IVoxelManager<number>).getScalarData();
                 const c = i - _segZ0;
                 const cropSliceBase = c * _cropY * _cropX;
                 let wrote = false;
@@ -2422,21 +2455,24 @@ const commandsModule = ({
                   }
                 }
                 if (wrote) z_range.push(flipped ? merged_derivedImages.length - i - 1 : i);
-              } else if (!_hasCropGeom && new_arrayBuffer) {
-                // Legacy: full-slice scan
-                const sliceData = new_arrayBuffer.subarray(i * sliceLen, (i + 1) * sliceLen);
+              }
+            } else if (new_arrayBuffer) {
+              for (let i = 0; i < merged_derivedImages.length; i++) {
+                const sd = (merged_derivedImages[i].voxelManager as csTypes.IVoxelManager<number>).getScalarData();
+                const sliceData = new_arrayBuffer.subarray(i * sd.length, (i + 1) * sd.length);
                 if (sliceData.some(v => v === 1)){
-                  for (let j = 0; j < sliceLen; j++) { if (sliceData[j] === 1) scalarData[j] = segmentNumber; }
+                  for (let j = 0; j < sd.length; j++) { if (sliceData[j] === 1) sd[j] = segmentNumber; }
                   z_range.push(flipped ? merged_derivedImages.length - i - 1 : i);
                 }
               }
             }
+            console.log(`[nninter] write (${z_range.length} slices): ${((Date.now()-_tWrite3)/1000).toFixed(3)}s`);
+
             if(flipped){
               merged_derivedImages.reverse();
             }
-
           }
-          
+
         }
           
                     
@@ -2453,9 +2489,10 @@ const commandsModule = ({
               algorithmName: "nninter_"+nninter_elapsed,
               description: prompt_info,
               center:  z_range.length > 0 ? z_range.reduce((sum, z) => sum + z, 0) / z_range.length : 0,
-              // z-range of this result — used next inference to limit the refine scan
+              // z-range kept for fallback; dirtySlices is the fast-path clear target
               segZ0: _hasCropGeom ? _segZ0 : 0,
               segZ1: _hasCropGeom ? _segZ1 : (merged_derivedImages?.length ?? 0),
+              dirtySlices: z_range,
             }
           };
           console.log(`Before add or update segs: ${(Date.now() - start)/1000} Seconds`);

--- a/Viewers/extensions/default/src/stores/toolboxState.ts
+++ b/Viewers/extensions/default/src/stores/toolboxState.ts
@@ -6,6 +6,7 @@ let refineNew = false;
 let textPromptReplaceNew = false; // Replace/New toggle for Text Prompt Segmentation
 let selectedModel: 'nnInteractive' | 'sam2' | 'medsam2' | 'sam3' = 'nnInteractive'; // Model selection: nnInteractive, SAM2, MedSAM2, or SAM3
 let locked = false;
+let promptsVisible = false; // default: hide prompts after each inference; pencil toggle to always-show
 let currentActiveSegment = 1;
 let medgemmaResult: string | null = null;
 let medgemmaInstruction: string = '';
@@ -70,6 +71,10 @@ export const toolboxState = {
   getPosNeg: () => posNeg,
   setPosNeg: (enabled: boolean) => {
     posNeg = enabled;
+  },
+  getPromptsVisible: () => promptsVisible,
+  setPromptsVisible: (visible: boolean) => {
+    promptsVisible = visible;
   },
   getRefineNew: () => refineNew,
   setRefineNew: (enabled: boolean) => {

--- a/Viewers/extensions/default/src/utils/Toolbox.tsx
+++ b/Viewers/extensions/default/src/utils/Toolbox.tsx
@@ -31,7 +31,7 @@ export function Toolbox({ buttonSectionId, title, defaultOpen = true }: { button
   const { servicesManager, commandsManager } = useSystem();
   const { t } = useTranslation();
 
-  const { toolbarService, customizationService, segmentationService, viewportGridService } = servicesManager.services;
+  const { toolbarService, customizationService, segmentationService, viewportGridService, measurementService } = servicesManager.services;
   const onInteractionRef = React.useRef<((args: { itemId: string }) => void) | null>(null);
   const isAIToolBox = buttonSectionId === 'aiToolBox';
   const isTextPromptToolbox = buttonSectionId === 'textPromptSegmentationToolbox';
@@ -184,6 +184,7 @@ export function Toolbox({ buttonSectionId, title, defaultOpen = true }: { button
       switch (event.key.toLowerCase()) {
         case 'q': {
           event.preventDefault();
+          event.stopPropagation();
           const newLiveMode = !toolboxState.getLiveMode();
           setLiveMode(newLiveMode);
           toolboxState.setLiveMode(newLiveMode);
@@ -191,6 +192,7 @@ export function Toolbox({ buttonSectionId, title, defaultOpen = true }: { button
         }
         case 't': {
           event.preventDefault();
+          event.stopPropagation();
           const newPosNeg = !toolboxState.getPosNeg();
           setPosNeg(newPosNeg);
           toolboxState.setPosNeg(newPosNeg);
@@ -198,31 +200,42 @@ export function Toolbox({ buttonSectionId, title, defaultOpen = true }: { button
         }
         case 'p':
           event.preventDefault();
+          event.stopPropagation();
           onInteractionRef.current?.({ itemId: 'Probe2' });
           break;
         case 'b':
           event.preventDefault();
+          event.stopPropagation();
           onInteractionRef.current?.({ itemId: 'RectangleROI2' });
           break;
         case 's':
           event.preventDefault();
+          event.stopPropagation();
           onInteractionRef.current?.({ itemId: 'PlanarFreehandROI2' });
           break;
         case 'l':
           event.preventDefault();
+          event.stopPropagation();
           onInteractionRef.current?.({ itemId: 'PlanarFreehandROI3' });
           break;
         case 'm': {
           event.preventDefault();
+          event.stopPropagation();
           const { activeViewportId: avId } = viewportGridService.getState();
-          const activeSeg = segmentationService.getActiveSegmentation(avId);
+          const activeSeg = segmentationService.getActiveSegmentation(avId)
+            ?? segmentationService.getSegmentations()?.[0];
           if (activeSeg?.segmentationId) {
             commandsManager.run('addSegment', { segmentationId: activeSeg.segmentationId });
+            // Always start fresh in positive mode
+            if (toolboxState.getPosNeg()) {
+              toolboxState.setPosNeg(false);
+            }
           }
           break;
         }
         case 'r': {
           event.preventDefault();
+          event.stopPropagation();
           const { activeViewportId: avId } = viewportGridService.getState();
           const activeSeg = segmentationService.getActiveSegmentation(avId);
           const activeSeg2 = segmentationService.getActiveSegment(avId);
@@ -234,11 +247,32 @@ export function Toolbox({ buttonSectionId, title, defaultOpen = true }: { button
           }
           break;
         }
+        case 'delete': {
+          event.preventDefault();
+          event.stopPropagation();
+          const { activeViewportId: avId } = viewportGridService.getState();
+          const activeSeg = segmentationService.getActiveSegmentation(avId);
+          const activeSeg2 = segmentationService.getActiveSegment(avId);
+          if (activeSeg?.segmentationId && activeSeg2?.segmentIndex != null) {
+            const { segmentationId } = activeSeg;
+            const { segmentIndex } = activeSeg2;
+            const measurementUIDs = measurementService
+              .getMeasurements()
+              .filter(m => m?.metadata?.segmentationId === segmentationId && m?.metadata?.SegmentNumber === segmentIndex)
+              .map(m => m?.uid);
+            if (measurementUIDs.length > 0) measurementService.removeMany(measurementUIDs);
+            commandsManager.run('resetNninter', { clearMeasurements: false });
+            commandsManager.run('deleteSegment', { segmentationId, segmentIndex });
+          }
+          break;
+        }
       }
     };
 
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
+    // Use capture phase so this fires before Mousetrap (bubble phase), preventing
+    // global hotkey bindings from also firing for keys we own in the AI toolbox.
+    document.addEventListener('keydown', handleKeyDown, true);
+    return () => document.removeEventListener('keydown', handleKeyDown, true);
   }, [hotkeysDisabled, isAIToolBox]);
 
 

--- a/Viewers/platform/app/public/config/docker-nginx-orthanc.js
+++ b/Viewers/platform/app/public/config/docker-nginx-orthanc.js
@@ -9,6 +9,9 @@ window.config = {
   showCPUFallbackMessage: true,
   showLoadingIndicator: true,
   disableConfirmationPrompts: true,
+  // Allow drawing in any viewport on the first pointer event without needing
+  // a prior click to "activate" it. Essential for MPR multi-viewport workflows.
+  activateViewportBeforeInteraction: false,
   showPatientInfo: 'disabled',
   measurementTrackingMode: 'none',
   experimentalStudyBrowserSort: false,

--- a/Viewers/platform/app/src/components/ViewportGrid.tsx
+++ b/Viewers/platform/app/src/components/ViewportGrid.tsx
@@ -351,7 +351,15 @@ function ViewerViewportGrid(props: withAppTypes) {
       });
 
       const onInteractionHandler = event => {
-        if (isActive) {
+        // Read current active viewport directly from the service instead of the
+        // stale closure value. This matters for onMouseEnter: setActiveViewportId
+        // updates the service synchronously, but the React re-render (which would
+        // update `isActive` in the closure) is async. Without this, the first
+        // pointerDown after a hover-activate still sees isActive=false and swallows
+        // the event.
+        const alreadyActive =
+          viewportGridService.getState().activeViewportId === viewportId;
+        if (alreadyActive) {
           return;
         }
 

--- a/Viewers/platform/core/src/defaults/hotkeyBindings.ts
+++ b/Viewers/platform/core/src/defaults/hotkeyBindings.ts
@@ -33,7 +33,7 @@ const bindings = [
   {
     commandName: 'rotateViewportCCW',
     label: 'Rotate Left',
-    keys: ['l'],
+    keys: ['ctrl+l'],
     isEditable: true,
   },
   {
@@ -196,12 +196,6 @@ const bindings = [
     isEditable: true,
   },
   {
-    commandName: 'runAiSegmentation',
-    label: 'Run inference',
-    keys: ['r'],
-    isEditable: true,
-  },
-  {
     commandName: 'resetNninter',
     label: 'Reset NNInteractive',
     keys: ['g'],
@@ -236,41 +230,7 @@ const bindings = [
     commandName: 'setToolActive',
     commandOptions: { toolName: 'CircularBrush' },
     label: 'Brush',
-    keys: ['b'],
-    isEditable: true,
-  },
-  {
-    commandName: 'setAiToolActive',
-    commandOptions: { toolName: 'Probe2' },
-    label: 'Point',
-    keys: ['a'],
-    isEditable: true,
-  },
-  {
-    commandName: 'setAiToolActive',
-    commandOptions: { toolName: 'RectangleROI2' },
-    label: 'Bounding Box',
-    keys: ['f'],
-    isEditable: true,
-  },
-  {
-    commandName: 'setAiToolActive',
-    commandOptions: { toolName: 'PlanarFreehandROI3' },
-    label: 'Lasso',
-    keys: ['d'],
-    isEditable: true,
-  },
-  {
-    commandName: 'setAiToolActive',
-    commandOptions: { toolName: 'PlanarFreehandROI2' },
-    label: 'Scribble',
-    keys: ['s'],
-    isEditable: true,
-  },
-  {
-    commandName: 'addNewSegment',
-    label: 'Add New Segment',
-    keys: ['y'],
+    keys: ['ctrl+b'],
     isEditable: true,
   },
 ];

--- a/Viewers/platform/ui-next/src/components/DataRow/DataRow.tsx
+++ b/Viewers/platform/ui-next/src/components/DataRow/DataRow.tsx
@@ -65,7 +65,9 @@ interface DataRowProps {
   details?: { primary: string[]; secondary: string[] };
   //
   isSelected?: boolean;
+  isMultiSelected?: boolean;
   onSelect?: (e) => void;
+  onToggleMultiSelect?: (e: React.MouseEvent) => void;
   //
   isVisible: boolean;
   isMeasurementVisible?: boolean;
@@ -91,6 +93,7 @@ export const DataRow: React.FC<DataRowProps> = ({
   colorHex,
   details,
   onSelect,
+  onToggleMultiSelect,
   isLocked,
   onToggleVisibility,
   onToggleMeasurement = () => {},
@@ -99,6 +102,7 @@ export const DataRow: React.FC<DataRowProps> = ({
   onDelete,
   onColor,
   isSelected = false,
+  isMultiSelected = false,
   isVisible = true,
   isMeasurementVisible = true,
   disableEditing = false,
@@ -218,6 +222,18 @@ export const DataRow: React.FC<DataRowProps> = ({
       >
         {/* Hover Overlay */}
         <div className="bg-primary/20 pointer-events-none absolute inset-0 opacity-0 transition-opacity group-hover:opacity-100"></div>
+
+        {/* Checkbox (only when multi-select is enabled for this row) */}
+        {onToggleMultiSelect && (
+          <div
+            className="flex h-7 w-5 flex-shrink-0 cursor-pointer items-center justify-center"
+            onClick={e => { e.stopPropagation(); onToggleMultiSelect(e); }}
+          >
+            {isMultiSelected
+              ? <Icons.CheckBoxChecked className="h-3.5 w-3.5" />
+              : <Icons.CheckBoxUnchecked className="h-3.5 w-3.5 opacity-30" />}
+          </div>
+        )}
 
         {/* Number Box */}
         <div

--- a/Viewers/platform/ui-next/src/components/SegmentationTable/AddSegmentRow.tsx
+++ b/Viewers/platform/ui-next/src/components/SegmentationTable/AddSegmentRow.tsx
@@ -11,6 +11,8 @@ export const AddSegmentRow: React.FC<{ children?: React.ReactNode }> = ({ childr
     onSegmentAdd,
     onSegmentReset,
     onToggleSegmentationRepresentationVisibility,
+    onTogglePromptsVisibility,
+    promptsVisible,
     data,
     showAddSegment,
   } = useSegmentationTableContext('AddSegmentRow');
@@ -78,6 +80,17 @@ export const AddSegmentRow: React.FC<{ children?: React.ReactNode }> = ({ childr
           >
             <Icons.Refresh className="h-4 w-4" />
             Reset Segment <span className="ml-1 opacity-50 text-xs">[R]</span>
+          </Button>
+        ) : null}
+        {onTogglePromptsVisibility ? (
+          <Button
+            size="sm"
+            variant="ghost"
+            className="pr pl-0.5"
+            onClick={() => onTogglePromptsVisibility()}
+          >
+            <Icons.Pencil className="h-4 w-4" />
+            {promptsVisible ? 'Hide Prompts' : 'Show Prompts'}
           </Button>
         ) : null}
       </div>

--- a/Viewers/platform/ui-next/src/components/SegmentationTable/SegmentationSegments.tsx
+++ b/Viewers/platform/ui-next/src/components/SegmentationTable/SegmentationSegments.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { ScrollArea, DataRow } from '../../components';
+import { Button } from '../Button/Button';
+import { Icons } from '../Icons/Icons';
 import { HoverCard, HoverCardTrigger, HoverCardContent } from '../../components/HoverCard';
 import { useSystem } from '@ohif/core';
 import { useSegmentationTableContext, useSegmentationExpanded } from './contexts';
@@ -17,6 +19,7 @@ import { useDynamicMaxHeight } from '../../hooks/useDynamicMaxHeight';
 export const SegmentationSegments = ({ children = null }: { children?: React.ReactNode }) => {
   const { servicesManager } = useSystem();
   const [forceUpdate, setForceUpdate] = useState(0);
+  const [selectedIndices, setSelectedIndices] = useState<Set<number>>(new Set());
   const {
     activeSegmentationId,
     disableEditing,
@@ -79,7 +82,14 @@ export const SegmentationSegments = ({ children = null }: { children?: React.Rea
     return null;
   }
 
+  const handleDeleteSelected = () => {
+    const indices = Array.from(selectedIndices).sort((a, b) => b - a); // descending to avoid index shift
+    setSelectedIndices(new Set());
+    indices.forEach(idx => onSegmentDelete(segmentation.segmentationId, idx));
+  };
+
   return (
+    <>
     <ScrollArea
       className={`bg-bkg-low space-y-px`}
       showArrows={true}
@@ -116,10 +126,10 @@ export const SegmentationSegments = ({ children = null }: { children?: React.Rea
               key={segmentIndex}
               number={segmentIndex}
               title={label}
-              // details={displayText}
               description={displayText}
               colorHex={cssColor}
               isSelected={active}
+              isMultiSelected={selectedIndices.has(segmentIndex)}
               isVisible={visible}
               isMeasurementVisible={isMeasurementVisible}
               isLocked={locked}
@@ -135,7 +145,17 @@ export const SegmentationSegments = ({ children = null }: { children?: React.Rea
               }
               onToggleMeasurement={() => onToggleSegmentMeasurement(segmentation.segmentationId, segmentIndex)}
               onToggleLocked={() => onToggleSegmentLock(segmentation.segmentationId, segmentIndex)}
-              onSelect={() => onSegmentClick(segmentation.segmentationId, segmentIndex)}
+              onSelect={() => {
+                setSelectedIndices(new Set());
+                onSegmentClick(segmentation.segmentationId, segmentIndex);
+              }}
+              onToggleMultiSelect={() => {
+                setSelectedIndices(prev => {
+                  const next = new Set(prev);
+                  next.has(segmentIndex) ? next.delete(segmentIndex) : next.add(segmentIndex);
+                  return next;
+                });
+              }}
               onRename={() => onSegmentEdit(segmentation.segmentationId, segmentIndex)}
               onDelete={() => onSegmentDelete(segmentation.segmentationId, segmentIndex)}
             />
@@ -179,6 +199,31 @@ export const SegmentationSegments = ({ children = null }: { children?: React.Rea
         })}
       </div>
     </ScrollArea>
+    {selectedIndices.size > 0 && (
+      <div className="flex items-center justify-between px-1 py-0.5">
+        <span className="text-muted-foreground text-xs">{selectedIndices.size} selected</span>
+        <div className="flex gap-1">
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-6 px-1.5 text-xs"
+            onClick={() => setSelectedIndices(new Set())}
+          >
+            Clear
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="text-destructive hover:text-destructive h-6 px-1.5 text-xs"
+            onClick={handleDeleteSelected}
+          >
+            <Icons.Delete className="mr-1 h-3 w-3" />
+            Delete
+          </Button>
+        </div>
+      </div>
+    )}
+    </>
   );
 };
 

--- a/Viewers/platform/ui-next/src/components/SegmentationTable/contexts/SegmentationTableContext.tsx
+++ b/Viewers/platform/ui-next/src/components/SegmentationTable/contexts/SegmentationTableContext.tsx
@@ -82,6 +82,8 @@ export interface SegmentationTableContextType {
   onSegmentColorClick?: (segmentationId: string, segmentIndex: number) => void;
   onSegmentDelete?: (segmentationId: string, segmentIndex: number) => void;
   onSegmentReset?: (segmentationId: string, segmentIndex: number) => void;
+  onTogglePromptsVisibility?: () => void;
+  promptsVisible?: boolean;
   onToggleSegmentVisibility?: (
     segmentationId: string,
     segmentIndex: number,

--- a/Viewers/platform/ui/src/components/ViewportPane/ViewportPane.tsx
+++ b/Viewers/platform/ui/src/components/ViewportPane/ViewportPane.tsx
@@ -60,6 +60,7 @@ function ViewportPane({
       // https://stackoverflow.com/questions/8378243/catch-scrolling-event-on-overflowhidden-element
       // Use onPointerDown so that for the config property activateViewportBeforeInteraction===false,
       // a touch drag will activate the viewport as well as apply the tool selected.
+      onMouseEnter={onInteractionHandler}
       onPointerDown={onInteractionHandler}
       onDoubleClick={onDoubleClick}
       onClick={onInteractionHandler}

--- a/monai-label/Dockerfile
+++ b/monai-label/Dockerfile
@@ -64,6 +64,6 @@ COPY ./monai-label/. ./
 COPY ./monai-label/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-EXPOSE 8003
+EXPOSE 8002
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["python", "-m", "monailabel.main", "start_server", "--app", "/code/apps/radiology", "--studies", "http://orthanc:8043/dicom-web", "--conf", "models", "segmentation", "--conf", "use_pretrained_model", "false", "-p", "8003"]
+CMD ["python", "-m", "monailabel.main", "start_server", "--app", "/code/apps/radiology", "--studies", "http://orthanc:8042/dicom-web", "--conf", "models", "segmentation", "--conf", "use_pretrained_model", "false", "-p", "8002"]

--- a/monai-label/Dockerfile
+++ b/monai-label/Dockerfile
@@ -64,6 +64,6 @@ COPY ./monai-label/. ./
 COPY ./monai-label/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-EXPOSE 8002
+EXPOSE 8003
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["python", "-m", "monailabel.main", "start_server", "--app", "/code/apps/radiology", "--studies", "http://orthanc:8042/dicom-web", "--conf", "models", "segmentation", "--conf", "use_pretrained_model", "false", "-p", "8002"]
+CMD ["python", "-m", "monailabel.main", "start_server", "--app", "/code/apps/radiology", "--studies", "http://orthanc:8043/dicom-web", "--conf", "models", "segmentation", "--conf", "use_pretrained_model", "false", "-p", "8003"]

--- a/monai-label/monailabel/tasks/infer/basic_infer.py
+++ b/monai-label/monailabel/tasks/infer/basic_infer.py
@@ -125,6 +125,20 @@ session = nnInteractiveInferenceSession(
 model_path = os.path.join(DOWNLOAD_DIR, MODEL_NAME)
 session.initialize_from_trained_model_folder(model_path)
 
+# Warmup: trigger torch.compile JIT at startup so the first real inference is fast.
+# session.warmup() uses the correct patch_size from the model plan — no set_image needed.
+try:
+    import threading
+    def _warmup_session():
+        import logging
+        _wlog = logging.getLogger(__name__)
+        _wlog.info("nnInteractive warmup: starting...")
+        ran = session.warmup()
+        _wlog.info(f"nnInteractive warmup: {'done' if ran else 'skipped (torch.compile not enabled)'}.")
+    threading.Thread(target=_warmup_session, daemon=True).start()
+except Exception as _warmup_err:
+    print(f"nnInteractive warmup failed (non-fatal): {_warmup_err}")
+
 # Config for the text prompt detector, it is disabled for now
 #config_path = '/code/dino_configs/dino.py'
 # Setup a checkpoint file to load
@@ -1045,6 +1059,15 @@ class BasicInferTask(InferTask):
             # features, so img_np and dicom_dir remain valid for subsequent interactions.
             logger.info("Reset nninter")
             return f'/code/predictions/reset.nii.gz', {}
+
+        # Folded reset: caller needs a segment switch + inference in one round-trip.
+        # Resetting here (before image loading) keeps the same semantics as a
+        # separate reset call, but saves ~1.4 s of network overhead on slow links.
+        if request.get('nninter_reset_first'):
+            for key, lst in self._session_used_interactions.items():
+                lst.clear()
+            session.reset_interactions()
+            logger.info("Folded reset before inference")
 
         req = copy.deepcopy(self._config)
         req.update(request)

--- a/monai-label/monailabel/utils/others/helper.py
+++ b/monai-label/monailabel/utils/others/helper.py
@@ -34,6 +34,9 @@ def clean_and_densify_polyline(polyline, max_segment_length=1):
                 if last[0] != px or last[1] != py:
                     cleaned.append([px, py, z])
 
+    if not cleaned:
+        return []
+
     first_x, first_y, _ = cleaned[0]
     last_x, last_y, _ = cleaned[-1]
     if first_x != last_x or first_y != last_y:

--- a/start.sh
+++ b/start.sh
@@ -23,10 +23,15 @@ fi
 
 _service_hash() {
     local paths="$@"
-    local commit diff_hash
-    commit=$(git -C "$REPO_ROOT" log -1 --format="%H" -- $paths 2>/dev/null || echo "nogit")
-    diff_hash=$(git -C "$REPO_ROOT" diff HEAD -- $paths 2>/dev/null | md5sum | cut -d' ' -f1)
-    echo "${commit}_${diff_hash}"
+    # ls-tree lists every committed file with its blob SHA1 (content-addressed).
+    # Unlike `git log -1 -- $paths`, this changes whenever any file's content changes,
+    # and it differs across branches even after a fast-forward merge because the
+    # tree objects are distinct once any file diverges.
+    # We combine it with the diff of any uncommitted changes.
+    {
+        git -C "$REPO_ROOT" ls-tree -r HEAD -- $paths 2>/dev/null
+        git -C "$REPO_ROOT" diff HEAD -- $paths 2>/dev/null
+    } | md5sum | cut -d' ' -f1
 }
 
 OHIF_HASH=$(_service_hash Viewers/)


### PR DESCRIPTION
## Summary

- **Viewer UX**: Draw in any MPR viewport on first pointer event without a prior click (`activateViewportBeforeInteraction=false`); viewport activates on hover; hotkey conflicts resolved (capture-phase handler wins over Mousetrap; L/B/R/S remapped).
- **Segmentation panel**: Show/Hide Prompts toggle (pencil button) next to Reset Segment; Add Segment auto-resets to positive mode; multi-select segments with checkboxes and bulk delete; Del key deletes active segment.
- **Inference performance**: Fold segment-switch reset into the inference POST (`nninter_reset_first`) to save ~1.4s round-trip; dirty-slice tracking clears only slices with pixels instead of full bounding-box range; skip clear for brand-new segments; single-pass clear loop.
- **MONAI server**: nnInteractive warmup at startup in background thread; scribble crash fix for duplicate polyline points; smart `start.sh` rebuild detection via `git ls-tree` content hash.

## Test plan

- [x] Open MPR layout and draw prompts in a non-active viewport without clicking it first
- [x] Hover over viewports and confirm the active viewport updates
- [x] Toggle Show/Hide Prompts and run inference — prompts stay visible when enabled
- [x] Multi-select segments via checkboxes and bulk-delete; confirm Del removes active segment
- [x] Switch segments during nnInteractive inference and confirm folded reset works (no separate reset round-trip)
- [x] Verify scribble prompts with duplicate points no longer crash the server
- [x] Run `./start.sh` after switching branches and confirm services rebuild when content changes


Made with [Cursor](https://cursor.com)