### PR TITLE
feat(nninter): multi-user session pool — per-client sessions, lease tokens, auto-replay

### DIFF
--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -2884,7 +2884,7 @@ const commandsModule = ({
             const afterPost = Date.now();
             const networkRoundTripMs = afterPost - beforePost;
             const ct = response.headers["content-type"] as string;
-            const { meta, seg } = await parseMultipart(response.data, ct);
+            const { meta, seg } = await parseMultipart(response.data, ct, { allowEmptySeg: true });
             // Server-side session was evicted/timed out. Reclaim, re-init, and
             // re-run: measurements still hold the full prompt history, and the
             // server replays any prompts it hasn't seen (one GPU prediction).
@@ -2911,6 +2911,9 @@ const commandsModule = ({
               await getNninterToken();
               await actions.initNninter();
               return actions.nninter(textPrompts);
+            }
+            if (!seg.length) {
+              throw new Error('seg part not found');
             }
             const afterParse = Date.now();
 

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -36,6 +36,7 @@ import {
 } from './stores/toolboxState';
 import { parseMultipart } from './utils/multipart';
 import { callInputDialog } from './utils/callInputDialog';
+import { getNninterToken, clearNninterToken } from './utils/nninterSession';
 
 /** Tracks the last series initialized by initNninter to detect study/series changes. */
 let _lastInitSeries: string | undefined = undefined;
@@ -1635,6 +1636,14 @@ const commandsModule = ({
         toolboxState.setPosNeg(false);
       }
 
+      let nninterToken = '';
+      try {
+        nninterToken = await getNninterToken();
+      } catch (e) {
+        // Server down or old server image without the endpoint — proceed
+        // tokenless; the infer call surfaces its own error/expired handling.
+        console.warn('nninter session claim failed; proceeding without token', e);
+      }
       let url = `/monai/infer/segmentation?image=${currentDisplaySets.SeriesInstanceUID}&output=dicom_seg`;
       let params = {
         largest_cc: false,
@@ -1644,6 +1653,7 @@ const commandsModule = ({
         studyInstanceUID: currentDisplaySets.StudyInstanceUID,
         restore_label_idx: false,
         nninter: "init",
+        nninter_token: nninterToken,
       };
 
       // Show notification only on the first initNninter for a new series.
@@ -1754,6 +1764,14 @@ const commandsModule = ({
         return;
       }
 
+      let nninterToken = '';
+      try {
+        nninterToken = await getNninterToken();
+      } catch (e) {
+        // Server down or old server image without the endpoint — proceed
+        // tokenless; the infer call surfaces its own error/expired handling.
+        console.warn('nninter session claim failed; proceeding without token', e);
+      }
       const url = `/monai/infer/segmentation?image=${currentDisplaySets.SeriesInstanceUID}&output=dicom_seg`;
       const params = {
         largest_cc: false,
@@ -1763,6 +1781,7 @@ const commandsModule = ({
         studyInstanceUID: currentDisplaySets.StudyInstanceUID,
         restore_label_idx: false,
         nninter: 'undo',
+        nninter_token: nninterToken,
       };
       const data = MonaiLabelClient.constructFormData(params, null);
 
@@ -1937,6 +1956,14 @@ const commandsModule = ({
       const currentDisplaySets = displaySets.filter(e => {
         return e.displaySetInstanceUID == displaySetInstanceUID;
       })[0];
+      let nninterToken = '';
+      try {
+        nninterToken = await getNninterToken();
+      } catch (e) {
+        // Server down or old server image without the endpoint — proceed
+        // tokenless; the infer call surfaces its own error/expired handling.
+        console.warn('nninter session claim failed; proceeding without token', e);
+      }
       let url = `/monai/infer/segmentation?image=${currentDisplaySets.SeriesInstanceUID}&output=dicom_seg`;
       let params = {
         largest_cc: false,
@@ -1946,6 +1973,7 @@ const commandsModule = ({
         studyInstanceUID: currentDisplaySets.StudyInstanceUID,
         restore_label_idx: false,
         nninter: "reset",
+        nninter_token: nninterToken,
       };
 
       let data = MonaiLabelClient.constructFormData(params, null);
@@ -2759,6 +2787,14 @@ const commandsModule = ({
         document.dispatchEvent(new Event('measurement-state-changed'));
       }
 
+      let nninterToken = '';
+      try {
+        nninterToken = await getNninterToken();
+      } catch (e) {
+        // Server down or old server image without the endpoint — proceed
+        // tokenless; the infer call surfaces its own error/expired handling.
+        console.warn('nninter session claim failed; proceeding without token', e);
+      }
       let url = `/monai/infer/segmentation?image=${currentDisplaySets.SeriesInstanceUID}&output=dicom_seg`;
       let params = {
         largest_cc: false,
@@ -2779,6 +2815,7 @@ const commandsModule = ({
         texts: text_prompts,
         nninter: true,
         nninter_reset_first: _needsReset,
+        nninter_token: nninterToken,
       };
 
       let data = MonaiLabelClient.constructFormData(params, null);

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -121,6 +121,11 @@ const commandsModule = ({
     }
   }
 
+  // Loop guard for session-expired auto-recovery: if a second recovery is
+  // needed within 5s the pool is thrashing (capacity pressure) — stop and
+  // tell the user instead of ping-ponging claims.
+  let _lastNninterRecoveryTs = 0;
+
   function beginInferenceRunOrQueue(): boolean {
     if (toolboxState.getLocked()) {
       return false;
@@ -1605,7 +1610,7 @@ const commandsModule = ({
         finishInferenceRun();
       }
     },
-    async initNninter( options: {viewportId: string} = {viewportId: undefined} ){
+    async initNninter( options: {viewportId: string} = {viewportId: undefined}, _sessionRetry = false ){
 
       let { activeViewportId, viewports } = viewportGridService.getState();
       if(options.viewportId !== undefined){
@@ -1684,6 +1689,16 @@ const commandsModule = ({
       try {
         const response = await initPromise;
         if (response.status === 200) {
+          const _initBody = new TextDecoder('utf-8').decode(response.data);
+          if (_initBody.includes('session_expired')) {
+            if (_sessionRetry) {
+              console.warn('Init nninter: session expired again after reclaim; giving up');
+              return response;
+            }
+            clearNninterToken();
+            await getNninterToken();
+            return actions.initNninter(options, true);
+          }
           if (_showNotification) {
             uiNotificationService.show({
               title: 'NNInit',
@@ -1812,6 +1827,22 @@ const commandsModule = ({
         // allowEmptySeg: undoing the only interaction restores an empty segment,
         // which arrives as a zero-length seg part.
         const { meta, seg } = await parseMultipart(response.data, ct, { allowEmptySeg: true });
+        let _undoOp: unknown = (meta as any).nninter_op;
+        try {
+          _undoOp = JSON.parse(((meta as any).nninter_op ?? 'null') as string);
+        } catch {
+          /* keep raw value */
+        }
+        if (_undoOp === 'session_expired') {
+          clearNninterToken();
+          uiNotificationService.show({
+            title: 'Undo',
+            message: 'nnInteractive session expired — nothing to undo.',
+            type: 'warning',
+            duration: 3000,
+          });
+          return;
+        }
         const afterParse = Date.now();
 
         // --- round-trip timing breakdown (mirrors the normal nninter path) ---
@@ -2854,6 +2885,33 @@ const commandsModule = ({
             const networkRoundTripMs = afterPost - beforePost;
             const ct = response.headers["content-type"] as string;
             const { meta, seg } = await parseMultipart(response.data, ct);
+            // Server-side session was evicted/timed out. Reclaim, re-init, and
+            // re-run: measurements still hold the full prompt history, and the
+            // server replays any prompts it hasn't seen (one GPU prediction).
+            let _nninterOp: unknown = (meta as any).nninter_op;
+            try {
+              _nninterOp = JSON.parse(((meta as any).nninter_op ?? 'null') as string);
+            } catch {
+              /* keep raw value */
+            }
+            if (_nninterOp === 'session_expired') {
+              const _now = Date.now();
+              if (_now - _lastNninterRecoveryTs < 5000) {
+                uiNotificationService.show({
+                  title: 'MONAI Label',
+                  message: 'nnInteractive session expired — please segment again.',
+                  type: 'warning',
+                  duration: 4000,
+                });
+                return;
+              }
+              _lastNninterRecoveryTs = _now;
+              console.warn('nninter session expired — reclaiming and replaying prompts');
+              clearNninterToken();
+              await getNninterToken();
+              await actions.initNninter();
+              return actions.nninter(textPrompts);
+            }
             const afterParse = Date.now();
 
             // --- server-side timing breakdown ---

--- a/Viewers/extensions/default/src/utils/nninterSession.ts
+++ b/Viewers/extensions/default/src/utils/nninterSession.ts
@@ -1,0 +1,39 @@
+// Lease-token holder for the MONAI nnInteractive session pool.
+// Claims lazily on first use so idle viewers never hold a session slot;
+// releases via sendBeacon on tab close (server idle-timeout is the backstop).
+
+let token: string | null = null;
+let claimPromise: Promise<string> | null = null;
+
+export async function getNninterToken(): Promise<string> {
+  if (token) {
+    return token;
+  }
+  if (!claimPromise) {
+    claimPromise = fetch('/monai/nninter/session/', { method: 'POST' })
+      .then(r => {
+        if (!r.ok) {
+          throw new Error(`nninter session claim failed: HTTP ${r.status}`);
+        }
+        return r.json();
+      })
+      .then(j => {
+        token = j.token;
+        return token;
+      })
+      .finally(() => {
+        claimPromise = null;
+      });
+  }
+  return claimPromise;
+}
+
+export function clearNninterToken(): void {
+  token = null;
+}
+
+window.addEventListener('pagehide', () => {
+  if (token) {
+    navigator.sendBeacon(`/monai/nninter/session/${token}/release`);
+  }
+});

--- a/monai-label/monailabel/app.py
+++ b/monai-label/monailabel/app.py
@@ -30,6 +30,7 @@ from monailabel.endpoints import (
     login,
     logs,
     model,
+    nninter_session,
     ohif,
     proxy,
     scoring,
@@ -96,6 +97,7 @@ app.include_router(logs.router, prefix=settings.MONAI_LABEL_API_STR)
 app.include_router(ohif.router, prefix=settings.MONAI_LABEL_API_STR)
 app.include_router(proxy.router, prefix=settings.MONAI_LABEL_API_STR)
 app.include_router(session.router, prefix=settings.MONAI_LABEL_API_STR)
+app.include_router(nninter_session.router, prefix=settings.MONAI_LABEL_API_STR)
 
 
 @app.get("/", include_in_schema=False)

--- a/monai-label/monailabel/endpoints/nninter_session.py
+++ b/monai-label/monailabel/endpoints/nninter_session.py
@@ -1,0 +1,33 @@
+"""Claim/release endpoints for the in-process nnInteractive session pool.
+
+Plain `def` (not `async def`) so FastAPI runs them in its threadpool:
+claim() constructs a GPU-backed session and must not block the event loop.
+Release is POST (not DELETE) because navigator.sendBeacon can only POST.
+"""
+
+import logging
+
+from fastapi import APIRouter
+
+from monailabel.tasks.infer import nninter_session_pool
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/nninter/session",
+    tags=["Infer"],
+    responses={404: {"description": "Not found"}},
+)
+
+
+@router.post("/", summary="Claim an nnInteractive session (evicts the LRU session when full)")
+def claim_session():
+    pool = nninter_session_pool.get_pool()
+    entry = pool.claim()
+    return {"token": entry.token, "idle_timeout": pool.idle_timeout}
+
+
+@router.post("/{token}/release", summary="Release an nnInteractive session (idempotent)")
+def release_session(token: str):
+    nninter_session_pool.get_pool().release(token)
+    return {"released": True}

--- a/monai-label/monailabel/tasks/infer/basic_infer.py
+++ b/monai-label/monailabel/tasks/infer/basic_infer.py
@@ -1132,7 +1132,8 @@ class BasicInferTask(InferTask):
 
             _t_undo = time.time()
             try:
-                undone = bool(session.undo())
+                with get_pool().gpu_lock:
+                    undone = bool(session.undo())
             except Exception as e:
                 logger.error(f"nninter undo() raised: {e}")
                 undone = False
@@ -1895,7 +1896,13 @@ class BasicInferTask(InferTask):
                     if nninter_first_interaction_ts is None:
                         nninter_first_interaction_ts = t_before
                     with timeout_context(seconds=100):
-                        perform_callable()
+                        # Global GPU lock: one prediction at a time across all
+                        # sessions. set_image preprocessing and result packaging
+                        # stay outside so they never block another user's
+                        # prediction. Lock order: entry.lock (held by __call__)
+                        # -> gpu_lock.
+                        with get_pool().gpu_lock:
+                            perform_callable()
                     nninter_core_elapsed += time.time() - t_before
                     return True
                 except Exception as e:
@@ -1911,15 +1918,33 @@ class BasicInferTask(InferTask):
                         logger.error(f"Failed to reset session: {reset_error}")
                     return False
             
+            # Replay optimization: a normal request carries exactly one
+            # not-yet-applied prompt. After a session-expired replay the request
+            # carries the full history — encode all but the last without running
+            # a prediction, then predict once at the end.
+            _pending_total = 0
+            for _key in _USED_INTERACTION_KEYS:
+                for _p in (data.get(_key) or []):
+                    if not self.is_prompt_used(used_interactions, _p, _key):
+                        _pending_total += 1
+
+            _applied_count = 0
+
+            def _run_prediction_flag():
+                nonlocal _applied_count
+                _applied_count += 1
+                return _applied_count >= _pending_total
+
             if len(data['pos_points'])!=0:
                 result_json["pos_points"]=copy.deepcopy(data["pos_points"])
                 
                 for point in data['pos_points']:
                     if not self.is_prompt_used(used_interactions, point, "pos_points"):
                         self.add_prompt(used_interactions, point, "pos_points")
+                        _rp = _run_prediction_flag()
                         if instanceNumber > instanceNumber2:
                             point[2]=img_np.shape[1]-1-point[2]
-                        if not _safe_interaction(lambda: session.add_point_interaction(tuple(point[::-1]), include_interaction=True)):
+                        if not _safe_interaction(lambda rp=_rp: session.add_point_interaction(tuple(point[::-1]), include_interaction=True, run_prediction=rp)):
                             return f'/code/predictions/reset.nii.gz', final_result_json
                         logger.info("Add pos points")
                                 
@@ -1929,9 +1954,10 @@ class BasicInferTask(InferTask):
                 for point in data['neg_points']:
                     if not self.is_prompt_used(used_interactions, point, "neg_points"):
                         self.add_prompt(used_interactions, point, "neg_points")
+                        _rp = _run_prediction_flag()
                         if instanceNumber > instanceNumber2:
                             point[2]=img_np.shape[1]-1-point[2]
-                        if not _safe_interaction(lambda: session.add_point_interaction(tuple(point[::-1]), include_interaction=False)):
+                        if not _safe_interaction(lambda rp=_rp: session.add_point_interaction(tuple(point[::-1]), include_interaction=False, run_prediction=rp)):
                             return f'/code/predictions/reset.nii.gz', final_result_json
                         logger.info("Add neg points")
 
@@ -1941,6 +1967,7 @@ class BasicInferTask(InferTask):
                 for box in data['pos_boxes']:
                     if not self.is_prompt_used(used_interactions, box, "pos_boxes"):
                         self.add_prompt(used_interactions, box, "pos_boxes")
+                        _rp = _run_prediction_flag()
                         if instanceNumber > instanceNumber2:
                             box[0][2]=img_np.shape[1]-1-box[0][2]
                             box[1][2]=img_np.shape[1]-1-box[1][2]
@@ -1950,12 +1977,13 @@ class BasicInferTask(InferTask):
                             [min(box[0][i], box[1][i]), max(box[0][i], box[1][i]) + 1]
                             for i in range(3)
                         ]
-                        if not _safe_interaction(lambda b=bbox: session.add_bbox_interaction(
+                        if not _safe_interaction(lambda b=bbox, rp=_rp: session.add_bbox_interaction(
                             b,
-                            include_interaction=True
+                            include_interaction=True,
+                            run_prediction=rp
                         )):
                             return f'/code/predictions/reset.nii.gz', final_result_json
-                        logger.info("Add a box")            
+                        logger.info("Add a box")
 
             if len(data['neg_boxes'])!=0:
                 result_json["neg_boxes"]=copy.deepcopy(data["neg_boxes"])
@@ -1963,6 +1991,7 @@ class BasicInferTask(InferTask):
                 for box in data['neg_boxes']:
                     if not self.is_prompt_used(used_interactions, box, "neg_boxes"):
                         self.add_prompt(used_interactions, box, "neg_boxes")
+                        _rp = _run_prediction_flag()
                         if instanceNumber > instanceNumber2:
                             box[0][2]=img_np.shape[1]-1-box[0][2]
                             box[1][2]=img_np.shape[1]-1-box[1][2]
@@ -1972,12 +2001,13 @@ class BasicInferTask(InferTask):
                             [min(box[0][i], box[1][i]), max(box[0][i], box[1][i]) + 1]
                             for i in range(3)
                         ]
-                        if not _safe_interaction(lambda b=bbox: session.add_bbox_interaction(
+                        if not _safe_interaction(lambda b=bbox, rp=_rp: session.add_bbox_interaction(
                             b,
-                            include_interaction=False
+                            include_interaction=False,
+                            run_prediction=rp
                         )):
                             return f'/code/predictions/reset.nii.gz', final_result_json
-                        logger.info("Add a box")            
+                        logger.info("Add a box")
 
 
             if len(data['pos_lassos'])!=0:
@@ -1986,6 +2016,7 @@ class BasicInferTask(InferTask):
                 for lasso_raw in data['pos_lassos']:
                     if not self.is_prompt_used(used_interactions, lasso_raw, "pos_lassos"):
                         self.add_prompt(used_interactions, lasso_raw, "pos_lassos")
+                        _rp = _run_prediction_flag()
                         _t_prep = time.time()
                         perim = clean_and_densify_polyline(lasso_raw)
                         perim_arr = np.round(np.asarray(perim)).astype(int)
@@ -1996,8 +2027,8 @@ class BasicInferTask(InferTask):
                         if lasso_image is None:
                             continue
                         if not _safe_interaction(
-                            lambda img=lasso_image, bbox=interaction_bbox: session.add_lasso_interaction(
-                                img, include_interaction=True, interaction_bbox=bbox
+                            lambda img=lasso_image, bbox=interaction_bbox, rp=_rp: session.add_lasso_interaction(
+                                img, include_interaction=True, interaction_bbox=bbox, run_prediction=rp
                             )
                         ):
                             return f'/code/predictions/reset.nii.gz', final_result_json
@@ -2009,6 +2040,7 @@ class BasicInferTask(InferTask):
                 for lasso_raw in data['neg_lassos']:
                     if not self.is_prompt_used(used_interactions, lasso_raw, "neg_lassos"):
                         self.add_prompt(used_interactions, lasso_raw, "neg_lassos")
+                        _rp = _run_prediction_flag()
                         _t_prep = time.time()
                         perim = clean_and_densify_polyline(lasso_raw)
                         perim_arr = np.round(np.asarray(perim)).astype(int)
@@ -2019,8 +2051,8 @@ class BasicInferTask(InferTask):
                         if lasso_image is None:
                             continue
                         if not _safe_interaction(
-                            lambda img=lasso_image, bbox=interaction_bbox: session.add_lasso_interaction(
-                                img, include_interaction=False, interaction_bbox=bbox
+                            lambda img=lasso_image, bbox=interaction_bbox, rp=_rp: session.add_lasso_interaction(
+                                img, include_interaction=False, interaction_bbox=bbox, run_prediction=rp
                             )
                         ):
                             return f'/code/predictions/reset.nii.gz', final_result_json
@@ -2032,6 +2064,7 @@ class BasicInferTask(InferTask):
                 for scribble in data['pos_scribbles']:
                     if not self.is_prompt_used(used_interactions, scribble, "pos_scribbles"):
                         self.add_prompt(used_interactions, scribble, "pos_scribbles")
+                        _rp = _run_prediction_flag()
                         _t_prep = time.time()
                         scribble = clean_and_densify_polyline(scribble)
                         filled_indices = np.round(np.asarray(scribble)).astype(int)
@@ -2049,14 +2082,14 @@ class BasicInferTask(InferTask):
                         scribble_start = time.time()
                         if interaction_bbox is not None:
                             if not _safe_interaction(
-                                lambda img=scribble_image, bbox=interaction_bbox: session.add_scribble_interaction(
-                                    scribble_image=img, include_interaction=True, interaction_bbox=bbox
+                                lambda img=scribble_image, bbox=interaction_bbox, rp=_rp: session.add_scribble_interaction(
+                                    scribble_image=img, include_interaction=True, interaction_bbox=bbox, run_prediction=rp
                                 )
                             ):
                                 return f'/code/predictions/reset.nii.gz', final_result_json
                         elif not _safe_interaction(
-                            lambda img=scribble_image: session.add_scribble_interaction(
-                                scribble_image=img, include_interaction=True
+                            lambda img=scribble_image, rp=_rp: session.add_scribble_interaction(
+                                scribble_image=img, include_interaction=True, run_prediction=rp
                             )
                         ):
                             return f'/code/predictions/reset.nii.gz', final_result_json
@@ -2070,6 +2103,7 @@ class BasicInferTask(InferTask):
                 for scribble in data['neg_scribbles']:
                     if not self.is_prompt_used(used_interactions, scribble, "neg_scribbles"):
                         self.add_prompt(used_interactions, scribble, "neg_scribbles")
+                        _rp = _run_prediction_flag()
                         _t_prep = time.time()
                         scribble = clean_and_densify_polyline(scribble)
                         filled_indices = np.round(np.asarray(scribble)).astype(int)
@@ -2086,14 +2120,14 @@ class BasicInferTask(InferTask):
                         prompt_prep_elapsed += time.time() - _t_prep
                         if interaction_bbox is not None:
                             if not _safe_interaction(
-                                lambda img=scribble_image, bbox=interaction_bbox: session.add_scribble_interaction(
-                                    scribble_image=img, include_interaction=False, interaction_bbox=bbox
+                                lambda img=scribble_image, bbox=interaction_bbox, rp=_rp: session.add_scribble_interaction(
+                                    scribble_image=img, include_interaction=False, interaction_bbox=bbox, run_prediction=rp
                                 )
                             ):
                                 return f'/code/predictions/reset.nii.gz', final_result_json
                         elif not _safe_interaction(
-                            lambda img=scribble_image: session.add_scribble_interaction(
-                                scribble_image=img, include_interaction=False
+                            lambda img=scribble_image, rp=_rp: session.add_scribble_interaction(
+                                scribble_image=img, include_interaction=False, run_prediction=rp
                             )
                         ):
                             return f'/code/predictions/reset.nii.gz', final_result_json

--- a/monai-label/monailabel/tasks/infer/basic_infer.py
+++ b/monai-label/monailabel/tasks/infer/basic_infer.py
@@ -167,11 +167,14 @@ try:
         import logging
 
         _wlog = logging.getLogger(__name__)
-        _wlog.info("nnInteractive warmup: starting...")
-        _artifact_loader.initialize_from_loaded_artifacts(_NNINTER_ARTIFACTS)
-        ran = _artifact_loader.warmup()
-        _NNINTER_ARTIFACTS["network"] = _artifact_loader.network
-        _wlog.info(f"nnInteractive warmup: {'done' if ran else 'skipped (torch.compile not enabled)'}.")
+        try:
+            _wlog.info("nnInteractive warmup: starting...")
+            _artifact_loader.initialize_from_loaded_artifacts(_NNINTER_ARTIFACTS)
+            ran = _artifact_loader.warmup()
+            _NNINTER_ARTIFACTS["network"] = _artifact_loader.network
+            _wlog.info(f"nnInteractive warmup: {'done' if ran else 'skipped (torch.compile not enabled)'}.")
+        except Exception:
+            _wlog.exception("nnInteractive warmup failed (non-fatal)")
 
     threading.Thread(target=_warmup_session, daemon=True).start()
 except Exception as _warmup_err:
@@ -1227,9 +1230,7 @@ class BasicInferTask(InferTask):
 
         dicom_dir = data['image'].split('.nii.gz')[0].rstrip("/")
 
-        _NNI_EXCLUDE = ("init", "reset",
-                        "medGemma", "gemini", "openai", "claude",
-                        "kimi", "qwen", "gemma", "vllm")
+        _NNI_EXCLUDE = ("init", "reset") + _NNI_VLM_OPS
         _is_nninter_interaction = nnInter and nnInter not in _NNI_EXCLUDE
 
         logger.info(
@@ -1409,16 +1410,7 @@ class BasicInferTask(InferTask):
 
             logger.info(f"interactions in _session_used_interactions: {used_interactions}")
 
-            if nnInter in (
-                "medGemma",
-                "gemini",
-                "openai",
-                "claude",
-                "kimi",
-                "qwen",
-                "gemma",
-                "vllm",
-            ):
+            if nnInter in _NNI_VLM_OPS:
                 if len(data['texts'])==1 and data['texts'][0]!='' and data['texts'][0]!={}:
                     hf_token = (
                         _resolve_hf_token(data)
@@ -1895,13 +1887,15 @@ class BasicInferTask(InferTask):
                     t_before = time.time()
                     if nninter_first_interaction_ts is None:
                         nninter_first_interaction_ts = t_before
-                    with timeout_context(seconds=100):
-                        # Global GPU lock: one prediction at a time across all
-                        # sessions. set_image preprocessing and result packaging
-                        # stay outside so they never block another user's
-                        # prediction. Lock order: entry.lock (held by __call__)
-                        # -> gpu_lock.
-                        with get_pool().gpu_lock:
+                    # Global GPU lock: one prediction at a time across all
+                    # sessions. set_image preprocessing and result packaging
+                    # stay outside so they never block another user's
+                    # prediction. Lock order: entry.lock (held by __call__)
+                    # -> gpu_lock. Acquired OUTSIDE timeout_context so waiting
+                    # for another user's prediction cannot burn this user's
+                    # alarm and trigger a session-destroying reset.
+                    with get_pool().gpu_lock:
+                        with timeout_context(seconds=100):
                             perform_callable()
                     nninter_core_elapsed += time.time() - t_before
                     return True

--- a/monai-label/monailabel/tasks/infer/basic_infer.py
+++ b/monai-label/monailabel/tasks/infer/basic_infer.py
@@ -2016,7 +2016,6 @@ class BasicInferTask(InferTask):
                 for lasso_raw in data['pos_lassos']:
                     if not self.is_prompt_used(used_interactions, lasso_raw, "pos_lassos"):
                         self.add_prompt(used_interactions, lasso_raw, "pos_lassos")
-                        _rp = _run_prediction_flag()
                         _t_prep = time.time()
                         perim = clean_and_densify_polyline(lasso_raw)
                         perim_arr = np.round(np.asarray(perim)).astype(int)
@@ -2026,6 +2025,7 @@ class BasicInferTask(InferTask):
                         prompt_prep_elapsed += time.time() - _t_prep
                         if lasso_image is None:
                             continue
+                        _rp = _run_prediction_flag()
                         if not _safe_interaction(
                             lambda img=lasso_image, bbox=interaction_bbox, rp=_rp: session.add_lasso_interaction(
                                 img, include_interaction=True, interaction_bbox=bbox, run_prediction=rp
@@ -2040,7 +2040,6 @@ class BasicInferTask(InferTask):
                 for lasso_raw in data['neg_lassos']:
                     if not self.is_prompt_used(used_interactions, lasso_raw, "neg_lassos"):
                         self.add_prompt(used_interactions, lasso_raw, "neg_lassos")
-                        _rp = _run_prediction_flag()
                         _t_prep = time.time()
                         perim = clean_and_densify_polyline(lasso_raw)
                         perim_arr = np.round(np.asarray(perim)).astype(int)
@@ -2050,6 +2049,7 @@ class BasicInferTask(InferTask):
                         prompt_prep_elapsed += time.time() - _t_prep
                         if lasso_image is None:
                             continue
+                        _rp = _run_prediction_flag()
                         if not _safe_interaction(
                             lambda img=lasso_image, bbox=interaction_bbox, rp=_rp: session.add_lasso_interaction(
                                 img, include_interaction=False, interaction_bbox=bbox, run_prediction=rp
@@ -2064,7 +2064,6 @@ class BasicInferTask(InferTask):
                 for scribble in data['pos_scribbles']:
                     if not self.is_prompt_used(used_interactions, scribble, "pos_scribbles"):
                         self.add_prompt(used_interactions, scribble, "pos_scribbles")
-                        _rp = _run_prediction_flag()
                         _t_prep = time.time()
                         scribble = clean_and_densify_polyline(scribble)
                         filled_indices = np.round(np.asarray(scribble)).astype(int)
@@ -2080,6 +2079,7 @@ class BasicInferTask(InferTask):
                         )
                         prompt_prep_elapsed += time.time() - _t_prep
                         scribble_start = time.time()
+                        _rp = _run_prediction_flag()
                         if interaction_bbox is not None:
                             if not _safe_interaction(
                                 lambda img=scribble_image, bbox=interaction_bbox, rp=_rp: session.add_scribble_interaction(
@@ -2103,7 +2103,6 @@ class BasicInferTask(InferTask):
                 for scribble in data['neg_scribbles']:
                     if not self.is_prompt_used(used_interactions, scribble, "neg_scribbles"):
                         self.add_prompt(used_interactions, scribble, "neg_scribbles")
-                        _rp = _run_prediction_flag()
                         _t_prep = time.time()
                         scribble = clean_and_densify_polyline(scribble)
                         filled_indices = np.round(np.asarray(scribble)).astype(int)
@@ -2118,6 +2117,7 @@ class BasicInferTask(InferTask):
                             img_np.shape[1:], filled_indices, flat_axis
                         )
                         prompt_prep_elapsed += time.time() - _t_prep
+                        _rp = _run_prediction_flag()
                         if interaction_bbox is not None:
                             if not _safe_interaction(
                                 lambda img=scribble_image, bbox=interaction_bbox, rp=_rp: session.add_scribble_interaction(
@@ -2132,6 +2132,18 @@ class BasicInferTask(InferTask):
                         ):
                             return f'/code/predictions/reset.nii.gz', final_result_json
                         logger.info("Add a scribble")
+
+            # Safety net for the replay optimization: degenerate prompts (empty
+            # polylines/scribbles) are counted in _pending_total but skip their
+            # session call, so the flag may never fire and the last real
+            # interaction may have run with run_prediction=False. If anything
+            # was applied but the flag never reached the last pending prompt,
+            # force one prediction now. _predict() is the same internal the
+            # session runs when run_prediction=True (this file already relies
+            # on session internals, e.g. _reset_session()).
+            if 0 < _applied_count < _pending_total:
+                if not _safe_interaction(lambda: session._predict()):
+                    return f'/code/predictions/reset.nii.gz', final_result_json
 
             # --- Retrieve Results ---
             _t_result = time.time()

--- a/monai-label/monailabel/tasks/infer/basic_infer.py
+++ b/monai-label/monailabel/tasks/infer/basic_infer.py
@@ -121,6 +121,9 @@ from monailabel.tasks.infer.nninter_session_pool import (
     set_pool,
 )
 
+# VLM ops ride the nninter param but never touch the nnInteractive session.
+_NNI_VLM_OPS = ("medGemma", "gemini", "openai", "claude", "kimi", "qwen", "gemma", "vllm")
+
 model_path = os.path.join(DOWNLOAD_DIR, MODEL_NAME)
 
 # Load model artifacts (weights, plans, capability metadata) from disk ONCE.
@@ -880,26 +883,6 @@ class BasicInferTask(InferTask):
         self.train_mode = train_mode
         self.skip_writer = skip_writer
 
-        self._session_image: Dict[str, Any] = {
-            "dicom_dir": None,        # normalised path MONAI served (level-1 key: exact path match)
-            "seriesInstanceUID": None, # DICOM tag (0020,000E) UID (level-2 key: works if path changes)
-            "img_np": None,           # cached [1,z,y,x] array; populated on init, reused for interactions
-            "instanceNumber": None,   # first DICOM file's InstanceNumber (used for flip detection)
-            "instanceNumber2": None,  # second DICOM file's InstanceNumber
-        }
-
-
-        self._session_used_interactions = {
-            "pos_points": set(),
-            "neg_points": set(),
-            "pos_boxes": set(),
-            "neg_boxes": set(),
-            "pos_lassos": set(),
-            "neg_lassos": set(),
-            "pos_scribbles": set(),
-            "neg_scribbles": set(),
-        }
-
         self._networks: Dict = {}
 
         self._config.update(
@@ -1056,17 +1039,46 @@ class BasicInferTask(InferTask):
         return None
 
     # When adding any type of prompt:
-    def add_prompt(self, prompt, prompt_type):
+    def add_prompt(self, used_interactions, prompt, prompt_type):
         prompt_hash = hashlib.md5(np.array(prompt).tobytes()).hexdigest()
-        self._session_used_interactions[prompt_type].add(prompt_hash)
+        used_interactions[prompt_type].add(prompt_hash)
 
     # When checking any type of prompt:
-    def is_prompt_used(self, prompt, prompt_type):
+    def is_prompt_used(self, used_interactions, prompt, prompt_type):
         prompt_hash = hashlib.md5(np.array(prompt).tobytes()).hexdigest()
-        return prompt_hash in self._session_used_interactions[prompt_type]
+        return prompt_hash in used_interactions[prompt_type]
 
     def __call__(
         self, request, callbacks: Union[Dict[CallBackTypes, Any], None] = None
+    ) -> Union[Dict, Tuple[str, Dict[str, Any]]]:
+        op = request.get("nninter")
+        needs_session = bool(request.get("nninter_reset_first")) or (
+            bool(op) and op not in _NNI_VLM_OPS
+        )
+        if not needs_session:
+            return self._call_core(request, callbacks, entry=None)
+
+        entry = get_pool().get(request.get("nninter_token"))
+        if entry is None:
+            # Expired / evicted / missing token. HTTP 200 in the normal
+            # response shapes; the client re-claims and replays on seeing
+            # nninter_op == "session_expired".
+            logger.warning(f"nninter session expired/missing for op={op!r}")
+            if op == "reset":
+                return "/code/predictions/reset.nii.gz", {}
+            expired_json = {
+                "nninter_op": "session_expired",
+                "label_name": "session_expired",
+                "server_end_ts": time.time(),
+            }
+            if op == "init":
+                return "/code/predictions/session_expired.nii.gz", expired_json
+            return np.zeros((0, 0, 0), dtype=np.uint8), expired_json
+        with entry.lock:
+            return self._call_core(request, callbacks, entry=entry)
+
+    def _call_core(
+        self, request, callbacks: Union[Dict[CallBackTypes, Any], None] = None, entry=None
     ) -> Union[Dict, Tuple[str, Dict[str, Any]]]:
         """
         It provides basic implementation to run the following in order
@@ -1084,9 +1096,19 @@ class BasicInferTask(InferTask):
         begin = time.time()
         server_begin_ts = begin  # Unix timestamp; client uses this to estimate network-to-server latency
 
+        # Per-entry state (None for SAM/VLM requests, which never touch these).
+        if entry is not None:
+            session = entry.session
+            image_cache = entry.image_cache
+            used_interactions = entry.used_interactions
+        else:
+            session = None
+            image_cache = None
+            used_interactions = None
+
         # Fast path: reset does not need config merge, image loading, or deep copy
         if request.get('nninter') == "reset":
-            for key, lst in self._session_used_interactions.items():
+            for key, lst in used_interactions.items():
                 lst.clear()
             session.reset_interactions()
             # Image cache (_session_image) is intentionally kept: session.reset_interactions()
@@ -1143,8 +1165,8 @@ class BasicInferTask(InferTask):
             undo_json["pred_full_shape"] = pred_full_shape
             undo_json["pred_crop_shape"] = list(pred.shape)
 
-            _inst = self._session_image.get("instanceNumber")
-            _inst2 = self._session_image.get("instanceNumber2")
+            _inst = image_cache.get("instanceNumber")
+            _inst2 = image_cache.get("instanceNumber2")
             undo_json["flipped"] = bool(_inst is not None and _inst2 is not None and _inst > _inst2)
 
             undo_json["label_name"] = f"nninter_pred_{datetime.now().strftime('%Y%m%d%H%M%S')}"
@@ -1166,7 +1188,7 @@ class BasicInferTask(InferTask):
         # Resetting here (before image loading) keeps the same semantics as a
         # separate reset call, but saves ~1.4 s of network overhead on slow links.
         if request.get('nninter_reset_first'):
-            for key, lst in self._session_used_interactions.items():
+            for key, lst in used_interactions.items():
                 lst.clear()
             session.reset_interactions()
             logger.info("Folded reset before inference")
@@ -1209,7 +1231,10 @@ class BasicInferTask(InferTask):
                         "kimi", "qwen", "gemma", "vllm")
         _is_nninter_interaction = nnInter and nnInter not in _NNI_EXCLUDE
 
-        logger.info(f"dicom_dir={dicom_dir!r}  cached_dicom_dir={self._session_image['dicom_dir']!r}  cached_uid={self._session_image['seriesInstanceUID']!r}")
+        logger.info(
+            f"dicom_dir={dicom_dir!r}  cached_dicom_dir={(image_cache or {}).get('dicom_dir')!r}"
+            f"  cached_uid={(image_cache or {}).get('seriesInstanceUID')!r}"
+        )
 
         # Level-1: full cache hit — skip GetGDCMSeriesFileNames, dcmread x2,
         # reader.Execute, and sitk.GetArrayFromImage entirely.
@@ -1219,18 +1244,18 @@ class BasicInferTask(InferTask):
         # block will fire, so computing it fresh would be pure wasted work.
         _img_np_hit = (
             (_is_nninter_interaction or nnInter == "init")
-            and dicom_dir == self._session_image["dicom_dir"]
-            and self._session_image["img_np"] is not None
-            and self._session_image["instanceNumber"] is not None
+            and dicom_dir == image_cache["dicom_dir"]
+            and image_cache["img_np"] is not None
+            and image_cache["instanceNumber"] is not None
         )
 
         _pixel_hit = False    # may be set True inside the else branch below
         _disk_hit = False     # may be set True if disk cache found
         _disk_cache_path = None
         if _img_np_hit:
-            seriesInstanceUID = self._session_image["seriesInstanceUID"]
-            instanceNumber    = self._session_image["instanceNumber"]
-            instanceNumber2   = self._session_image["instanceNumber2"]
+            seriesInstanceUID = image_cache["seriesInstanceUID"]
+            instanceNumber    = image_cache["instanceNumber"]
+            instanceNumber2   = image_cache["instanceNumber2"]
             img_convert_elapsed = 0.0
             logger.info("img_np cache hit — skipping all DICOM I/O")
         else:
@@ -1285,18 +1310,18 @@ class BasicInferTask(InferTask):
             # → skip reader.Execute + sitk.GetArrayFromImage, keep header metadata.
             _pixel_hit = (
                 _is_nninter_interaction
-                and seriesInstanceUID == self._session_image["seriesInstanceUID"]
-                and self._session_image["img_np"] is not None
+                and seriesInstanceUID == image_cache["seriesInstanceUID"]
+                and image_cache["img_np"] is not None
             )
 
             if _pixel_hit:
                 logger.info("img_np pixel-cache hit (path UID changed) — skipping reader.Execute")
             else:
                 if _is_nninter_interaction:
-                    cached_uid = self._session_image["seriesInstanceUID"]
+                    cached_uid = image_cache["seriesInstanceUID"]
                     if cached_uid != seriesInstanceUID:
                         logger.info(f"img_np cache MISS — UID mismatch: cached={cached_uid!r} incoming={seriesInstanceUID!r}")
-                    elif self._session_image["img_np"] is None:
+                    elif image_cache["img_np"] is None:
                         logger.info("img_np cache MISS — not yet initialised")
                 # Level-3: disk cache — skip reader.Execute + sitk.GetArrayFromImage on hit.
                 # Key: md5(dicom_dir) — stable across container restarts for the same DICOM series.
@@ -1321,7 +1346,7 @@ class BasicInferTask(InferTask):
             prompt_prep_elapsed = 0.0           # lasso/scribble mask building (CPU, excludes model calls)
 
             if _img_np_hit or _pixel_hit:
-                img_np = self._session_image["img_np"]
+                img_np = image_cache["img_np"]
                 img_convert_elapsed = 0.0
             elif _disk_hit:
                 img_convert_elapsed = 0.0
@@ -1349,18 +1374,18 @@ class BasicInferTask(InferTask):
                 # session uninitialized, so the next interaction timed out on preprocessed_image.
                 _uid_changed = (
                     seriesInstanceUID is not None
-                    and self._session_image["seriesInstanceUID"] != seriesInstanceUID
+                    and image_cache["seriesInstanceUID"] != seriesInstanceUID
                 )
                 _session_needs_image = (
                     getattr(session, "original_image_shape", None) is None
                     or getattr(session, "preprocessed_image", None) is None
                 )
                 if _uid_changed or _session_needs_image:
-                    self._session_image["dicom_dir"]       = dicom_dir
-                    self._session_image["seriesInstanceUID"] = seriesInstanceUID
-                    self._session_image["img_np"]          = img_np
-                    self._session_image["instanceNumber"]  = instanceNumber
-                    self._session_image["instanceNumber2"] = instanceNumber2
+                    image_cache["dicom_dir"]       = dicom_dir
+                    image_cache["seriesInstanceUID"] = seriesInstanceUID
+                    image_cache["img_np"]          = img_np
+                    image_cache["instanceNumber"]  = instanceNumber
+                    image_cache["instanceNumber2"] = instanceNumber2
                     try:
                         logger.info(f"init set_image (uid_changed={_uid_changed}, session_needs_image={_session_needs_image})")
                         session.set_image(img_np)
@@ -1368,20 +1393,20 @@ class BasicInferTask(InferTask):
                     except Exception as init_error:
                         logger.error(f"Failed to initialize session: {init_error}")
                         logger.info("Prefer fail!!")
-                elif self._session_image["img_np"] is None:
+                elif image_cache["img_np"] is None:
                     # Same series but cache was cleared; repopulate
-                    self._session_image["dicom_dir"]       = dicom_dir
-                    self._session_image["img_np"]          = img_np
-                    self._session_image["instanceNumber"]  = instanceNumber
-                    self._session_image["instanceNumber2"] = instanceNumber2
-                for key, lst in self._session_used_interactions.items():
+                    image_cache["dicom_dir"]       = dicom_dir
+                    image_cache["img_np"]          = img_np
+                    image_cache["instanceNumber"]  = instanceNumber
+                    image_cache["instanceNumber2"] = instanceNumber2
+                for key, lst in used_interactions.items():
                     lst.clear()
                 _t_reset = time.time()
                 session.reset_interactions()
                 logger.info(f"[timing] session.reset_interactions: {time.time()-_t_reset:.3f}s")
                 return f'/code/predictions/init.nii.gz', final_result_json
 
-            logger.info(f"interactions in _session_used_interactions: {self._session_used_interactions}")
+            logger.info(f"interactions in _session_used_interactions: {used_interactions}")
 
             if nnInter in (
                 "medGemma",
@@ -1834,9 +1859,9 @@ class BasicInferTask(InferTask):
                         # If that's not possible, shutdown the executor and assign new one.
                         logger.info(f"Check queue size: {session.executor._work_queue.qsize()}")
                         logger.info("Set image and target buffer before interaction")
-                        if seriesInstanceUID is not None and self._session_image["seriesInstanceUID"] != seriesInstanceUID:
+                        if seriesInstanceUID is not None and image_cache["seriesInstanceUID"] != seriesInstanceUID:
                             logger.info("Series Instance UID changed -> update")
-                            self._session_image["seriesInstanceUID"] = seriesInstanceUID
+                            image_cache["seriesInstanceUID"] = seriesInstanceUID
                         # Do NOT gate on preprocess_future being None: a stale future left over
                         # from a shut-down executor would otherwise skip set_image, and we'd wait
                         # the full 5s for a preprocess that never runs (then loop on shutdown).
@@ -1890,8 +1915,8 @@ class BasicInferTask(InferTask):
                 result_json["pos_points"]=copy.deepcopy(data["pos_points"])
                 
                 for point in data['pos_points']:
-                    if not self.is_prompt_used(point, "pos_points"):
-                        self.add_prompt(point, "pos_points")
+                    if not self.is_prompt_used(used_interactions, point, "pos_points"):
+                        self.add_prompt(used_interactions, point, "pos_points")
                         if instanceNumber > instanceNumber2:
                             point[2]=img_np.shape[1]-1-point[2]
                         if not _safe_interaction(lambda: session.add_point_interaction(tuple(point[::-1]), include_interaction=True)):
@@ -1902,8 +1927,8 @@ class BasicInferTask(InferTask):
                 result_json["neg_points"]=copy.deepcopy(data["neg_points"])
                 
                 for point in data['neg_points']:
-                    if not self.is_prompt_used(point, "neg_points"):
-                        self.add_prompt(point, "neg_points")
+                    if not self.is_prompt_used(used_interactions, point, "neg_points"):
+                        self.add_prompt(used_interactions, point, "neg_points")
                         if instanceNumber > instanceNumber2:
                             point[2]=img_np.shape[1]-1-point[2]
                         if not _safe_interaction(lambda: session.add_point_interaction(tuple(point[::-1]), include_interaction=False)):
@@ -1914,8 +1939,8 @@ class BasicInferTask(InferTask):
                 result_json["pos_boxes"]=copy.deepcopy(data["pos_boxes"])
                 
                 for box in data['pos_boxes']:
-                    if not self.is_prompt_used(box, "pos_boxes"):
-                        self.add_prompt(box, "pos_boxes")
+                    if not self.is_prompt_used(used_interactions, box, "pos_boxes"):
+                        self.add_prompt(used_interactions, box, "pos_boxes")
                         if instanceNumber > instanceNumber2:
                             box[0][2]=img_np.shape[1]-1-box[0][2]
                             box[1][2]=img_np.shape[1]-1-box[1][2]
@@ -1936,8 +1961,8 @@ class BasicInferTask(InferTask):
                 result_json["neg_boxes"]=copy.deepcopy(data["neg_boxes"])
                 
                 for box in data['neg_boxes']:
-                    if not self.is_prompt_used(box, "neg_boxes"):
-                        self.add_prompt(box, "neg_boxes")
+                    if not self.is_prompt_used(used_interactions, box, "neg_boxes"):
+                        self.add_prompt(used_interactions, box, "neg_boxes")
                         if instanceNumber > instanceNumber2:
                             box[0][2]=img_np.shape[1]-1-box[0][2]
                             box[1][2]=img_np.shape[1]-1-box[1][2]
@@ -1959,8 +1984,8 @@ class BasicInferTask(InferTask):
                 result_json["pos_lassos"]=copy.deepcopy(data["pos_lassos"])
 
                 for lasso_raw in data['pos_lassos']:
-                    if not self.is_prompt_used(lasso_raw, "pos_lassos"):
-                        self.add_prompt(lasso_raw, "pos_lassos")
+                    if not self.is_prompt_used(used_interactions, lasso_raw, "pos_lassos"):
+                        self.add_prompt(used_interactions, lasso_raw, "pos_lassos")
                         _t_prep = time.time()
                         perim = clean_and_densify_polyline(lasso_raw)
                         perim_arr = np.round(np.asarray(perim)).astype(int)
@@ -1982,8 +2007,8 @@ class BasicInferTask(InferTask):
                 result_json["neg_lassos"]=copy.deepcopy(data["neg_lassos"])
 
                 for lasso_raw in data['neg_lassos']:
-                    if not self.is_prompt_used(lasso_raw, "neg_lassos"):
-                        self.add_prompt(lasso_raw, "neg_lassos")
+                    if not self.is_prompt_used(used_interactions, lasso_raw, "neg_lassos"):
+                        self.add_prompt(used_interactions, lasso_raw, "neg_lassos")
                         _t_prep = time.time()
                         perim = clean_and_densify_polyline(lasso_raw)
                         perim_arr = np.round(np.asarray(perim)).astype(int)
@@ -2005,8 +2030,8 @@ class BasicInferTask(InferTask):
                 result_json["pos_scribbles"]=copy.deepcopy(data["pos_scribbles"])
 
                 for scribble in data['pos_scribbles']:
-                    if not self.is_prompt_used(scribble, "pos_scribbles"):
-                        self.add_prompt(scribble, "pos_scribbles")
+                    if not self.is_prompt_used(used_interactions, scribble, "pos_scribbles"):
+                        self.add_prompt(used_interactions, scribble, "pos_scribbles")
                         _t_prep = time.time()
                         scribble = clean_and_densify_polyline(scribble)
                         filled_indices = np.round(np.asarray(scribble)).astype(int)
@@ -2043,8 +2068,8 @@ class BasicInferTask(InferTask):
                 result_json["neg_scribbles"]=copy.deepcopy(data["neg_scribbles"])
 
                 for scribble in data['neg_scribbles']:
-                    if not self.is_prompt_used(scribble, "neg_scribbles"):
-                        self.add_prompt(scribble, "neg_scribbles")
+                    if not self.is_prompt_used(used_interactions, scribble, "neg_scribbles"):
+                        self.add_prompt(used_interactions, scribble, "neg_scribbles")
                         _t_prep = time.time()
                         scribble = clean_and_densify_polyline(scribble)
                         filled_indices = np.round(np.asarray(scribble)).astype(int)

--- a/monai-label/monailabel/tasks/infer/basic_infer.py
+++ b/monai-label/monailabel/tasks/infer/basic_infer.py
@@ -114,27 +114,62 @@ vox_predictor = VoxTellPredictor(model_dir=vox_model_path, device=torch.device("
 
 from nnInteractive.inference.inference_session import nnInteractiveInferenceSession
 
-session = nnInteractiveInferenceSession(
+from monailabel.tasks.infer.nninter_session_pool import (
+    _USED_INTERACTION_KEYS,
+    SessionPool,
+    get_pool,
+    set_pool,
+)
+
+model_path = os.path.join(DOWNLOAD_DIR, MODEL_NAME)
+
+# Load model artifacts (weights, plans, capability metadata) from disk ONCE.
+# Every pooled session receives them by reference via
+# initialize_from_loaded_artifacts(), so N sessions share one GPU copy of the
+# network; only per-study state (image tensors, buffers) is per-session.
+_artifact_loader = nnInteractiveInferenceSession(
     device=torch.device("cuda:0"),
     use_torch_compile=True,
     verbose=True,
     torch_n_threads=os.cpu_count(),
     do_autozoom=True,
 )
+_NNINTER_ARTIFACTS = _artifact_loader._load_model_artifacts_from_disk(model_path)
 
-model_path = os.path.join(DOWNLOAD_DIR, MODEL_NAME)
-session.initialize_from_trained_model_folder(model_path)
 
-# Warmup: trigger torch.compile JIT at startup so the first real inference is fast.
-# session.warmup() uses the correct patch_size from the model plan — no set_image needed.
+def _new_nninter_session() -> nnInteractiveInferenceSession:
+    s = nnInteractiveInferenceSession(
+        device=torch.device("cuda:0"),
+        use_torch_compile=True,
+        verbose=True,
+        torch_n_threads=os.cpu_count(),
+        do_autozoom=True,
+    )
+    s.initialize_from_loaded_artifacts(_NNINTER_ARTIFACTS)
+    return s
+
+
+set_pool(SessionPool(factory=_new_nninter_session))
+
+# Warmup: trigger torch.compile JIT at startup so the first real inference is
+# fast. warmup() uses the correct patch_size from the model plan — no set_image
+# needed. Afterwards the compiled network is published back into the shared
+# artifacts so pooled sessions reuse it instead of recompiling. Sessions
+# claimed before warmup finishes just compile-on-first-use (same as the old
+# single-global behavior).
 try:
     import threading
+
     def _warmup_session():
         import logging
+
         _wlog = logging.getLogger(__name__)
         _wlog.info("nnInteractive warmup: starting...")
-        ran = session.warmup()
+        _artifact_loader.initialize_from_loaded_artifacts(_NNINTER_ARTIFACTS)
+        ran = _artifact_loader.warmup()
+        _NNINTER_ARTIFACTS["network"] = _artifact_loader.network
         _wlog.info(f"nnInteractive warmup: {'done' if ran else 'skipped (torch.compile not enabled)'}.")
+
     threading.Thread(target=_warmup_session, daemon=True).start()
 except Exception as _warmup_err:
     print(f"nnInteractive warmup failed (non-fatal): {_warmup_err}")

--- a/monai-label/monailabel/tasks/infer/nninter_session_pool.py
+++ b/monai-label/monailabel/tasks/infer/nninter_session_pool.py
@@ -64,7 +64,7 @@ class SessionPool:
     ):
         self._factory = factory
         self.max_sessions = max(1, int(
-            max_sessions if max_sessions is not None else os.environ.get("NNINTER_MAX_SESSIONS", 3)
+            max_sessions if max_sessions is not None else os.environ.get("NNINTER_MAX_SESSIONS", 10)
         ))
         self.idle_timeout = float(
             idle_timeout if idle_timeout is not None else os.environ.get("NNINTER_SESSION_IDLE_TIMEOUT", 600)

--- a/monai-label/monailabel/tasks/infer/nninter_session_pool.py
+++ b/monai-label/monailabel/tasks/infer/nninter_session_pool.py
@@ -63,9 +63,9 @@ class SessionPool:
         start_reaper: bool = True,
     ):
         self._factory = factory
-        self.max_sessions = int(
+        self.max_sessions = max(1, int(
             max_sessions if max_sessions is not None else os.environ.get("NNINTER_MAX_SESSIONS", 3)
-        )
+        ))
         self.idle_timeout = float(
             idle_timeout if idle_timeout is not None else os.environ.get("NNINTER_SESSION_IDLE_TIMEOUT", 600)
         )

--- a/monai-label/monailabel/tasks/infer/nninter_session_pool.py
+++ b/monai-label/monailabel/tasks/infer/nninter_session_pool.py
@@ -1,0 +1,150 @@
+"""In-process session pool for nnInteractive multi-user support.
+
+Replicates the coordination pattern of nnInteractive's own server
+(nnInteractive/inference/server/app.py) without its FastAPI layer:
+one copy of the model weights shared by reference across N real
+nnInteractiveInferenceSession instances, a per-session lock, a global
+GPU lock, lease tokens, LRU eviction, and idle reaping.
+
+Lock order is ALWAYS entry.lock -> gpu_lock, never reversed.
+Stdlib-only on purpose: unit-testable without torch or a GPU.
+"""
+
+import logging
+import os
+import threading
+import time
+import uuid
+from typing import Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_USED_INTERACTION_KEYS = (
+    "pos_points",
+    "neg_points",
+    "pos_boxes",
+    "neg_boxes",
+    "pos_lassos",
+    "neg_lassos",
+    "pos_scribbles",
+    "neg_scribbles",
+)
+
+
+class SessionEntry:
+    """Per-client nnInteractive state: one real inference session plus the
+    image cache and used-interaction sets that used to be process-global."""
+
+    def __init__(self, token: str, session):
+        self.token = token
+        self.session = session
+        self.lock = threading.Lock()
+        self.last_active = time.time()
+        self.image_cache = {
+            "dicom_dir": None,
+            "seriesInstanceUID": None,
+            "img_np": None,
+            "instanceNumber": None,
+            "instanceNumber2": None,
+        }
+        self.used_interactions = {k: set() for k in _USED_INTERACTION_KEYS}
+
+    def touch(self):
+        self.last_active = time.time()
+
+
+class SessionPool:
+    def __init__(
+        self,
+        factory: Callable[[], object],
+        max_sessions: Optional[int] = None,
+        idle_timeout: Optional[float] = None,
+        reap_interval: float = 60.0,
+        start_reaper: bool = True,
+    ):
+        self._factory = factory
+        self.max_sessions = int(
+            max_sessions if max_sessions is not None else os.environ.get("NNINTER_MAX_SESSIONS", 3)
+        )
+        self.idle_timeout = float(
+            idle_timeout if idle_timeout is not None else os.environ.get("NNINTER_SESSION_IDLE_TIMEOUT", 600)
+        )
+        self.gpu_lock = threading.Lock()
+        self._entries: Dict[str, SessionEntry] = {}
+        self._dict_lock = threading.Lock()
+        self._reap_interval = reap_interval
+        if start_reaper:
+            threading.Thread(
+                target=self._reaper_loop, name="nninter-session-reaper", daemon=True
+            ).start()
+
+    def claim(self) -> SessionEntry:
+        token = uuid.uuid4().hex
+        with self._dict_lock:
+            while len(self._entries) >= self.max_sessions:
+                lru = min(self._entries.values(), key=lambda e: e.last_active)
+                self._drop_locked(lru.token, reason="lru-evicted")
+            entry = SessionEntry(token, self._factory())
+            self._entries[token] = entry
+        logger.info(f"nninter session claimed: {token[:8]} (pool {self.size()}/{self.max_sessions})")
+        return entry
+
+    def get(self, token: Optional[str]) -> Optional[SessionEntry]:
+        if not token:
+            return None
+        with self._dict_lock:
+            entry = self._entries.get(token)
+        if entry is not None:
+            entry.touch()
+        return entry
+
+    def release(self, token: Optional[str]):
+        with self._dict_lock:
+            self._drop_locked(token, reason="released")
+
+    def size(self) -> int:
+        with self._dict_lock:
+            return len(self._entries)
+
+    def sweep(self):
+        now = time.time()
+        with self._dict_lock:
+            idle = [t for t, e in self._entries.items() if now - e.last_active > self.idle_timeout]
+            for t in idle:
+                self._drop_locked(t, reason="idle-reaped")
+
+    def _drop_locked(self, token: Optional[str], reason: str = ""):
+        # Caller must hold self._dict_lock. An in-flight request holding a
+        # reference to the dropped entry finishes harmlessly on the detached
+        # entry; its tensors are freed when the last reference drops.
+        entry = self._entries.pop(token, None) if token else None
+        if entry is None:
+            return
+        try:
+            entry.session.executor.shutdown(wait=False, cancel_futures=True)
+        except Exception:
+            pass
+        logger.info(f"nninter session dropped ({reason}): {entry.token[:8]}")
+
+    def _reaper_loop(self):
+        while True:
+            time.sleep(self._reap_interval)
+            try:
+                self.sweep()
+            except Exception:
+                logger.exception("nninter session reaper sweep failed")
+
+
+# Process-wide singleton, published by basic_infer at startup.
+POOL: Optional[SessionPool] = None
+
+
+def set_pool(pool: SessionPool):
+    global POOL
+    POOL = pool
+
+
+def get_pool() -> SessionPool:
+    if POOL is None:
+        raise RuntimeError("nnInteractive session pool is not initialised")
+    return POOL


### PR DESCRIPTION
## Summary

Replaces the single module-global `nnInteractiveInferenceSession` (which let concurrent users silently corrupt each other's image/interaction/undo state) with an in-process multi-session pool inside monai-label — no second FastAPI service, no extra HTTP hop.

**Server (monai-label):**
- New `nninter_session_pool.py`: `SessionPool`/`SessionEntry` — per-client real `nnInteractiveInferenceSession`s sharing ONE GPU copy of the model weights via `initialize_from_loaded_artifacts()` (pattern borrowed from nnInteractive's own server, minus its FastAPI layer). Per-entry lock → global GPU lock (predictions serialized; preprocessing/packaging concurrent), LRU eviction on claim past capacity, idle reaping (600s), stdlib-only and unit-tested (13 tests).
- New endpoints: `POST /nninter/session/` (claim) and `POST /nninter/session/{token}/release` (idempotent; POST because `sendBeacon` can't DELETE).
- `basic_infer.py`: model artifacts loaded once at startup; all nnInteractive state (image cache, used-interaction sets, undo) moved into per-token entries; expired/missing tokens get HTTP 200 `nninter_op: "session_expired"` responses; GPU-lock waits don't burn the interaction timeout (no cross-user session resets).
- Replay optimization: a request with N unapplied prompts runs exactly one GPU prediction (`run_prediction=False` for earlier ones, plus a `session._predict()` safety net for degenerate-prompt edge cases).

**Client (OHIF):**
- `nninterSession.ts`: lazy token claim (deduped), `clearNninterToken()`, `pagehide` → `sendBeacon` release.
- The 4 session-touching ops (init/interactions/undo/reset) send `nninter_token` in params; VLM/SAM paths untouched.
- On `session_expired`: automatic re-claim → re-init → replay of the full prompt history (client already sends all prompts per request), with a 5s loop guard.

**Config:** `NNINTER_MAX_SESSIONS` (default 10) and `NNINTER_SESSION_IDLE_TIMEOUT` (default 600) env vars; defaults live in code. Compose passthrough lines are intentionally not included here (local compose carries environment-specific port/GPU edits) — set the env vars per deployment as needed.

## Testing

- 13 unit tests (pool semantics: claim/get/release, LRU eviction, idle sweep, concurrent-claim capacity, clamp; endpoint routing) — all passing in the container. Test files are intentionally not part of this PR; they run locally/in-container.
- Claim/release concurrency smoke (2x25 parallel loops) against the live server.
- Manual: two browser tabs on different studies segment in full isolation (verified); expired-token recovery exercised end-to-end during rollout (old bundle -> tokenless requests -> `session_expired` responses as designed).
- Per-task + whole-branch multi-model code review; the whole-branch review caught (and we fixed) an integration bug where the client's multipart parser threw on the empty expired-response mask before the recovery branch could run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
