### PR TITLE
feat: timing breakdown for nnInteractive undo

### DIFF
--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -1282,6 +1282,7 @@ const commandsModule = ({
         return;
       }
 
+      const start = Date.now();
       const { activeViewportId, viewports } = viewportGridService.getState();
       const activeViewportSpecificData = viewports.get(activeViewportId);
       const { displaySetInstanceUIDs } = activeViewportSpecificData;
@@ -1319,6 +1320,7 @@ const commandsModule = ({
       };
       const data = MonaiLabelClient.constructFormData(params, null);
 
+      const beforePost = Date.now();
       const undoPromise = axios.post(url, data, {
         responseType: 'arraybuffer',
         headers: { accept: 'application/octet-stream' },
@@ -1337,6 +1339,7 @@ const commandsModule = ({
 
       try {
         const response = await undoPromise;
+        const afterPost = Date.now();
         if (response.status !== 200) {
           return;
         }
@@ -1344,6 +1347,31 @@ const commandsModule = ({
         // allowEmptySeg: undoing the only interaction restores an empty segment,
         // which arrives as a zero-length seg part.
         const { meta, seg } = await parseMultipart(response.data, ct, { allowEmptySeg: true });
+        const afterParse = Date.now();
+
+        // --- round-trip timing breakdown (mirrors the normal nninter path) ---
+        const networkRoundTripMs = afterPost - beforePost;
+        const sRequestTs = metaNum(meta as Record<string, unknown>, 'server_request_ts');
+        const sBeginTs   = metaNum(meta as Record<string, unknown>, 'server_begin_ts');
+        const sEndTs     = metaNum(meta as Record<string, unknown>, 'server_end_ts');
+        const sUndoCore  = metaNum(meta as Record<string, unknown>, 'nninter_core_elapsed');
+        const sResult    = metaNum(meta as Record<string, unknown>, 'server_result_elapsed');
+        const postInFlightMs     = (sRequestTs != null) ? sRequestTs * 1000 - beforePost : undefined;
+        const monaiPrepMs        = (sRequestTs != null && sBeginTs != null) ? (sBeginTs - sRequestTs) * 1000 : undefined;
+        const serverProcessMs    = (sBeginTs != null && sEndTs != null) ? (sEndTs - sBeginTs) * 1000 : undefined;
+        const responseInFlightMs = (sEndTs != null) ? afterPost - sEndTs * 1000 : undefined;
+        console.log(
+          `[nninter undo timing]\n` +
+          `  client → undoNninter():          ${((beforePost - start) / 1000).toFixed(3)}s\n` +
+          `  ── round-trip total:              ${(networkRoundTripMs / 1000).toFixed(3)}s\n` +
+          (postInFlightMs     != null ? `     POST in flight:               ${(postInFlightMs / 1000).toFixed(3)}s\n` : '') +
+          (monaiPrepMs        != null ? `     MONAI pre-processing:          ${(monaiPrepMs / 1000).toFixed(3)}s\n` : '') +
+          (serverProcessMs    != null ? `     server processing (undo):      ${(serverProcessMs / 1000).toFixed(3)}s\n` : '') +
+          (sUndoCore != null ? `       ↳ session.undo():            ${sUndoCore.toFixed(3)}s\n` : '') +
+          (sResult   != null ? `       ↳ result retrieve:           ${sResult.toFixed(3)}s\n` : '') +
+          (responseInFlightMs != null ? `     response in flight:            ${(responseInFlightMs / 1000).toFixed(3)}s\n` : '') +
+          `  client parse multipart:          ${((afterParse - afterPost) / 1000).toFixed(3)}s`
+        );
 
         const undone = String((meta as any).undone).toLowerCase() === 'true';
         if (!undone) {
@@ -1447,6 +1475,7 @@ const commandsModule = ({
             detail: { segmentationId },
           })
         );
+        console.log(`[nninter undo timing] total client: ${((Date.now() - start) / 1000).toFixed(3)}s`);
         uiNotificationService.show({
           title: 'MONAI Label',
           message: 'Undo - Successful',

--- a/monai-label/monailabel/tasks/infer/basic_infer.py
+++ b/monai-label/monailabel/tasks/infer/basic_infer.py
@@ -1073,16 +1073,19 @@ class BasicInferTask(InferTask):
                 undo_json["server_end_ts"] = time.time()
                 return np.zeros((0, 0, 0), dtype=np.uint8), undo_json
 
+            _t_undo = time.time()
             try:
                 undone = bool(session.undo())
             except Exception as e:
                 logger.error(f"nninter undo() raised: {e}")
                 undone = False
+            undo_core_elapsed = time.time() - _t_undo  # time inside session.undo() only
             logger.info(f"nninter undo: undone={undone}")
             undo_json["undone"] = undone
 
             # Restored full object buffer, cropped to its tight non-zero bbox
             # (identical packaging to the normal nninter result path).
+            _t_result = time.time()
             pred = session.target_buffer.clone().numpy()  # (Z, Y, X) uint8
             pred_full_shape = list(pred.shape)
             z_nz = np.where(np.any(pred, axis=(1, 2)))[0]
@@ -1099,6 +1102,7 @@ class BasicInferTask(InferTask):
                 # crop; the client clears the segment and writes nothing.
                 pred = np.zeros((0, 0, 0), dtype=np.uint8)
                 pred_offset = [0, 0, 0]
+            result_elapsed = time.time() - _t_result  # target_buffer → numpy + bbox crop
 
             undo_json["pred_offset"] = pred_offset
             undo_json["pred_full_shape"] = pred_full_shape
@@ -1109,7 +1113,18 @@ class BasicInferTask(InferTask):
             undo_json["flipped"] = bool(_inst is not None and _inst2 is not None and _inst > _inst2)
 
             undo_json["label_name"] = f"nninter_pred_{datetime.now().strftime('%Y%m%d%H%M%S')}"
-            undo_json["server_end_ts"] = time.time()
+
+            # --- round-trip timing breakdown (mirrors the normal nninter path) ---
+            undo_elapsed = time.time() - begin  # total time inside this undo block
+            logger.info(
+                f"[timing] undo_core={undo_core_elapsed:.3f}s  "
+                f"result_retrieve={result_elapsed:.3f}s  total_undo={undo_elapsed:.3f}s"
+            )
+            undo_json["server_begin_ts"] = server_begin_ts          # Unix ts; client computes network-to-server latency
+            undo_json["nninter_core_elapsed"] = undo_core_elapsed   # GPU session.undo()
+            undo_json["server_result_elapsed"] = result_elapsed     # target_buffer → numpy + bbox crop
+            undo_json["nninter_elapsed"] = undo_elapsed             # total undo block
+            undo_json["server_end_ts"] = time.time()  # wall-clock just before serialization; client isolates server→client latency
             return pred, undo_json
 
         # Folded reset: caller needs a segment switch + inference in one round-trip.


### PR DESCRIPTION
## Summary
Adds a per-stage timing breakdown for the nnInteractive **undo** path, mirroring the instrumentation already present on the normal run path.

- **Backend** (`basic_infer.py`): the `nninter == "undo"` fast-path now measures `session.undo()` duration, result-retrieve time (target_buffer → numpy + bbox crop), and total undo-block elapsed, and writes them into the undo response metadata (`nninter_core_elapsed`, `server_result_elapsed`, `nninter_elapsed`, `server_begin_ts`/`server_end_ts`). These keys are already forwarded by the infer endpoint, so no endpoint changes were needed.
- **Frontend** (`commandsModule.ts`): `undoNninter` now captures client timestamps and logs a `[nninter undo timing]` round-trip breakdown (client→call, POST in flight, MONAI pre-processing, server processing with session.undo()/result-retrieve sub-legs, response in flight, multipart parse, and total client time).

Built on top of the merged Undo feature (#52); branched from `main`.

## Test plan
- [ ] Run an nnInteractive interaction, then undo; confirm a `[nninter undo timing]` block is printed to the browser console with non-zero server processing and sub-legs.
- [ ] Check the MONAI Label server log shows the `[timing] undo_core=… result_retrieve=… total_undo=…` line.
- [ ] Undo the only interaction (empty result) and confirm timing still logs without errors.

Made with [Cursor](https://cursor.com)