### PR TITLE
Fix MPR single-segment refine disappearing + nnInteractive session re-init

### DIFF
--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -479,8 +479,16 @@ const commandsModule = ({
       servicesManager.services.segmentationService.addSegmentationRepresentation(viewportId, { segmentationId })
     ));
 
-    // Explicitly trigger MPR reconcile (idempotent: if representation exists, this just fires
-    // REPRESENTATION_MODIFIED → triggerSegmentationRender → reconcile with new volume/actors).
+    // Force MPR actors to rebuild. The legacy-volume reconcile REUSES the existing actor
+    // (actors 1->1) when the layer set is unchanged (single-segment refine) and does NOT
+    // rebuild the actor's volume from the new block imageIds. Since remount purged the old
+    // volume, the reused actor then references a dead volume and renders blank (disappears).
+    // Explicitly removing the representation drops the stale actor (1->0) so the re-add
+    // rebuilds it (0->1) from the current imageIds. (Adding a 2nd segment worked only because
+    // the new layer changed the actor set and forced this rebuild.)
+    for (const viewportId of mprViewportIds) {
+      servicesManager.services.segmentationService.removeSegmentationRepresentations(viewportId, { segmentationId });
+    }
     for (const viewportId of mprViewportIds) {
       updateLabelmapSegmentationImageReferences(viewportId, segmentationId);
       await servicesManager.services.segmentationService.addSegmentationRepresentation(viewportId, {

--- a/monai-label/monailabel/tasks/infer/basic_infer.py
+++ b/monai-label/monailabel/tasks/infer/basic_infer.py
@@ -1307,14 +1307,27 @@ class BasicInferTask(InferTask):
                 raise ValueError("Input image must be 4D with shape (1, x, y, z)")
 
             if nnInter == "init":
-                if seriesInstanceUID is not None and self._session_image["seriesInstanceUID"] != seriesInstanceUID:
+                # Re-run set_image not only when the series changed, but also whenever the
+                # nnInteractive session itself has no valid image (e.g. a prior interaction shut
+                # down the executor / cleared preprocessed_image). Relying only on the img_np
+                # cache / UID meant an "img_np cache hit" could skip set_image and leave the
+                # session uninitialized, so the next interaction timed out on preprocessed_image.
+                _uid_changed = (
+                    seriesInstanceUID is not None
+                    and self._session_image["seriesInstanceUID"] != seriesInstanceUID
+                )
+                _session_needs_image = (
+                    getattr(session, "original_image_shape", None) is None
+                    or getattr(session, "preprocessed_image", None) is None
+                )
+                if _uid_changed or _session_needs_image:
                     self._session_image["dicom_dir"]       = dicom_dir
                     self._session_image["seriesInstanceUID"] = seriesInstanceUID
                     self._session_image["img_np"]          = img_np
                     self._session_image["instanceNumber"]  = instanceNumber
                     self._session_image["instanceNumber2"] = instanceNumber2
                     try:
-                        logger.info("Only first time, no image at nnInter or image changed")
+                        logger.info(f"init set_image (uid_changed={_uid_changed}, session_needs_image={_session_needs_image})")
                         session.set_image(img_np)
                         session.set_target_buffer(torch.zeros(img_np.shape[1:], dtype=torch.uint8))
                     except Exception as init_error:
@@ -1789,7 +1802,11 @@ class BasicInferTask(InferTask):
                         if seriesInstanceUID is not None and self._session_image["seriesInstanceUID"] != seriesInstanceUID:
                             logger.info("Series Instance UID changed -> update")
                             self._session_image["seriesInstanceUID"] = seriesInstanceUID
-                        if session.executor._work_queue.qsize() == 0 and session.preprocess_future is None:
+                        # Do NOT gate on preprocess_future being None: a stale future left over
+                        # from a shut-down executor would otherwise skip set_image, and we'd wait
+                        # the full 5s for a preprocess that never runs (then loop on shutdown).
+                        # set_image submits a fresh preprocess future.
+                        if session.executor._work_queue.qsize() == 0:
                             session.set_image(img_np)
                             session.set_target_buffer(torch.zeros(img_np.shape[1:], dtype=torch.uint8))
 


### PR DESCRIPTION
Two independent bug fixes.

## MPR single-segment refine disappearing (client)
Refining the first/only segment in an MPR viewport made the overlay **disappear** (it reappeared only after adding a second segment or reloading). Not flip/series-specific.

Root cause (confirmed by instrumentation): the MPR `legacy-volume` reconcile **reuses** the existing actor (`actors 1->1`) when the layer set is unchanged, and does **not** rebuild the actor's volume from the new block imageIds. Since `remountSegmentationRepresentations` purges the old volume, the reused actor then references a dead volume and renders blank. Adding a second segment "worked" only because the new layer changed the actor set and forced a rebuild.

Fix: in `remountSegmentationRepresentations`, explicitly `removeSegmentationRepresentations` for each MPR viewport before re-adding, so the reconcile drops the stale actor (`1->0`) and the re-add rebuilds it (`0->1`) from the current imageIds. Verified: overlay updates correctly, no blink observed.

## nnInteractive session re-init (server, basic_infer.py)
Interactions failed with `Session preprocessed_image still None after 5.0s wait` → executor shutdown loop, when the MONAI `img_np` cache hit but the nnInteractive session had lost its image. Pre-existing (the in-memory `_session_image` cache; the disk cache can make it more likely across restarts).

Fixes:
- `init` now re-runs `session.set_image` when the session has no valid image (`original_image_shape`/`preprocessed_image` is `None`), not only on series-UID change — so an `img_np` cache hit can't leave the session uninitialized.
- `_safe_interaction` recovery no longer gates `set_image` on `preprocess_future is None`; a stale future from a shut-down executor was skipping re-init and guaranteeing the 5s timeout.

## Testing
- MPR: verified single-segment refine in MPR now updates instead of disappearing; no blink.
- nnInteractive: user confirmed the "preprocessed_image still None" failure no longer occurs. Server-side (MONAI container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)