### PR TITLE
Segment/prompt visibility UX + suppress dev-only error toasts

### DIFF
--- a/Viewers/extensions/cornerstone/src/commandsModule.ts
+++ b/Viewers/extensions/cornerstone/src/commandsModule.ts
@@ -1316,12 +1316,14 @@ function commandsModule({
      */
     setActiveSegmentAndCenterCommand: ({ segmentationId, segmentIndex }) => {
       const { segmentationService, viewportGridService } = servicesManager.services;
+      const viewportId = viewportGridService.getActiveViewportId();
       // set both active segmentation and active segment
-      segmentationService.setActiveSegmentation(
-        viewportGridService.getActiveViewportId(),
-        segmentationId
-      );
+      segmentationService.setActiveSegmentation(viewportId, segmentationId);
       segmentationService.setActiveSegment(segmentationId, segmentIndex);
+      // Selecting a segment turns its visibility ON as a starting point — you can't work on a
+      // hidden segment. Selection and visibility are otherwise independent: the user can hide
+      // it again afterward, and that hidden state is now preserved across inferences.
+      segmentationService.setSegmentVisibility(viewportId, segmentationId, segmentIndex, true);
       segmentationService.jumpToSegmentCenter(segmentationId, segmentIndex);
     },
 

--- a/Viewers/extensions/cornerstone/src/init.tsx
+++ b/Viewers/extensions/cornerstone/src/init.tsx
@@ -290,17 +290,9 @@ export default async function init({
   eventTarget.addEventListenerDebounced(
     EVENTS.ERROR_EVENT,
     ({ detail }) => {
-      // Create a stable ID for deduplication based on error type and message
-      const errorId = `cornerstone-error-${detail.type}-${detail.message.substring(0, 50)}`;
-
-      uiNotificationService.show({
-        title: detail.type,
-        message: detail.message,
-        type: 'error',
-        id: errorId,
-        allowDuplicates: false, // Prevent duplicate error notifications
-        deduplicationInterval: 30000, // 30 seconds deduplication window
-      });
+      // These cornerstone errors are technical/dev-oriented and not informative for end
+      // users, so log them to the console instead of showing a user-facing error toast.
+      console.error(`[cornerstone:${detail.type}] ${detail.message}`);
     },
     100
   );

--- a/Viewers/extensions/cornerstone/src/panels/PanelSegmentation.tsx
+++ b/Viewers/extensions/cornerstone/src/panels/PanelSegmentation.tsx
@@ -121,7 +121,33 @@ export default function PanelSegmentation({ children }: withAppTypes) {
       });
     },
     onToggleSegmentVisibility: (segmentationId, segmentIndex, type) => {
+      // Keep the segment's prompts in sync with the segment:
+      //  - hiding the segment hides its prompts together.
+      //  - showing the segment brings its prompts back only if the global "show prompts"
+      //    toggle (hotkey O / toolboxState.promptsVisible) is on, so transient prompts don't
+      //    reappear when the user has prompts turned off.
+      const { segmentationService, viewportGridService } = servicesManager.services;
+      const viewportId = viewportGridService.getActiveViewportId();
+      const reps = segmentationService.getSegmentationRepresentations(viewportId, { segmentationId });
+      const segWasVisible = reps?.[0]?.segments?.[segmentIndex]?.visible;
       commandsManager.run('toggleSegmentVisibility', { segmentationId, segmentIndex, type });
+      const segPrompts = measurementService
+        .getMeasurements()
+        .filter(
+          m =>
+            AI_PROMPT_TOOLS.includes(m.toolName) &&
+            m.metadata?.segmentationId === segmentationId &&
+            m.metadata?.SegmentNumber === segmentIndex
+        );
+      if (segPrompts.length === 0) {
+        return;
+      }
+      const uids = segPrompts.map(m => m.uid);
+      if (segWasVisible) {
+        measurementService.toggleVisibilityMeasurementMany(uids, false);
+      } else if (toolboxState.getPromptsVisible()) {
+        measurementService.toggleVisibilityMeasurementMany(uids, true);
+      }
     },
     onToggleSegmentMeasurement: (segmentationId, segmentIndex) => {
       commandsManager.run('toggleSegmentMeasurement', { segmentationId, segmentIndex });

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -411,17 +411,17 @@ const commandsModule = ({
     currentImageIdIndex?: number;
     representations: any[];
   }) {
+    // Capture the current per-segment visibility BEFORE any remove/re-add. Removing and
+    // re-adding a representation resets every segment to visible, so we restore this map
+    // AFTER all re-adds below — otherwise each inference clobbers the user's hidden segments.
+    const visibilityBySegment: Record<number, boolean> = {};
     for (let i = 0; i < representations.length; i++) {
-      const representation = representations[i];
-      const segs = Object.values(representation.segments);
+      const segs = Object.values(representations[i].segments);
       for (let j = 0; j < segs.length; j++) {
-        const seg = segs[j];
-        servicesManager.services.segmentationService.setSegmentVisibility(
-          activeViewportId,
-          representation.segmentationId,
-          (seg as any).segmentIndex,
-          (seg as any).visible
-        );
+        const seg = segs[j] as any;
+        if (seg.segmentIndex != null) {
+          visibilityBySegment[seg.segmentIndex] = seg.visible;
+        }
       }
     }
 
@@ -508,6 +508,20 @@ const commandsModule = ({
       });
       await new Promise(resolve => setTimeout(resolve, 100));
       requestAnimationFrame(() => vp?.render());
+    }
+
+    // Restore per-segment visibility on every viewport (the remove/re-adds above reset it
+    // to visible). Newly-added segments aren't in the map, so they stay visible by default.
+    const _restoreViewportIds = servicesManager.services.cornerstoneViewportService.getViewportIds();
+    for (const viewportId of _restoreViewportIds) {
+      for (const [segIdxStr, visible] of Object.entries(visibilityBySegment)) {
+        servicesManager.services.segmentationService.setSegmentVisibility(
+          viewportId,
+          segmentationId,
+          Number(segIdxStr),
+          visible
+        );
+      }
     }
 
     const activeVp = activeViewportId.startsWith('default')


### PR DESCRIPTION
## Segment & prompt visibility
- **Preserve visibility across inferences** — `remountSegmentationRepresentations` captures each segment's visibility before the remove/re-adds (which reset segments to visible) and restores it afterward, so user-hidden segments stay hidden on every inference (previously they were reset to visible each time).
- **Select turns visibility on** — clicking a segment (`setActiveSegmentAndCenter`) makes it visible as a starting point. Selection and visibility are otherwise independent (you can hide it afterward, and that state is preserved).
- **Hide segment + its prompts together** — hiding a segment also hides that segment's prompt annotations (Probe2 / RectangleROI2 / PlanarFreehandROI2 / PlanarFreehandROI3, matched by `segmentationId` + `SegmentNumber`).
- **Show brings prompts back only if "show prompts" (O) is on** — showing a segment re-shows its prompts only when the global prompts-visible toggle (hotkey O) is enabled, so transient prompts don't reappear when the user has prompts off.

## Suppress dev-only error toasts
The cornerstone `ERROR_EVENT` handler surfaced **every** internal cornerstone error as a user-facing error toast. These are technical/dev-oriented and not informative for end users, so they're now logged to the console instead (`console.error('[cornerstone:<type>] <message>')`).

## Testing
Client-side only. Suggested checks: hide a segment → it + its prompts hide, and stay hidden across inferences; click a hidden segment → it becomes visible; with O on, showing a segment brings its prompts back; with O off, only the segment shows. Confirm the previous cornerstone error toasts no longer pop up (they appear in the console instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)