### PR TITLE
Thicker nnInteractive scribble prompt line

### DIFF
--- a/Viewers/extensions/cornerstone/src/initCornerstoneTools.js
+++ b/Viewers/extensions/cornerstone/src/initCornerstoneTools.js
@@ -142,9 +142,17 @@ export default function initCornerstoneTools(configuration = {}) {
 
   const defaultStyles = annotation.config.style.getDefaultToolStyles();
   annotation.config.style.setDefaultToolStyles({
+    ...defaultStyles,
     global: {
       ...defaultStyles.global,
       ...annotationStyle,
+    },
+    // Thicker line for the nnInteractive scribble prompt so it's easier to see/draw.
+    // Tool-specific style wins over `global` (see ToolStyle._getToolStyle), so only the
+    // scribble is affected — other annotations keep the global 1.5 lineWidth.
+    PlanarFreehandROI2: {
+      ...(defaultStyles.PlanarFreehandROI2 || {}),
+      lineWidth: '4',
     },
   });
 }


### PR DESCRIPTION
Make the scribble prompt easier to see and draw by giving the scribble tool
(`PlanarFreehandROI2`) a **tool-specific `lineWidth: 4`** (vs the global `1.5`).

Tool-specific styles win over `global` in `ToolStyle._getToolStyle`, so **only the scribble is affected** — all other annotations keep the global 1.5 line width.

The value (`4`) is easy to tune — let me know if you want it thicker/thinner, or if the negative/lasso tools (`PlanarFreehandROI3`) should match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)