### PR TITLE
Rename "Non-Interactive Segmentation (Legacy)" panel to "Manual Segmentation"

### DIFF
--- a/Viewers/extensions/cornerstone/src/getPanelModule.tsx
+++ b/Viewers/extensions/cornerstone/src/getPanelModule.tsx
@@ -52,7 +52,7 @@ const getPanelModule = ({ commandsManager, servicesManager, extensionManager }: 
         />
         <Toolbox
           buttonSectionId="segmentationToolbox"
-          title="Non-Interactive Segmentation (Legacy)"
+          title="Manual Segmentation"
           defaultOpen={false}
         />
         <PanelSegmentation


### PR DESCRIPTION
Renames the segmentation toolbox panel title from **"Non-Interactive Segmentation (Legacy)"** to **"Manual Segmentation"** (`getPanelModule.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)