### PR TITLE
fix(reset): Reset Segment now works for all segments in stack and MPR

### DIFF
--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -2093,6 +2093,43 @@ const commandsModule = ({
       }
       (activeVp as any)?.render?.();   // synchronous WebGL render — instant visual removal
 
+      // 2b. MPR viewports render the labelmap as built 3D VOLUMEs (not per-slice stack images), so the
+      //     stack push above never touches them — and because reset keeps the same imageIds, cornerstone
+      //     just re-serves the cached (pre-zeroed) volume, which is why a remount/DATA_MODIFIED didn't
+      //     clear it. Instead, zero this segment's value directly in each labelmap volume's scalar buffer
+      //     and re-render. Only labelmap volumes are Uint8Array (the CT is Int16/float) so the source is
+      //     never touched; native indexOf skips block volumes that don't hold this segment; and volumes
+      //     shared across the 3 MPR viewports are scanned once.
+      {
+        const _vpService = servicesManager.services.cornerstoneViewportService;
+        const _scanned = new Set<any>();
+        const _mprVps: any[] = [];
+        for (const _vid of _vpService.getViewportIds()) {
+          const _vp = _vpService.getCornerstoneViewport(_vid) as any;
+          if (!(_vp instanceof VolumeViewport) || _vp instanceof VolumeViewport3D) continue;
+          _mprVps.push(_vp);
+          for (const _ae of (_vp?.getActors?.() ?? [])) {
+            const _inputData = _ae?.actor?.getMapper?.()?.getInputData?.();
+            const _scalars = _inputData?.getPointData?.()?.getScalars?.();
+            const _vtkData = _scalars?.getData?.();
+            if (!(_vtkData instanceof Uint8Array)) continue;   // labelmap volumes only; skip the CT
+            if (!_scanned.has(_vtkData)) {
+              _scanned.add(_vtkData);
+              if (_vtkData.indexOf(segmentIndex) !== -1) {   // this block volume holds the segment
+                for (let i = 0; i < _vtkData.length; i++) {
+                  if (_vtkData[i] === segmentIndex) _vtkData[i] = 0;
+                }
+                _scalars.modified?.();
+                _inputData.modified?.();
+              }
+            }
+            _ae.actor?.modified?.();
+            _ae.actor?.getMapper?.()?.modified?.();
+          }
+        }
+        for (const _vp of _mprVps) _vp?.render?.();
+      }
+
       // 3. Background: zero all remaining slices, remove measurements, reset server.
       setTimeout(() => {
         for (const imageId of imageIds) {

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -2037,7 +2037,12 @@ const commandsModule = ({
     },
     async resetSegment({ segmentationId, segmentIndex }: { segmentationId: string; segmentIndex: number }) {
       const segmentation = csToolsSegmentation.state.getSegmentation(segmentationId);
-      const imageIds: string[] = (segmentation?.representationData?.Labelmap as any)?.imageIds ?? [];
+      // Use allImageIds (every block). representationData.Labelmap.imageIds is reverted to the PRIMARY
+      // block (segment 1) by syncLegacyLabelmapData, so it misses segments 2+ (their private blocks) —
+      // which is why Reset only cleared the 1st segment. _zeroImageId only zeros THIS segment's value,
+      // so scanning every block's images is safe (other segments' blocks hold other values, untouched).
+      const _lmData = (segmentation?.representationData?.Labelmap as any);
+      const imageIds: string[] = _lmData?.allImageIds ?? _lmData?.imageIds ?? [];
 
       const _zeroImageId = (imageId: string) => {
         const image = cache.getImage(imageId);


### PR DESCRIPTION
Two independent, verified fixes for **Reset Segment** — it previously only worked for the 1st segment in stack, and did nothing in MPR. Both confirmed working in stack **and** MPR (all segments, only the reset one clears). One commit each.

## 1. `fix(reset)` — clear segments 2+ in stack viewports
`resetSegment` looped over `representationData.Labelmap.imageIds`, which `syncLegacyLabelmapData` reverts to the **primary block (segment 1)** after inference. Segments 2+ live in their own private blocks under `allImageIds`, so they were never zeroed — hence "Reset only clears the 1st segment." Switched to `allImageIds`. Safe because `_zeroImageId` only zeros the target segment's value, so other segments' blocks (which hold other values) are untouched.

## 2. `fix(reset)` — clear segment in MPR
In MPR the labelmap is rendered as a built **3D volume**, not the per-slice stack images. Zeroing the source images doesn't touch that volume, and since reset keeps the same imageIds, cornerstone just re-serves the **cached** (pre-zeroed) volume — so a remount / `SEGMENTATION_DATA_MODIFIED` couldn't clear it. Instead, zero the segment's value **directly in each MPR labelmap volume's scalar buffer** and re-render. Guards:
- **`Uint8Array` only** → labelmap volumes, never the CT (`Int16`/float).
- **native `indexOf(segmentIndex)`** → skips block volumes that don't hold this segment (multi-block scheme: each segment has its own block).
- **dedup by buffer** → volumes shared across the 3 MPR panes are scanned once, then all panes re-render.

### Scope / notes
- Stack path is unchanged by #2; both are additive and low-risk.
- Verified statically (`@babel` parse) and manually (stack + MPR, multiple overlapping segments).
- **Not** included: the separate MPR labelmap-**volume leak** (climbing `vols`/`mpr=` over a long session) — that needs an in-place-volume rework and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
