### PR TITLE
ci: move the security workflow off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/weekly-security-fix.yml
+++ b/.github/workflows/weekly-security-fix.yml
@@ -54,14 +54,18 @@ jobs:
 
     steps:
       - name: Check out main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: main
 
+      # Node 22, not 24: this is the version the yarn install/build runs under, and 22 is the
+      # conservative LTS choice for OHIF's toolchain. It is independent of the runner's own
+      # Node 24 runtime. Node 20 is EOL (April 2026), so it is not an option for a job whose
+      # whole purpose is security.
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '22'
 
       # yarn audit exits with a non-zero BITMASK when it finds anything
       # (1=info 2=low 4=moderate 8=high 16=critical), so every audit call needs
@@ -220,7 +224,7 @@ jobs:
 
       - name: Open pull request
         if: steps.fix.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: chore/security-fix
           base: main


### PR DESCRIPTION
Fixes the Node 20 deprecation failure on the weekly security workflow ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).

GitHub is retiring the **Node 20 action runtime**, so any action pinned to a `node20` major now fails on current runners. All three actions in the workflow were affected.

| Action | Before | After | Runtime |
|---|---|---|---|
| `actions/checkout` | `v4` | `v7` | `node24` |
| `actions/setup-node` | `v4` | `v7` | `node24` |
| `peter-evans/create-pull-request` | `v7` | `v8` | `node24` |

### Is the create-pull-request major bump safe?

Yes — I checked the [v8.0.0 release notes](https://github.com/peter-evans/create-pull-request/releases/tag/v8.0.0) rather than assuming. v8 is a **runtime-only major**: the only substantive change is Node 24 support (plus a self-hosted-runner requirement of Actions Runner ≥ 2.327.1). No input changes, so the existing step — `branch`, `base`, `title`, `body`, `commit-message`, `labels`, `delete-branch`, `add-paths` — needs no rework.

### Also: Node 20 → 22 for the build

Separate from the runner runtime, the job's own `node-version` was `20`. **Node 20 reached end of life in April 2026**, and a workflow whose entire purpose is applying security fixes shouldn't itself run on an unsupported runtime.

Bumped to **22**, not 24 — 22 is the conservative LTS choice for OHIF's toolchain, and this is the version `yarn install` and the optional build execute under. Added an inline comment recording that reasoning so it isn't "fixed" to 24 later without thought.

### Verified

- Action versions and their `using:` runtime read directly from each repo's `action.yml` — not guessed
- YAML re-parsed after the edit: 11 steps intact, all three `uses:` on node24, `node-version: 22`
- No behavioural change to the security policy: cornerstone still excluded, the cornerstone guard still aborts, no major bumps, Python still untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
