### PR TITLE
feat: nnInteractive segmentation Undo (Ctrl+Z)

### DIFF
--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -1274,6 +1274,185 @@ const commandsModule = ({
       }
 
     },
+    async undoNninter() {
+      if (toolboxState.getLocked()) {
+        return;
+      }
+      if (toolboxState.getSelectedModel() !== 'nnInteractive') {
+        return;
+      }
+
+      const { activeViewportId, viewports } = viewportGridService.getState();
+      const activeViewportSpecificData = viewports.get(activeViewportId);
+      const { displaySetInstanceUIDs } = activeViewportSpecificData;
+      const displaySets = displaySetService.activeDisplaySets;
+      const displaySetInstanceUID = displaySetInstanceUIDs[0];
+      const currentDisplaySets = displaySets.filter(
+        e => e.displaySetInstanceUID == displaySetInstanceUID
+      )[0];
+
+      // Locate the active nnInteractive segmentation for this series.
+      const { segmentationService, cornerstoneViewportService } = servicesManager.services;
+      const activeSegmentation = segmentationService.getActiveSegmentation(activeViewportId);
+      const activeSegmentObj = segmentationService.getActiveSegment(activeViewportId);
+      if (!activeSegmentation || !activeSegmentObj) {
+        return;
+      }
+      const segmentationId = activeSegmentation.segmentationId;
+      const segmentNumber = activeSegmentObj.segmentIndex;
+      const segImageIds: string[] =
+        (csToolsSegmentation.state.getSegmentation(segmentationId)
+          ?.representationData?.Labelmap as any)?.imageIds ?? [];
+      if (segImageIds.length === 0) {
+        return;
+      }
+
+      const url = `/monai/infer/segmentation?image=${currentDisplaySets.SeriesInstanceUID}&output=dicom_seg`;
+      const params = {
+        largest_cc: false,
+        result_extension: '.nii.gz',
+        result_dtype: 'uint16',
+        result_compress: false,
+        studyInstanceUID: currentDisplaySets.StudyInstanceUID,
+        restore_label_idx: false,
+        nninter: 'undo',
+      };
+      const data = MonaiLabelClient.constructFormData(params, null);
+
+      const undoPromise = axios.post(url, data, {
+        responseType: 'arraybuffer',
+        headers: { accept: 'application/octet-stream' },
+      });
+
+      uiNotificationService.show({
+        title: 'MONAI Label',
+        message: 'Undoing last interaction...',
+        type: 'info',
+        promise: undoPromise,
+        promiseMessages: {
+          loading: 'Undoing last interaction...',
+          success: () => 'Undo - Successful',
+          error: error => `Undo - Failed: ${error.message || 'Unknown error'}`,
+        },
+      });
+
+      try {
+        const response = await undoPromise;
+        if (response.status !== 200) {
+          return;
+        }
+        const ct = response.headers['content-type'] as string;
+        const { meta, seg } = await parseMultipart(response.data, ct);
+
+        const undone = String((meta as any).undone).toLowerCase() === 'true';
+        if (!undone) {
+          uiNotificationService.show({
+            title: 'MONAI Label',
+            message: 'Nothing to undo',
+            type: 'info',
+          });
+          return;
+        }
+
+        const flipped = String((meta as any).flipped).toLowerCase() === 'true';
+        const predOffset: number[] = JSON.parse((meta as any).pred_offset || '[0,0,0]');
+        const predFull: number[] = JSON.parse((meta as any).pred_full_shape || '[]');
+        const predCrop: number[] = JSON.parse((meta as any).pred_crop_shape || '[]');
+        const cropBytes = new Uint8Array(seg);
+
+        let _hasCropGeom = false;
+        let _segZ0 = 0, _segZ1 = 0, _cropY = 0, _cropX = 0, _y0 = 0, _x0 = 0, _fullX = 0;
+        if (predFull.length === 3 && predCrop.length === 3 && predCrop.every(v => v > 0)) {
+          const [, , fullX] = predFull;
+          const [cropZ, cropY, cropX] = predCrop;
+          const [z0, y0, x0] = predOffset;
+          _segZ0 = z0; _segZ1 = z0 + cropZ;
+          _cropY = cropY; _cropX = cropX;
+          _y0 = y0; _x0 = x0; _fullX = fullX;
+          _hasCropGeom = true;
+        }
+
+        let merged = segImageIds.map(imageId => cache.getImage(imageId));
+        if (flipped) merged.reverse();
+
+        // Pass 1: clear all voxels of the active segment (use dirtySlices when available).
+        const prevStats = (activeSegmentation.segments?.[segmentNumber] as any)?.cachedStats;
+        const prevDirty: number[] | undefined = prevStats?.dirtySlices;
+        const clearSlice = (arrIdx: number) => {
+          const vm = merged[arrIdx]?.voxelManager;
+          if (!vm) return;
+          const sd = vm.getScalarData();
+          for (let j = 0; j < sd.length; j++) {
+            if (sd[j] === segmentNumber) sd[j] = 0;
+          }
+        };
+        if (prevDirty?.length) {
+          for (const origIdx of prevDirty) {
+            clearSlice(flipped ? merged.length - 1 - origIdx : origIdx);
+          }
+        } else {
+          for (let i = 0; i < merged.length; i++) clearSlice(i);
+        }
+
+        // Pass 2: write the restored crop (skipped entirely when the object is now empty).
+        const z_range: number[] = [];
+        if (_hasCropGeom) {
+          for (let i = _segZ0; i < _segZ1; i++) {
+            const sd = merged[i].voxelManager.getScalarData();
+            const c = i - _segZ0;
+            const cropSliceBase = c * _cropY * _cropX;
+            let wrote = false;
+            for (let cy = 0; cy < _cropY; cy++) {
+              const srcRow = cropSliceBase + cy * _cropX;
+              const dstRow = (_y0 + cy) * _fullX + _x0;
+              for (let cx = 0; cx < _cropX; cx++) {
+                if (cropBytes[srcRow + cx] === 1) {
+                  sd[dstRow + cx] = segmentNumber;
+                  wrote = true;
+                }
+              }
+            }
+            if (wrote) z_range.push(flipped ? merged.length - i - 1 : i);
+          }
+        }
+        if (flipped) merged.reverse();
+
+        // Keep cachedStats.dirtySlices in sync so the next interaction clears correctly.
+        if ((activeSegmentation.segments?.[segmentNumber] as any)?.cachedStats) {
+          (activeSegmentation.segments[segmentNumber] as any).cachedStats.dirtySlices = z_range;
+          (activeSegmentation.segments[segmentNumber] as any).cachedStats.segZ0 = _hasCropGeom ? _segZ0 : 0;
+          (activeSegmentation.segments[segmentNumber] as any).cachedStats.segZ1 = _hasCropGeom ? _segZ1 : merged.length;
+        }
+
+        // Remove the most-recently-added prompt measurement for this series.
+        const AI_PROMPT_TOOLS = ['Probe2', 'RectangleROI2', 'PlanarFreehandROI2', 'PlanarFreehandROI3'];
+        const promptsForSeries = measurementService
+          .getMeasurements()
+          .filter(
+            m =>
+              AI_PROMPT_TOOLS.includes(m.toolName) &&
+              m.referenceSeriesUID === currentDisplaySets.SeriesInstanceUID
+          );
+        const lastPrompt = promptsForSeries[promptsForSeries.length - 1];
+        if (lastPrompt?.uid) {
+          measurementService.removeMany([lastPrompt.uid]);
+        }
+
+        // Repaint.
+        const activeVp = cornerstoneViewportService.getCornerstoneViewport(activeViewportId);
+        (activeVp as any)?.render?.();
+        eventTarget.dispatchEvent(
+          new CustomEvent(csToolsEnums.Events.SEGMENTATION_DATA_MODIFIED, {
+            detail: { segmentationId },
+          })
+        );
+        return response;
+      } catch (error) {
+        console.error('Undo nninter error:', error);
+        throw error;
+      }
+    },
+
     async resetNninter(options: {clearMeasurements: boolean} = {clearMeasurements: false}){
       if (toolboxState.getLocked()) {
         return;
@@ -2925,6 +3104,7 @@ const commandsModule = ({
     runAiSegmentation: actions.runAiSegmentation,
     sam2: actions.sam2,
     initNninter: actions.initNninter,
+    undoNninter: actions.undoNninter,
     resetNninter: actions.resetNninter,
     resetSegment: actions.resetSegment,
     medGemma: actions.medGemma,

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -1331,7 +1331,6 @@ const commandsModule = ({
         promise: undoPromise,
         promiseMessages: {
           loading: 'Undoing last interaction...',
-          success: () => 'Undo - Successful',
           error: error => `Undo - Failed: ${error.message || 'Unknown error'}`,
         },
       });
@@ -1446,6 +1445,11 @@ const commandsModule = ({
             detail: { segmentationId },
           })
         );
+        uiNotificationService.show({
+          title: 'MONAI Label',
+          message: 'Undo - Successful',
+          type: 'success',
+        });
         return response;
       } catch (error) {
         console.error('Undo nninter error:', error);

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -1341,7 +1341,9 @@ const commandsModule = ({
           return;
         }
         const ct = response.headers['content-type'] as string;
-        const { meta, seg } = await parseMultipart(response.data, ct);
+        // allowEmptySeg: undoing the only interaction restores an empty segment,
+        // which arrives as a zero-length seg part.
+        const { meta, seg } = await parseMultipart(response.data, ct, { allowEmptySeg: true });
 
         const undone = String((meta as any).undone).toLowerCase() === 'true';
         if (!undone) {

--- a/Viewers/extensions/default/src/utils/Toolbox.tsx
+++ b/Viewers/extensions/default/src/utils/Toolbox.tsx
@@ -260,6 +260,14 @@ export function Toolbox({ buttonSectionId, title, defaultOpen = true }: { button
           measurementService.toggleVisibilityMeasurementMany(uids, next);
           break;
         }
+        case 'z': {
+          if (event.ctrlKey && !event.shiftKey) {
+            event.preventDefault();
+            event.stopPropagation();
+            commandsManager.run('undoNninter');
+          }
+          break;
+        }
         case 'delete': {
           event.preventDefault();
           event.stopPropagation();
@@ -463,7 +471,17 @@ export function Toolbox({ buttonSectionId, title, defaultOpen = true }: { button
                          <SelectItem value="medsam2">MedSAM2</SelectItem>
                          <SelectItem value="sam3">SAM3</SelectItem>
                        </SelectContent>
-                     </Select>
+                      </Select>
+                   </div>
+                   <div className="flex items-center gap-2">
+                     <Button
+                       variant="secondary"
+                       size="sm"
+                       onClick={() => commandsManager.run('undoNninter')}
+                       title="Undo last interaction (Ctrl+Z)"
+                     >
+                       Undo
+                     </Button>
                    </div>
                  </div>
                 )}

--- a/Viewers/extensions/default/src/utils/Toolbox.tsx
+++ b/Viewers/extensions/default/src/utils/Toolbox.tsx
@@ -471,7 +471,7 @@ export function Toolbox({ buttonSectionId, title, defaultOpen = true }: { button
                          <SelectItem value="medsam2">MedSAM2</SelectItem>
                          <SelectItem value="sam3">SAM3</SelectItem>
                        </SelectContent>
-                      </Select>
+                    </Select>
                    </div>
                    <div className="flex items-center gap-2">
                      <Button

--- a/Viewers/extensions/default/src/utils/Toolbox.tsx
+++ b/Viewers/extensions/default/src/utils/Toolbox.tsx
@@ -473,16 +473,6 @@ export function Toolbox({ buttonSectionId, title, defaultOpen = true }: { button
                        </SelectContent>
                     </Select>
                    </div>
-                   <div className="flex items-center gap-2">
-                     <Button
-                       variant="secondary"
-                       size="sm"
-                       onClick={() => commandsManager.run('undoNninter')}
-                       title="Undo last interaction (Ctrl+Z)"
-                     >
-                       Undo
-                     </Button>
-                   </div>
                  </div>
                 )}
               {isTextPromptToolbox && (

--- a/Viewers/extensions/default/src/utils/multipart.ts
+++ b/Viewers/extensions/default/src/utils/multipart.ts
@@ -72,7 +72,8 @@ function uint8ToString(u8: Uint8Array): string {
    */
   export async function parseMultipart(
     bodyBuf: ArrayBuffer,
-    contentType: string
+    contentType: string,
+    opts?: { allowEmptySeg?: boolean }
   ): Promise<{ meta: any; seg: Uint8Array }> {
     const boundary = getBoundary(contentType);
     const u8 = new Uint8Array(bodyBuf);
@@ -165,7 +166,9 @@ function uint8ToString(u8: Uint8Array): string {
     }
   
     if (!metaObj) throw new Error("meta part not found");
-    if (!seg.length) throw new Error("seg part not found");
+    // An empty seg is legitimate for some responses (e.g. nnInteractive undo that
+    // restores an empty segment); callers opt into it via allowEmptySeg.
+    if (!seg.length && !opts?.allowEmptySeg) throw new Error("seg part not found");
 
     if (typeof metaObj === 'string') {
       metaObj = JSON.parse(metaObj);

--- a/Viewers/modes/basic-test-mode/src/index.ts
+++ b/Viewers/modes/basic-test-mode/src/index.ts
@@ -152,7 +152,7 @@ function modeFactory() {
               {
                 commandName: 'undo',
                 label: 'Undo',
-                keys: ['ctrl+z'],
+                keys: ['ctrl+shift+z'],
                 isEditable: true,
               },
             ],

--- a/Viewers/modes/longitudinal/src/index.ts
+++ b/Viewers/modes/longitudinal/src/index.ts
@@ -156,6 +156,7 @@ function modeFactory({ modeConfiguration }) {
         'RectangleROI2',
         //'sam2',
         'nninter',
+        'undoNninter',
         //'resetNninter',
         //'jumpToSegment',
         //'toggleCurrentSegment',

--- a/Viewers/modes/longitudinal/src/toolbarButtons.ts
+++ b/Viewers/modes/longitudinal/src/toolbarButtons.ts
@@ -622,6 +622,17 @@ const toolbarButtons: Button[] = [
     },
   },
   {
+    id: 'undoNninter',
+    uiType: 'ohif.toolBoxButton',
+    props: {
+      type: 'tool',
+      icon: 'Undo',
+      label: 'Undo',
+      tooltip: 'Undo (Ctrl+Z)',
+      commands: 'undoNninter',
+    },
+  },
+  {
     id: 'textPromptSegmentation',
     uiType: 'ohif.toolBoxButton',
     props: {

--- a/Viewers/platform/core/src/defaults/hotkeyBindings.ts
+++ b/Viewers/platform/core/src/defaults/hotkeyBindings.ts
@@ -186,6 +186,12 @@ const bindings = [
   {
     commandName: 'undo',
     label: 'Undo',
+    keys: ['ctrl+shift+z'],
+    isEditable: true,
+  },
+  {
+    commandName: 'undoNninter',
+    label: 'Undo NNInteractive',
     keys: ['ctrl+z'],
     isEditable: true,
   },

--- a/monai-label/Dockerfile
+++ b/monai-label/Dockerfile
@@ -66,4 +66,4 @@ RUN chmod +x /entrypoint.sh
 
 EXPOSE 8002
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["python", "-m", "monailabel.main", "start_server", "--app", "/code/apps/radiology", "--studies", "http://orthanc:8042/dicom-web", "--conf", "models", "segmentation", "--conf", "use_pretrained_model", "false", "-p", "8002"]
+CMD ["python", "-m", "monailabel.main", "start_server", "--app", "/code/sample-apps/radiology", "--studies", "http://orthanc:8042/dicom-web", "--conf", "models", "segmentation", "--conf", "use_pretrained_model", "false", "-p", "8002"]

--- a/monai-label/entrypoint.sh
+++ b/monai-label/entrypoint.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 set -e
 
-# Download the radiology app on first run (avoids baking it into the image layer)
-if [ ! -d "/code/apps/radiology" ]; then
-    echo "[entrypoint] Downloading MONAI Label radiology app..."
-    python -m monailabel.main apps --download --name radiology --output /code/apps
-fi
+# The radiology app is vendored in the repo (monai-label/sample-apps/radiology) and
+# baked into the image at /code/sample-apps/radiology, so there is no runtime download.
+# The server CMD points --app at that bundled copy.
 
 exec "$@"

--- a/monai-label/monailabel/endpoints/infer.py
+++ b/monai-label/monailabel/endpoints/infer.py
@@ -261,6 +261,8 @@ def run_inference(
             "pred_offset": json.dumps(res_json.get("pred_offset")),
             "pred_full_shape": json.dumps(res_json.get("pred_full_shape")),
             "pred_crop_shape": json.dumps(res_json.get("pred_crop_shape")),
+            "nninter_op": json.dumps(res_json.get("nninter_op")),
+            "undone": json.dumps(res_json.get("undone")),
         }
         boundary = f"monai-{secrets.token_hex(12)}"
         meta_json = json.dumps(fields, separators=(",", ":"))

--- a/monai-label/monailabel/tasks/infer/basic_infer.py
+++ b/monai-label/monailabel/tasks/infer/basic_infer.py
@@ -1060,6 +1060,58 @@ class BasicInferTask(InferTask):
             logger.info("Reset nninter")
             return f'/code/predictions/reset.nii.gz', {}
 
+        # Fast path: single-level undo of the last interaction (mirrors reset).
+        # Returns the restored target_buffer in the same cropped format as a
+        # normal interaction so the client can repaint the segment.
+        if request.get('nninter') == "undo":
+            undo_json = {"nninter_op": "undo"}
+            supports_undo = hasattr(session, "undo") and getattr(session, "supports_undo", True)
+            if not supports_undo:
+                logger.warning("nnInteractive session has no undo()/supports_undo; ignoring undo request")
+                undo_json["nninter_op"] = "unsupported"
+                undo_json["undone"] = False
+                undo_json["server_end_ts"] = time.time()
+                return np.zeros((0, 0, 0), dtype=np.uint8), undo_json
+
+            try:
+                undone = bool(session.undo())
+            except Exception as e:
+                logger.error(f"nninter undo() raised: {e}")
+                undone = False
+            logger.info(f"nninter undo: undone={undone}")
+            undo_json["undone"] = undone
+
+            # Restored full object buffer, cropped to its tight non-zero bbox
+            # (identical packaging to the normal nninter result path).
+            pred = session.target_buffer.clone().numpy()  # (Z, Y, X) uint8
+            pred_full_shape = list(pred.shape)
+            z_nz = np.where(np.any(pred, axis=(1, 2)))[0]
+            if z_nz.size > 0:
+                y_nz = np.where(np.any(pred, axis=(0, 2)))[0]
+                x_nz = np.where(np.any(pred, axis=(0, 1)))[0]
+                z0, z1 = int(z_nz[0]), int(z_nz[-1]) + 1
+                y0, y1 = int(y_nz[0]), int(y_nz[-1]) + 1
+                x0, x1 = int(x_nz[0]), int(x_nz[-1]) + 1
+                pred = pred[z0:z1, y0:y1, x0:x1]
+                pred_offset = [z0, y0, x0]
+            else:
+                # Undid the only interaction: object is now empty. Send an empty
+                # crop; the client clears the segment and writes nothing.
+                pred = np.zeros((0, 0, 0), dtype=np.uint8)
+                pred_offset = [0, 0, 0]
+
+            undo_json["pred_offset"] = pred_offset
+            undo_json["pred_full_shape"] = pred_full_shape
+            undo_json["pred_crop_shape"] = list(pred.shape)
+
+            _inst = self._session_image.get("instanceNumber")
+            _inst2 = self._session_image.get("instanceNumber2")
+            undo_json["flipped"] = bool(_inst is not None and _inst2 is not None and _inst > _inst2)
+
+            undo_json["label_name"] = f"nninter_pred_{datetime.now().strftime('%Y%m%d%H%M%S')}"
+            undo_json["server_end_ts"] = time.time()
+            return pred, undo_json
+
         # Folded reset: caller needs a segment switch + inference in one round-trip.
         # Resetting here (before image loading) keeps the same semantics as a
         # separate reset call, but saves ~1.4 s of network overhead on slow links.


### PR DESCRIPTION
## Summary
- Add single-level **Undo** for nnInteractive segmentation, wired to `nnInteractiveInferenceSession.undo()` in the MONAI Label backend.
- Backend `nninter == "undo"` fast-path returns the restored `target_buffer` (or an empty seg when the only interaction is undone), with `nninter_op`/`undone` metadata surfaced through the infer endpoint.
- Frontend `undoNninter` command sends the undo request, parses the multipart response (allowing empty seg), repaints the segment via a dedicated clear+repaint render, removes the last visual prompt measurement, and shows accurate success / "nothing to undo" toasts.
- UI: dedicated **Undo** toolbar button placed immediately after the run segmentation icon with an "Undo (Ctrl+Z)" tooltip.
- Hotkeys: `Ctrl+Z` triggers nnInteractive undo (captured while the AI toolbox is active); generic undo moved to `Ctrl+Shift+Z`.
- Chore: MONAI Label container uses the bundled radiology app instead of re-downloading it at runtime.

## Test plan
- [x] Run nnInteractive interaction(s), click Undo / press Ctrl+Z, confirm labelmap reverts and last prompt measurement is removed.
- [x] Undo the only interaction → segmentation clears, no "seg part not found" error, "Undo - Successful" toast.
- [x] Undo with nothing to undo → "nothing to undo" toast, no contradictory success toast.
- [x] Confirm `Ctrl+Shift+Z` still performs generic undo and `Ctrl+Z` is scoped to nnInteractive.
- [x] Rebuild MONAI Label container and verify radiology app is served from the bundled path.

> Note: local `docker-compose.yml` and `.gitignore` env-specific changes were intentionally excluded from this PR.

Made with [Cursor](https://cursor.com)