### PR TITLE
feat(hotkeys): hotkeys follow the mouse across OHIF browser windows

### DIFF
--- a/Viewers/extensions/cornerstone/src/init.tsx
+++ b/Viewers/extensions/cornerstone/src/init.tsx
@@ -103,6 +103,47 @@ export default async function init({
   window.extensionManager = extensionManager;
   window.commandsManager = commandsManager;
 
+  // Single-click window activation: when this browser window gains OS focus,
+  // activate the viewport pane under the mouse cursor. The first click on an
+  // unfocused window may be swallowed by the OS/window manager (it only
+  // focuses the window), which otherwise forces a second click before
+  // hotkeys target the intended pane.
+  const lastMousePosition = { x: NaN, y: NaN };
+  const trackMousePosition = (event: MouseEvent) => {
+    lastMousePosition.x = event.clientX;
+    lastMousePosition.y = event.clientY;
+  };
+  const activateViewportUnderCursor = () => {
+    const { viewports, activeViewportId } = viewportGridService.getState() || {};
+    if (!viewports || Number.isNaN(lastMousePosition.x)) {
+      return;
+    }
+    const viewportIds =
+      viewports instanceof Map ? [...viewports.keys()] : Object.keys(viewports);
+    for (const viewportId of viewportIds) {
+      const element = cornerstoneViewportService.getCornerstoneViewport(viewportId)?.element;
+      if (!element) {
+        continue;
+      }
+      const rect = element.getBoundingClientRect();
+      const inside =
+        lastMousePosition.x >= rect.left &&
+        lastMousePosition.x <= rect.right &&
+        lastMousePosition.y >= rect.top &&
+        lastMousePosition.y <= rect.bottom;
+      if (inside) {
+        if (viewportId !== activeViewportId) {
+          viewportGridService.setActiveViewportId(viewportId);
+        }
+        break;
+      }
+    }
+  };
+  document.addEventListener('mousemove', trackMousePosition, true);
+  // Defer so the focus transition (and a delivered click's own pane
+  // activation) settles first; ours then confirms or fills the gap.
+  window.addEventListener('focus', () => setTimeout(activateViewportUnderCursor, 0));
+
   if (appConfig.showCPUFallbackMessage && cornerstone.getShouldUseCPURendering()) {
     _showCPURenderingModal(uiModalService, hangingProtocolService);
   }

--- a/Viewers/extensions/default/src/utils/Toolbox.tsx
+++ b/Viewers/extensions/default/src/utils/Toolbox.tsx
@@ -28,7 +28,7 @@ interface ButtonProps {
  * and display various tools and their corresponding options
  */
 export function Toolbox({ buttonSectionId, title, defaultOpen = true }: { buttonSectionId: string; title: string; defaultOpen?: boolean }) {
-  const { servicesManager, commandsManager } = useSystem();
+  const { servicesManager, commandsManager, hotkeysManager } = useSystem();
   const { t } = useTranslation();
 
   const { toolbarService, customizationService, segmentationService, viewportGridService, measurementService } = servicesManager.services;
@@ -174,53 +174,46 @@ export function Toolbox({ buttonSectionId, title, defaultOpen = true }: { button
       return;
     }
 
-    const handleKeyDown = (event: KeyboardEvent) => {
-      const activeElement = document.activeElement;
-      const isInputField = activeElement?.tagName === 'INPUT' ||
-                           activeElement?.tagName === 'TEXTAREA' ||
-                           (activeElement as HTMLElement)?.contentEditable === 'true';
-      if (isInputField) return;
+    // Plain, structured-cloneable summary of a keydown — also what gets
+    // forwarded to sibling OHIF windows via hotkeysManager.
+    type AiKeyDescriptor = { key: string; ctrlKey: boolean; shiftKey: boolean };
 
-      switch (event.key.toLowerCase()) {
+    // Keys owned by the AI toolbox (must stay in sync with runAiKeyAction).
+    const matchesAiKey = ({ key, ctrlKey, shiftKey }: AiKeyDescriptor) => {
+      const k = key.toLowerCase();
+      if (k === 'z') {
+        return ctrlKey && !shiftKey;
+      }
+      return ['q', 't', 'p', 'b', 's', 'l', 'm', 'r', 'o', 'delete'].includes(k);
+    };
+
+    const runAiKeyAction = (descriptor: AiKeyDescriptor) => {
+      switch (descriptor.key.toLowerCase()) {
         case 'q': {
-          event.preventDefault();
-          event.stopPropagation();
           const newLiveMode = !toolboxState.getLiveMode();
           setLiveMode(newLiveMode);
           toolboxState.setLiveMode(newLiveMode);
           break;
         }
         case 't': {
-          event.preventDefault();
-          event.stopPropagation();
           const newPosNeg = !toolboxState.getPosNeg();
           setPosNeg(newPosNeg);
           toolboxState.setPosNeg(newPosNeg);
           break;
         }
         case 'p':
-          event.preventDefault();
-          event.stopPropagation();
           onInteractionRef.current?.({ itemId: 'Probe2' });
           break;
         case 'b':
-          event.preventDefault();
-          event.stopPropagation();
           onInteractionRef.current?.({ itemId: 'RectangleROI2' });
           break;
         case 's':
-          event.preventDefault();
-          event.stopPropagation();
           onInteractionRef.current?.({ itemId: 'PlanarFreehandROI2' });
           break;
         case 'l':
-          event.preventDefault();
-          event.stopPropagation();
           onInteractionRef.current?.({ itemId: 'PlanarFreehandROI3' });
           break;
         case 'm': {
-          event.preventDefault();
-          event.stopPropagation();
           const { activeViewportId: avId } = viewportGridService.getState();
           const activeSeg = segmentationService.getActiveSegmentation(avId)
             ?? segmentationService.getSegmentations()?.[0];
@@ -234,8 +227,6 @@ export function Toolbox({ buttonSectionId, title, defaultOpen = true }: { button
           break;
         }
         case 'r': {
-          event.preventDefault();
-          event.stopPropagation();
           const { activeViewportId: avId } = viewportGridService.getState();
           const activeSeg = segmentationService.getActiveSegmentation(avId);
           const activeSeg2 = segmentationService.getActiveSegment(avId);
@@ -248,8 +239,6 @@ export function Toolbox({ buttonSectionId, title, defaultOpen = true }: { button
           break;
         }
         case 'o': {
-          event.preventDefault();
-          event.stopPropagation();
           const next = !toolboxState.getPromptsVisible();
           toolboxState.setPromptsVisible(next);
           const AI_PROMPT_TOOLS = ['Probe2', 'RectangleROI2', 'PlanarFreehandROI2', 'PlanarFreehandROI3'];
@@ -261,16 +250,12 @@ export function Toolbox({ buttonSectionId, title, defaultOpen = true }: { button
           break;
         }
         case 'z': {
-          if (event.ctrlKey && !event.shiftKey) {
-            event.preventDefault();
-            event.stopPropagation();
+          if (descriptor.ctrlKey && !descriptor.shiftKey) {
             commandsManager.run('undoNninter');
           }
           break;
         }
         case 'delete': {
-          event.preventDefault();
-          event.stopPropagation();
           const { activeViewportId: avId } = viewportGridService.getState();
           const activeSeg = segmentationService.getActiveSegmentation(avId);
           const activeSeg2 = segmentationService.getActiveSegment(avId);
@@ -290,10 +275,45 @@ export function Toolbox({ buttonSectionId, title, defaultOpen = true }: { button
       }
     };
 
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const activeElement = document.activeElement;
+      const isInputField = activeElement?.tagName === 'INPUT' ||
+                           activeElement?.tagName === 'TEXTAREA' ||
+                           (activeElement as HTMLElement)?.contentEditable === 'true';
+      if (isInputField) return;
+
+      const descriptor: AiKeyDescriptor = {
+        key: event.key,
+        ctrlKey: event.ctrlKey,
+        shiftKey: event.shiftKey,
+      };
+      if (!matchesAiKey(descriptor)) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      // Same follow-the-mouse routing as Mousetrap hotkeys: act here unless
+      // a sibling OHIF window has the cursor — then hand the key to it.
+      if (hotkeysManager.shouldRunLocally()) {
+        runAiKeyAction(descriptor);
+      } else {
+        hotkeysManager.forwardKeyEvent(descriptor);
+      }
+    };
+
+    // Keys forwarded from a sibling window while the cursor is over this one.
+    const unsubscribeForwarded = hotkeysManager.subscribeForwardedKeys(descriptor => {
+      if (matchesAiKey(descriptor)) {
+        runAiKeyAction(descriptor);
+      }
+    });
+
     // Use capture phase so this fires before Mousetrap (bubble phase), preventing
     // global hotkey bindings from also firing for keys we own in the AI toolbox.
     document.addEventListener('keydown', handleKeyDown, true);
-    return () => document.removeEventListener('keydown', handleKeyDown, true);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown, true);
+      unsubscribeForwarded();
+    };
   }, [hotkeysDisabled, isAIToolBox]);
 
 

--- a/Viewers/platform/core/src/classes/HotkeysManager.ts
+++ b/Viewers/platform/core/src/classes/HotkeysManager.ts
@@ -224,12 +224,25 @@ export class HotkeysManager {
     this._channel?.postMessage({ type: 'bye', id: this._instanceId });
   };
 
+  /**
+   * Re-announces this window on the channel. The startup hello can be missed
+   * when several windows (re)load around the same time or before the app has
+   * bound its hotkeys, and nothing else would ever heal the mesh — so we also
+   * announce on window focus and on becoming visible. Receivers use a Set, so
+   * repeated hellos are idempotent.
+   */
+  private _announcePresence = () => {
+    this._channel?.postMessage({ type: 'hello', id: this._instanceId });
+  };
+
   // Tab-switching away fires no mouseleave, so _hasMouse would otherwise
   // stay stuck true and a hidden tab could execute (or double-execute)
   // forwarded commands invisibly.
   private _onVisibilityChange = () => {
     if (document.hidden) {
       this._hasMouse = false;
+    } else {
+      this._announcePresence();
     }
   };
 
@@ -290,13 +303,22 @@ export class HotkeysManager {
     }
     this._channel = new BroadcastChannel('ohif-hotkeys');
     this._channel.onmessage = this._onChannelMessage;
-    this._channel.postMessage({ type: 'hello', id: this._instanceId });
+    this._announcePresence();
     document.documentElement.addEventListener('mouseenter', this._onMousePresent);
     document.documentElement.addEventListener('mouseleave', this._onMouseLeave);
     document.addEventListener('mousemove', this._onMousePresent);
     window.addEventListener('pagehide', this._onPageHide);
     document.addEventListener('visibilitychange', this._onVisibilityChange);
     window.addEventListener('pageshow', this._onPageShow);
+    window.addEventListener('focus', this._announcePresence);
+    // Console-inspectable routing state for field debugging.
+    (window as any).__ohifHotkeysRouting = () => ({
+      instanceId: this._instanceId,
+      siblings: [...this._siblings],
+      hasMouse: this._hasMouse,
+      enabled: this.isEnabled,
+      keySubscribers: this._keySubscribers.size,
+    });
   }
 
   /**
@@ -358,6 +380,8 @@ export class HotkeysManager {
     window.removeEventListener('pagehide', this._onPageHide);
     document.removeEventListener('visibilitychange', this._onVisibilityChange);
     window.removeEventListener('pageshow', this._onPageShow);
+    window.removeEventListener('focus', this._announcePresence);
+    delete (window as any).__ohifHotkeysRouting;
   }
 
   /**

--- a/Viewers/platform/core/src/classes/HotkeysManager.ts
+++ b/Viewers/platform/core/src/classes/HotkeysManager.ts
@@ -18,6 +18,13 @@ export class HotkeysManager {
   private isEnabled: boolean = true;
   public hotkeyDefinitions: Record<string, any> = {};
   public hotkeyDefaults: any[] = [];
+  /** True while the mouse cursor is inside this browser window. */
+  private _hasMouse: boolean = false;
+  /** Channel connecting all same-origin OHIF windows for hotkey routing. */
+  private _channel: BroadcastChannel | null = null;
+  /** Instance ids of other OHIF windows currently on the channel. */
+  private _siblings: Set<string> = new Set();
+  private _instanceId: string = Math.random().toString(36).slice(2);
 
   constructor(
     commandsManager: AppTypes.CommandsManager,
@@ -76,6 +83,7 @@ export class HotkeysManager {
    *
    */
   destroy() {
+    this._teardownRouting();
     this.hotkeyDefaults = [];
     this.hotkeyDefinitions = {};
     mouseTrapAPI.reset();
@@ -200,6 +208,68 @@ export class HotkeysManager {
       commandName: propertyName,
       ...propertyValue,
     };
+  }
+
+  private _onMousePresent = () => {
+    this._hasMouse = true;
+  };
+
+  private _onMouseLeave = () => {
+    this._hasMouse = false;
+  };
+
+  private _onPageHide = () => {
+    this._channel?.postMessage({ type: 'bye', id: this._instanceId });
+  };
+
+  private _onChannelMessage = (event: MessageEvent) => {
+    const { type, id } = event.data || {};
+    switch (type) {
+      case 'hello':
+        this._siblings.add(id);
+        this._channel?.postMessage({ type: 'hello-ack', id: this._instanceId });
+        break;
+      case 'hello-ack':
+        this._siblings.add(id);
+        break;
+      case 'bye':
+        this._siblings.delete(id);
+        break;
+    }
+  };
+
+  /**
+   * Lazily joins the cross-window hotkey routing channel and starts tracking
+   * whether the mouse cursor is inside this window. Mouse events fire in
+   * windows without keyboard focus, which is what makes routing possible.
+   * No-op when BroadcastChannel is unavailable (tests/older browsers).
+   */
+  private _ensureRouting() {
+    if (this._channel || typeof BroadcastChannel === 'undefined') {
+      return;
+    }
+    this._channel = new BroadcastChannel('ohif-hotkeys');
+    this._channel.onmessage = this._onChannelMessage;
+    this._channel.postMessage({ type: 'hello', id: this._instanceId });
+    document.documentElement.addEventListener('mouseenter', this._onMousePresent);
+    document.documentElement.addEventListener('mouseleave', this._onMouseLeave);
+    document.addEventListener('mousemove', this._onMousePresent);
+    window.addEventListener('pagehide', this._onPageHide);
+  }
+
+  private _teardownRouting() {
+    if (!this._channel) {
+      return;
+    }
+    this._channel.postMessage({ type: 'bye', id: this._instanceId });
+    this._channel.close();
+    this._channel = null;
+    this._siblings.clear();
+    this._hasMouse = false;
+    document.documentElement.removeEventListener('mouseenter', this._onMousePresent);
+    document.documentElement.removeEventListener('mouseleave', this._onMouseLeave);
+    document.removeEventListener('mousemove', this._onMousePresent);
+    window.removeEventListener('pagehide', this._onPageHide);
   }
 
   /**

--- a/Viewers/platform/core/src/classes/HotkeysManager.ts
+++ b/Viewers/platform/core/src/classes/HotkeysManager.ts
@@ -222,23 +222,46 @@ export class HotkeysManager {
     this._channel?.postMessage({ type: 'bye', id: this._instanceId });
   };
 
+  // Tab-switching away fires no mouseleave, so _hasMouse would otherwise
+  // stay stuck true and a hidden tab could execute (or double-execute)
+  // forwarded commands invisibly.
+  private _onVisibilityChange = () => {
+    if (document.hidden) {
+      this._hasMouse = false;
+    }
+  };
+
+  // bfcache restore skips our pagehide 'bye' handling on the way back in:
+  // the restored page still has its old channel/listeners and stale
+  // _siblings, while siblings have already forgotten it. Re-form the mesh.
+  private _onPageShow = (event: PageTransitionEvent) => {
+    if (event.persisted) {
+      this._siblings.clear();
+      this._channel?.postMessage({ type: 'hello', id: this._instanceId });
+    }
+  };
+
   private _onChannelMessage = (event: MessageEvent) => {
     const { type, id, commandName, commandOptions, context } = event.data || {};
     switch (type) {
       case 'hello':
-        this._siblings.add(id);
-        this._channel?.postMessage({ type: 'hello-ack', id: this._instanceId });
+        if (id) {
+          this._siblings.add(id);
+          this._channel?.postMessage({ type: 'hello-ack', id: this._instanceId });
+        }
         break;
       case 'hello-ack':
-        this._siblings.add(id);
+        if (id) {
+          this._siblings.add(id);
+        }
         break;
       case 'bye':
         this._siblings.delete(id);
         break;
       case 'run':
-        // Execute only if this window is the one under the cursor and its
-        // hotkeys are not paused (e.g. hotkey-recording dialog open).
-        if (this._hasMouse && this.isEnabled) {
+        // Execute only if this window is the one under the cursor, visible,
+        // and its hotkeys are not paused (e.g. hotkey-recording dialog open).
+        if (this._hasMouse && !document.hidden && this.isEnabled) {
           this._commandsManager.runCommand(commandName, { ...commandOptions }, context);
         }
         break;
@@ -262,6 +285,8 @@ export class HotkeysManager {
     document.documentElement.addEventListener('mouseleave', this._onMouseLeave);
     document.addEventListener('mousemove', this._onMousePresent);
     window.addEventListener('pagehide', this._onPageHide);
+    document.addEventListener('visibilitychange', this._onVisibilityChange);
+    window.addEventListener('pageshow', this._onPageShow);
   }
 
   /**
@@ -293,6 +318,8 @@ export class HotkeysManager {
     document.documentElement.removeEventListener('mouseleave', this._onMouseLeave);
     document.removeEventListener('mousemove', this._onMousePresent);
     window.removeEventListener('pagehide', this._onPageHide);
+    document.removeEventListener('visibilitychange', this._onVisibilityChange);
+    window.removeEventListener('pageshow', this._onPageShow);
   }
 
   /**

--- a/Viewers/platform/core/src/classes/HotkeysManager.ts
+++ b/Viewers/platform/core/src/classes/HotkeysManager.ts
@@ -274,9 +274,15 @@ export class HotkeysManager {
         this._siblings.delete(id);
         break;
       case 'run':
-        // Execute only if this window is the one under the cursor, visible,
-        // and its hotkeys are not paused (e.g. hotkey-recording dialog open).
-        if (this._hasMouse && !document.hidden && this.isEnabled) {
+        // Execute only if this window is the one under the cursor and its
+        // hotkeys are not paused (e.g. hotkey-recording dialog open).
+        // Deliberately NOT gated on document.hidden: Linux Chrome can
+        // misreport a visible unfocused window as hidden (occlusion
+        // tracking), which would drop legitimate keys. _hasMouse alone is
+        // safe — it is cleared on visibilitychange→hidden and only a real
+        // mousemove over the page re-arms it, which a genuinely hidden tab
+        // can never receive.
+        if (this._hasMouse && this.isEnabled) {
           this._commandsManager.runCommand(commandName, { ...commandOptions }, context);
         }
         break;
@@ -284,7 +290,7 @@ export class HotkeysManager {
         // Same gate as 'run', but for raw key descriptors forwarded by
         // components that bind their own keydown listeners outside Mousetrap
         // (e.g. the AI toolbox). Subscribers decide what the key does.
-        if (this._hasMouse && !document.hidden && this.isEnabled) {
+        if (this._hasMouse && this.isEnabled) {
           this._keySubscribers.forEach(handler => handler(descriptor));
         }
         break;
@@ -318,6 +324,8 @@ export class HotkeysManager {
       hasMouse: this._hasMouse,
       enabled: this.isEnabled,
       keySubscribers: this._keySubscribers.size,
+      visibilityState: document.visibilityState,
+      focused: document.hasFocus(),
     });
   }
 

--- a/Viewers/platform/core/src/classes/HotkeysManager.ts
+++ b/Viewers/platform/core/src/classes/HotkeysManager.ts
@@ -223,7 +223,7 @@ export class HotkeysManager {
   };
 
   private _onChannelMessage = (event: MessageEvent) => {
-    const { type, id } = event.data || {};
+    const { type, id, commandName, commandOptions, context } = event.data || {};
     switch (type) {
       case 'hello':
         this._siblings.add(id);
@@ -234,6 +234,13 @@ export class HotkeysManager {
         break;
       case 'bye':
         this._siblings.delete(id);
+        break;
+      case 'run':
+        // Execute only if this window is the one under the cursor and its
+        // hotkeys are not paused (e.g. hotkey-recording dialog open).
+        if (this._hasMouse && this.isEnabled) {
+          this._commandsManager.runCommand(commandName, { ...commandOptions }, context);
+        }
         break;
     }
   };
@@ -255,6 +262,22 @@ export class HotkeysManager {
     document.documentElement.addEventListener('mouseleave', this._onMouseLeave);
     document.addEventListener('mousemove', this._onMousePresent);
     window.addEventListener('pagehide', this._onPageHide);
+  }
+
+  /**
+   * Runs a hotkey command in the window that currently contains the mouse
+   * cursor. Local execution when the cursor is here or when no sibling OHIF
+   * windows are known (preserves single-window behavior, e.g. Alt+Tab focus).
+   */
+  private _runOrForward(commandName, commandOptions = {}, context, evt) {
+    const shouldForward = this._channel && this._siblings.size > 0 && !this._hasMouse;
+    if (!shouldForward) {
+      this._commandsManager.runCommand(commandName, { evt, ...commandOptions }, context);
+      return;
+    }
+    // evt is a DOM event and cannot cross BroadcastChannel (not cloneable);
+    // preventDefault/stopPropagation already ran in this window.
+    this._channel.postMessage({ type: 'run', commandName, commandOptions, context });
   }
 
   private _teardownRouting() {
@@ -330,10 +353,11 @@ export class HotkeysManager {
     const isKeyArray = keys instanceof Array;
     const combinedKeys = isKeyArray ? keys.join('+') : keys;
 
+    this._ensureRouting();
     mouseTrapAPI.bind(combinedKeys, evt => {
       evt.preventDefault();
       evt.stopPropagation();
-      this._commandsManager.runCommand(commandName, { evt, ...commandOptions }, context);
+      this._runOrForward(commandName, commandOptions, context, evt);
     });
   }
 

--- a/Viewers/platform/core/src/classes/HotkeysManager.ts
+++ b/Viewers/platform/core/src/classes/HotkeysManager.ts
@@ -25,6 +25,8 @@ export class HotkeysManager {
   /** Instance ids of other OHIF windows currently on the channel. */
   private _siblings: Set<string> = new Set();
   private _instanceId: string = Math.random().toString(36).slice(2);
+  /** Handlers for key descriptors forwarded from sibling windows. */
+  private _keySubscribers: Set<(descriptor) => void> = new Set();
 
   constructor(
     commandsManager: AppTypes.CommandsManager,
@@ -242,7 +244,7 @@ export class HotkeysManager {
   };
 
   private _onChannelMessage = (event: MessageEvent) => {
-    const { type, id, commandName, commandOptions, context } = event.data || {};
+    const { type, id, commandName, commandOptions, context, descriptor } = event.data || {};
     switch (type) {
       case 'hello':
         if (id) {
@@ -263,6 +265,14 @@ export class HotkeysManager {
         // and its hotkeys are not paused (e.g. hotkey-recording dialog open).
         if (this._hasMouse && !document.hidden && this.isEnabled) {
           this._commandsManager.runCommand(commandName, { ...commandOptions }, context);
+        }
+        break;
+      case 'key':
+        // Same gate as 'run', but for raw key descriptors forwarded by
+        // components that bind their own keydown listeners outside Mousetrap
+        // (e.g. the AI toolbox). Subscribers decide what the key does.
+        if (this._hasMouse && !document.hidden && this.isEnabled) {
+          this._keySubscribers.forEach(handler => handler(descriptor));
         }
         break;
     }
@@ -303,6 +313,34 @@ export class HotkeysManager {
     // evt is a DOM event and cannot cross BroadcastChannel (not cloneable);
     // preventDefault/stopPropagation already ran in this window.
     this._channel.postMessage({ type: 'run', commandName, commandOptions, context });
+  }
+
+  /**
+   * Whether a keyboard handler in this window should act locally. False only
+   * when sibling OHIF windows exist and the mouse cursor is not inside this
+   * one — in that case forward the key with `forwardKeyEvent` instead.
+   * For components that bind their own keydown listeners outside Mousetrap.
+   */
+  public shouldRunLocally(): boolean {
+    return !(this._channel && this._siblings.size > 0 && !this._hasMouse);
+  }
+
+  /**
+   * Forwards a plain key descriptor ({key, ctrlKey, ...} — structured-cloneable,
+   * never the DOM event itself) to sibling windows; the one under the cursor
+   * delivers it to its `subscribeForwardedKeys` handlers.
+   */
+  public forwardKeyEvent(descriptor): void {
+    this._channel?.postMessage({ type: 'key', descriptor });
+  }
+
+  /**
+   * Registers a handler for key descriptors forwarded from sibling windows.
+   * Returns an unsubscribe function.
+   */
+  public subscribeForwardedKeys(handler: (descriptor) => void): () => void {
+    this._keySubscribers.add(handler);
+    return () => this._keySubscribers.delete(handler);
   }
 
   private _teardownRouting() {


### PR DESCRIPTION
## Summary

Hotkeys now execute in the same-origin OHIF browser window under the **mouse cursor**, instead of always acting in the last-clicked (OS-focused) window.

Since the OS only delivers keystrokes to the focused window, each window tracks cursor presence (mouse events fire without keyboard focus) and joins `BroadcastChannel('ohif-hotkeys')` with a hello/hello-ack/bye presence protocol. A hotkey runs locally when the cursor is here or no sibling windows are known; otherwise it is forwarded and executed by the hovered window with its own services/study.

- `HotkeysManager`: presence tracking, sibling mesh (self-healing on focus/visibility), routing for Mousetrap hotkeys, and a public API (`shouldRunLocally` / `forwardKeyEvent` / `subscribeForwardedKeys`) for components that bind raw keydown listeners
- AI toolbox (`Toolbox.tsx`): `q/t/p/b/s/l/m/r/o/ctrl+z/delete` routed through the same channel
- Receiver gate is `_hasMouse && isEnabled` — deliberately **not** `document.hidden` (Linux Chrome occlusion tracking misreports visible unfocused windows as hidden)
- `window.__ohifHotkeysRouting()` console probe for field debugging
- On window focus, the viewport pane under the cursor is activated (single-click activation attempt, see notes)

Single-window behavior is unchanged (no channel/siblings → always local), including Alt+Tab workflows.

## Testing

- 25 unit tests for routing/presence/forwarding + 15 existing HotkeysManager tests pass (test files intentionally not committed, per project policy; they live untracked locally)
- Full `platform/core` jest suite green except pre-existing unrelated `MeasurementService.test.js` failure (broken since c0a84e8)
- Manually verified: two side-by-side windows, hotkeys (arrows + AI toolbox keys) act on the hovered window

## ⚠️ Known open issues (deliberately left for a follow-up)

1. **DevTools dependency (unresolved):** on Linux (NVIDIA, X11), cross-window forwarding is only reliable while DevTools is open on a window. Wheel/mouse input and rendering in the unfocused window work fine without DevTools, so the page is alive — suspicion is Chrome deferring `BroadcastChannel` delivery or backgrounding side effects. Decisive experiment (run in the focused window's console, DevTools closed on the other):
   `__bc = new BroadcastChannel('ohif-hotkeys'); __bc.onmessage = e => console.log(JSON.stringify(e.data)); __bc.postMessage({type:'hello', id:'probe1'})` → one `hello-ack` = other window's channel is suspended (transport problem → consider SharedWorker relay); two = transport fine, look at key execution. Clean up with `{type:'bye', id:'probe1'}`.
2. **Single-click activation not confirmed:** the window-focus → activate-pane-under-cursor handler (a67cc62) did not fix the "need to double-click" symptom in manual testing; needs investigation of what the first click/focus actually delivers on this window manager.
3. A forgotten background OHIF tab counts as a sibling: hotkeys pressed with the cursor outside every OHIF document then do nothing instead of falling back to the focused window (documented trade-off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)