### PR TITLE
Fix z-flip labelmap rendering + hide nnInteractive bbox prompt description

### DIFF
--- a/Viewers/extensions/cornerstone/src/initCornerstoneTools.js
+++ b/Viewers/extensions/cornerstone/src/initCornerstoneTools.js
@@ -49,7 +49,20 @@ import ImageOverlayViewerTool from './tools/ImageOverlayViewerTool';
 class Probe2Tool extends ProbeTool {}
 Probe2Tool.toolName = 'Probe2';
 
-class RectangleROI2Tool extends RectangleROITool {}
+class RectangleROI2Tool extends RectangleROITool {
+  constructor(toolProps = {}) {
+    // nnInteractive bounding-box prompt: hide the stat/description text box. An empty
+    // getTextLines result makes the tool skip text rendering. calculateStats stays true
+    // (inherited default) so the prompt's pointsInShape is still computed.
+    super({
+      ...toolProps,
+      configuration: {
+        ...(toolProps.configuration || {}),
+        getTextLines: () => [],
+      },
+    });
+  }
+}
 RectangleROI2Tool.toolName = 'RectangleROI2';
 
 class PlanarFreehandROI2Tool extends PlanarFreehandROITool {}

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -188,6 +188,17 @@ const commandsModule = ({
     const labelmaps: Record<string, object> = {};
     const segmentBindings: Record<number, object> = {};
 
+    // Cornerstone's labelmap resolver maps labelmap image k -> referencedImageIds[k]
+    // strictly by INDEX. For a flipped series the block's imageIds are stored in reversed
+    // z-order, so using the display-order `imageIds` here would pair each labelmap slice
+    // with the wrong source slice and render the overlay z-mirrored. Derive referencedImageIds
+    // from each labelmap image's own referencedImageId so the mapping is order-safe
+    // (identity for a non-flipped series where blockImageIds are already in display order).
+    const refIdsFor = (ids: string[]): string[] => {
+      const refs = ids.map(id => (cache.getImage(id) as any)?.referencedImageId);
+      return refs.length === N && refs.every(Boolean) ? (refs as string[]) : imageIds;
+    };
+
     for (let b = 0; b < blockCount; b++) {
       const segIdx = b + 1;
       const blockImageIds = derivedImageIds.slice(b * N, (b + 1) * N);
@@ -197,7 +208,7 @@ const commandsModule = ({
         type: 'stack',
         imageIds: blockImageIds,
         referencedVolumeId: currentDisplaySets.displaySetInstanceUID,
-        referencedImageIds: imageIds,
+        referencedImageIds: refIdsFor(blockImageIds),
         labelToSegmentIndex: {},
       };
       segmentBindings[segIdx] = { labelmapId, labelValue: segIdx };
@@ -220,7 +231,7 @@ const commandsModule = ({
         imageIds: derivedImageIds,
         allImageIds: derivedImageIds,
         referencedVolumeId: currentDisplaySets.displaySetInstanceUID,
-        referencedImageIds: imageIds,
+        referencedImageIds: refIdsFor(derivedImageIds.slice(0, N)),
         labelmaps,
         segmentBindings,
         primaryLabelmapId,


### PR DESCRIPTION
Follow-up fixes on top of #55.

## Z-flip labelmap rendering
For a **flipped** series, the multi-block labelmap's block `imageIds` are stored in reversed z-order, but `buildMultiBlockLabelmapRepresentation` set each block's `referencedImageIds` to the **display-order** `imageIds`. Cornerstone 5.x's labelmap resolver (`getReferencedImageIdForImageIndex`) maps labelmap image `k` → `referencedImageIds[k]` strictly **by index** (it does not read each image's own `referencedImageId`), so the overlay rendered **z-mirrored**.

Fix: derive `referencedImageIds` from each labelmap image's own `referencedImageId` (via `cache.getImage`), for both per-block and top-level. Order-safe; **identity for non-flipped series** (resolves to `imageIds`); falls back to `imageIds` if any `referencedImageId` is missing.

## Hide bounding-box prompt description
The `RectangleROI2` tool (nnInteractive bounding-box prompt) rendered an area/mean/stdDev text box that isn't meaningful for a prompt. Override its `getTextLines` to return `[]` so no text box is drawn. `calculateStats` stays `true`, so the prompt's `pointsInShape` is unaffected.

## Testing
- Z-flip: verified on a flipped series — the overlay now lands on the correct slices (previously z-mirrored). Non-flipped series unchanged.
- Bbox prompt: no stat/description text on the box; segmentation prompt still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)