### PR TITLE
Fix "Something went wrong" error toast (segment stats hooks + worker OOM)

### DIFF
--- a/Viewers/backup/esm/getSegmentLargestBidirectional.js
+++ b/Viewers/backup/esm/getSegmentLargestBidirectional.js
@@ -126,12 +126,20 @@ async function calculateStackBidirectional({ segImageIds, indices, mode }) {
     if (!segmentationInfo.length) {
         return [];
     }
-    const bidirectionalData = await getWebWorkerManager().executeTask('compute', 'getSegmentLargestBidirectionalInternal', {
-        segmentationInfo,
-        indices,
-        mode,
-        isStack: true,
-    });
+    let bidirectionalData;
+    try {
+        bidirectionalData = await getWebWorkerManager().executeTask('compute', 'getSegmentLargestBidirectionalInternal', {
+            segmentationInfo,
+            indices,
+            mode,
+            isStack: true,
+        });
+    } catch (e) {
+        // DataCloneError / OOM when the payload is too large to clone — degrade gracefully
+        // instead of throwing (which surfaces as the "Something went wrong" ErrorBoundary).
+        console.warn('getSegmentLargestBidirectionalInternal worker failed; skipping bidirectional:', e);
+        return [];
+    }
     // Tag each result with the correctly-aligned imageIds so resolveReferencedImageId
     // maps sliceIndex → the right segImageId even when some slices were skipped.
     const effectiveIds = includedSegImageIds ?? segImageIds;

--- a/Viewers/backup/esm/getStatistics.js
+++ b/Viewers/backup/esm/getStatistics.js
@@ -191,12 +191,22 @@ async function calculateStackStatistics({ segImageIds, indices, unit, mode }) {
         triggerWorkerProgress(WorkerTypes.COMPUTE_STATISTICS, 100);
         return mode === 'individual' ? {} : undefined;
     }
-    const stats = await getWebWorkerManager().executeTask('compute', 'calculateSegmentsStatisticsStack', {
-        segmentationInfo,
-        imageInfo,
-        indices,
-        mode,
-    });
+    let stats;
+    try {
+        stats = await getWebWorkerManager().executeTask('compute', 'calculateSegmentsStatisticsStack', {
+            segmentationInfo,
+            imageInfo,
+            indices,
+            mode,
+        });
+    } catch (e) {
+        // e.g. DataCloneError / out-of-memory when the payload is still too large to clone.
+        // Stats are display-only — degrade gracefully instead of throwing (which otherwise
+        // surfaces as the "Something went wrong" ErrorBoundary toast).
+        console.warn('calculateSegmentsStatisticsStack worker failed; skipping stats:', e);
+        triggerWorkerProgress(WorkerTypes.COMPUTE_STATISTICS, 100);
+        return mode === 'individual' ? {} : undefined;
+    }
     triggerWorkerProgress(WorkerTypes.COMPUTE_STATISTICS, 100);
     const spacing = segmentationInfo[0].spacing;
     const segmentationImageData = segmentationInfo[0];

--- a/Viewers/backup/esm/utilsForWorker.js
+++ b/Viewers/backup/esm/utilsForWorker.js
@@ -175,6 +175,18 @@ export const prepareStackDataForWorker = (segImageIds) => {
             skipped++;
             continue;
         }
+        // Skip slices with no segmentation foreground. A labelmap block is mostly empty (the
+        // segment occupies a small z-range), and posting every slice's scalar data to the
+        // compute worker clones hundreds of MB → DataCloneError / out-of-memory. Aggregate
+        // stats are unaffected (empty slices contribute nothing) and bidirectional maps its
+        // results via includedSegImageIds, so dropping empty slices here is safe.
+        let _hasForeground = false;
+        for (let k = 0; k < segPixelData.length; k++) {
+            if (segPixelData[k] !== 0) { _hasForeground = true; break; }
+        }
+        if (!_hasForeground) {
+            continue;
+        }
         const { origin, direction, spacing, dimensions } = utilities.getImageDataMetadata(segImage);
         const refVoxelManager = refImage.voxelManager;
         segmentationInfo.push({

--- a/Viewers/extensions/cornerstone/src/customizations/CustomSegmentStatisticsHeader.tsx
+++ b/Viewers/extensions/cornerstone/src/customizations/CustomSegmentStatisticsHeader.tsx
@@ -25,25 +25,28 @@ export const CustomSegmentStatisticsHeader = ({
   const [bidirectionalComputed, setBidirectionalComputed] = useState(false);
 
   const segmentation = segmentationService.getSegmentation(segmentationId);
-  const segment = segmentation.segments[segmentIndex];
-  const cachedStats = segment.cachedStats;
-  const namedStats = cachedStats.namedStats;
+  const segment = segmentation?.segments?.[segmentIndex];
+  const cachedStats = segment?.cachedStats;
+  const namedStats = cachedStats?.namedStats;
 
-  if (!namedStats) {
-    return null;
-  }
-  
-
-  // Use useEffect to run bidirectional computation only once
+  // Run bidirectional computation once. This hook MUST run on every render — hooks cannot be
+  // conditional. namedStats appears/disappears while stats compute (statsPending/"Calculating"),
+  // so keeping the effect BEFORE the early returns preserves a stable hook order; otherwise the
+  // hook count changes between renders and React throws "Rendered fewer hooks than expected"
+  // (surfaced by the ErrorBoundary as "Something went wrong").
   useEffect(() => {
-    if (!namedStats.bidirectional && !bidirectionalComputed) {
+    if (namedStats && !namedStats.bidirectional && !bidirectionalComputed) {
       setBidirectionalComputed(true);
       commandsManager.run('runSegmentBidirectional', {
         segmentationId,
         segmentIndex,
       });
     }
-  }, [namedStats.bidirectional, bidirectionalComputed, segmentationId, segmentIndex, commandsManager]);
+  }, [namedStats?.bidirectional, bidirectionalComputed, segmentationId, segmentIndex, commandsManager, namedStats]);
+
+  if (!namedStats) {
+    return null;
+  }
 
   if (!namedStats.bidirectional) {
     return (


### PR DESCRIPTION
Fixes the red **"Something went wrong … Try again."** ErrorBoundary toast that appeared during segmentation-panel actions. Two layers — a render crash and its root cause.

## Root cause: stats worker OOM
`calculateSegmentsStatisticsStack` failed with `DataCloneError: … out of memory`. `prepareStackDataForWorker` posted the **full scalar data of every block slice × 2 arrays** (hundreds of MB) to the compute worker, and `postMessage` couldn't clone it. The failed stats left `namedStats` empty, which then tripped the header's hooks bug and surfaced the ErrorBoundary toast.

- **`prepareStackDataForWorker`**: skip empty slices (no segmentation foreground). A labelmap block is mostly empty — the segment occupies a small z-range — so this cuts the worker payload ~5–10×. Safe: aggregate stats are unaffected (empty slices contribute nothing) and bidirectional maps results via `includedSegImageIds`.
- **`calculateStackStatistics` / `calculateStackBidirectional`**: catch worker failures and degrade gracefully (return empty) instead of throwing.

## Render crash: hooks-order violation
`CustomSegmentStatisticsHeader` called a `useEffect` **after** an early `return null` (taken when `namedStats` is missing). Since `namedStats` now appears/disappears while stats compute (`statsPending` / "Calculating…"), the hook count changed between renders → React threw *"Rendered fewer hooks than expected."*

- Move the effect **before** the early returns so hooks run unconditionally; optional-chain `segment?.cachedStats?.namedStats` so it can't throw.

## Notes
- The worker fixes live in `backup/esm/*`, so they take effect after the **Docker viewer rebuild** (the header fix is a normal extension build).

## Testing
Interact with the segmentation panel (select/hide segments, run/undo inference, watch stats populate) — the "Something went wrong" toast should no longer appear and stats should populate.