### PR TITLE
ci: fix the cornerstone-versions lockfile path

### DIFF
--- a/.github/scripts/cornerstone-versions.sh
+++ b/.github/scripts/cornerstone-versions.sh
@@ -16,10 +16,22 @@
 # indented. Output is sorted so it can be diffed directly.
 set -euo pipefail
 
-LOCKFILE="${1:-Viewers/yarn.lock}"
+# Accept an explicit path. Falling back, try both the repo root and Viewers/ -- the workflow
+# invokes this with `working-directory: Viewers`, so a default of "Viewers/yarn.lock" would
+# resolve to Viewers/Viewers/yarn.lock and fail.
+LOCKFILE="${1:-}"
 
-if [ ! -f "$LOCKFILE" ]; then
-  echo "cornerstone-versions.sh: no lockfile at $LOCKFILE" >&2
+if [ -z "$LOCKFILE" ]; then
+  for candidate in yarn.lock Viewers/yarn.lock ../Viewers/yarn.lock; do
+    if [ -f "$candidate" ]; then
+      LOCKFILE="$candidate"
+      break
+    fi
+  done
+fi
+
+if [ -z "$LOCKFILE" ] || [ ! -f "$LOCKFILE" ]; then
+  echo "cornerstone-versions.sh: no yarn.lock found (looked for '${1:-yarn.lock, Viewers/yarn.lock, ../Viewers/yarn.lock}' from $(pwd))" >&2
   exit 1
 fi
 

--- a/.github/workflows/weekly-security-fix.yml
+++ b/.github/workflows/weekly-security-fix.yml
@@ -80,7 +80,7 @@ jobs:
           # The RESOLVED versions in yarn.lock are what actually get installed and therefore
           # what the ESM overrides are patched against - a package.json range like ^5.0.13 can
           # silently resolve to a different 5.x, so comparing ranges alone would miss a move.
-          ../.github/scripts/cornerstone-versions.sh > /tmp/cornerstone-before.txt
+          ../.github/scripts/cornerstone-versions.sh yarn.lock > /tmp/cornerstone-before.txt
           echo "Pinned cornerstone versions:"; cat /tmp/cornerstone-before.txt
 
       # yarn-audit-fix verifies the package structure before it runs and fails with
@@ -123,7 +123,7 @@ jobs:
         id: guard
         working-directory: Viewers
         run: |
-          ../.github/scripts/cornerstone-versions.sh > /tmp/cornerstone-after.txt
+          ../.github/scripts/cornerstone-versions.sh yarn.lock > /tmp/cornerstone-after.txt
 
           if ! diff -q /tmp/cornerstone-before.txt /tmp/cornerstone-after.txt > /dev/null; then
             echo "::error::A fix could not be applied without moving @cornerstonejs/*."


### PR DESCRIPTION
Fixes `cornerstone-versions.sh: no lockfile at Viewers/yarn.lock` in the guard step.

**The lockfile is fine and already tracked** — no need to push anything. The script's default path was simply wrong for the directory it runs in.

### The bug

The workflow invokes the script with `working-directory: Viewers`, so the script's default of `Viewers/yarn.lock` resolved to `Viewers/Viewers/yarn.lock`.

I tested the script from the repo root when I wrote it — which is the one working directory the workflow never uses.

### The fix

- Both call sites now pass `yarn.lock` explicitly (cwd is already `Viewers`)
- The bare default falls back through `yarn.lock` → `Viewers/yarn.lock` → `../Viewers/yarn.lock`, so it works from either convention
- A missing lockfile now reports **the paths searched and the cwd**, rather than a single hard-coded guess

### Verified — all four cases, from the actual directories

| case | result |
|---|---|
| explicit arg, from `Viewers/` (how the workflow calls it) | 17 entries ✅ |
| bare default, from `Viewers/` | 17 entries ✅ |
| bare default, from repo root | 17 entries ✅ |
| missing file | clean error naming searched paths + cwd, exit 1 ✅ |

### The rest of the run was healthy

The `Audit before` step worked — it reported **6 critical / 57 high / 78 moderate / 4 low** before hitting this. The `Resolution field ... is incompatible` lines above it are pre-existing `resolutions` warnings in the repo's package.json, not errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
