### PR TITLE
Fix z-flip handling in nnInteractive undo

### DIFF
--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -1757,8 +1757,12 @@ const commandsModule = ({
           _hasCropGeom = true;
         }
 
-        let merged = segImageIds.map(imageId => cache.getImage(imageId));
-        if (flipped) merged.reverse();
+        // segImageIds is the stored block order. The running (overlap) inference path already
+        // leaves it in reversed z-order for a flipped series — the same order the crop is
+        // written by index. Do NOT reverse here: doing so double-flips and lands the restored
+        // crop on the mirrored slice. The `flipped ? merged.length-1-x : x` formulas below map
+        // array index <-> display-slice index within this stored order.
+        const merged = segImageIds.map(imageId => cache.getImage(imageId));
 
         // Pass 1: clear all voxels of the active segment (use dirtySlices when available).
         const prevStats = (activeSegmentation.segments?.[segmentNumber] as any)?.cachedStats;
@@ -1800,7 +1804,6 @@ const commandsModule = ({
             if (wrote) z_range.push(flipped ? merged.length - i - 1 : i);
           }
         }
-        if (flipped) merged.reverse();
 
         // Keep cachedStats.dirtySlices in sync so the next interaction clears correctly.
         if ((activeSegmentation.segments?.[segmentNumber] as any)?.cachedStats) {


### PR DESCRIPTION
Follow-up to #56 (z-flip labelmap rendering).

## Problem
Right after **undo** on a **flipped** series, the segmentation overlay appeared z-mirrored.

The undo path modifies the stored labelmap block images **in place**. Those block `imageIds` are already stored in **reversed** z-order for a flipped series (the running overlap inference path reverses `derivedImages_new` and never reverses back). The undo path then reversed `merged` **again**, double-flipping it, so the restored crop was cleared/written on the **mirrored** slice.

## Fix
Remove the two `merged.reverse()` calls in `undoNninter`. The stored block is already in the order the crop is written by index — matching the inference path — so the crop now lands on the correct slice. The existing `flipped ? merged.length-1-x : x` index formulas remain correct in this order.

Cross-checked via `referencedImageId`: undo now writes server crop slice `c` to `stored[_segZ0+c]`, whose `referencedImageId` matches the slice the inference path writes/renders — so undo and inference are consistent.

## Testing
Verify on a flipped series: run an nnInteractive segmentation, then undo — the restored overlay lands on the correct slices (previously mirrored). Non-flipped series unaffected (`if (flipped)` guarded the removed calls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)