### PR TITLE
perf(seg): sparse (z-cropped) labelmap blocks — 841MB → ~480MB, MPR volume leak fixed

### DIFF
--- a/Viewers/extensions/cornerstone-dicom-seg/src/commandsModule.ts
+++ b/Viewers/extensions/cornerstone-dicom-seg/src/commandsModule.ts
@@ -93,13 +93,18 @@ const commandsModule = ({
     generateSegmentation: async ({ segmentationId, options = {} }) => {
       const segmentation = cornerstoneToolsSegmentation.state.getSegmentation(segmentationId);
 
-      const { imageIds, labelmaps } = segmentation.representationData.Labelmap;
+      const lm = segmentation.representationData.Labelmap;
+      const { imageIds, labelmaps } = lm;
 
-      // Primary block images — used for CT slice ordering and referencedImageIds
-      const segImages = imageIds.map(imageId => cache.getImage(imageId));
+      // Series geometry comes from referencedImageIds — the SOURCE slice list for the whole series,
+      // which every producer sets (buildMultiBlockLabelmapRepresentation, SegmentationService, and
+      // buildOverlappingSegLayers). Labelmap.imageIds is NOT usable here: syncLegacyLabelmapData
+      // reverts it to the primary block, which is shorter than the series once blocks are z-cropped.
+      const sourceImageIds: string[] = (lm.referencedImageIds?.length ? lm.referencedImageIds : imageIds) as string[];
 
-      // Collect all referenced image IDs (maintaining array structure to match segImages)
-      const referencedImageIds = segImages.map(image => image?.referencedImageId);
+      // Indexed by SOURCE slice, so every layer lands on the right CT slice regardless of which
+      // slices its own block covers.
+      const referencedImageIds = sourceImageIds;
 
       // Load all referenced images that exist but may not be in cache yet
       // This is necessary because lazy loading may not have loaded all slices yet
@@ -121,15 +126,15 @@ const commandsModule = ({
         })
       );
 
-      // Now get all referenced images from cache, maintaining the same order as segImages
-      const referencedImages = segImages.map(image => {
-        if (!image?.referencedImageId) {
-          return null;
-        }
-        return cache.getImage(image.referencedImageId);
-      });
+      const referencedImages = sourceImageIds.map(id => cache.getImage(id));
 
-      const N = imageIds.length;
+      const N = sourceImageIds.length;
+
+      // Map a labelmap image's referencedImageId -> its index in the source series. Mapping by
+      // IDENTITY rather than by position is what makes this correct for a z-cropped block (which
+      // starts at its own z0) and for a flipped series (whose block is stored in reverse).
+      const sourceIndexById = new Map<string, number>();
+      sourceImageIds.forEach((id, i) => sourceIndexById.set(id, i));
       const isMultiBlock = labelmaps && Object.keys(labelmaps).length > 1;
 
       // Compute sort permutation matching the dcmjs SEGImageNormalizer (descending by scan-axis
@@ -250,19 +255,24 @@ const commandsModule = ({
         for (const [, layer] of Object.entries(labelmaps as Record<string, any>)) {
           const layerLabelmaps2D: any[] = new Array(N);
 
-          for (let z = 0; z < N; z++) {
-            const primaryImage = segImages[z];
-            if (!primaryImage || !layer.imageIds?.[z]) continue;
-            const { rows, columns } = primaryImage;
-            const layerImage = cache.getImage(layer.imageIds[z]);
+          for (const layerImageId of (layer.imageIds ?? [])) {
+            const layerImage = cache.getImage(layerImageId);
             if (!layerImage) continue;
+            const origIdx = sourceIndexById.get((layerImage as any).referencedImageId);
+            if (origIdx === undefined) continue;
+            const { rows, columns } = layerImage;
             const pixelData = layerImage.getPixelData();
             const segmentsOnLabelmap = new Set<number>();
             for (let i = 0; i < pixelData.length; i++) {
               if (pixelData[i] !== 0) segmentsOnLabelmap.add(pixelData[i]);
             }
             if (segmentsOnLabelmap.size > 0) {
-              layerLabelmaps2D[z] = { segmentsOnLabelmap: Array.from(segmentsOnLabelmap), pixelData, rows, columns };
+              layerLabelmaps2D[origIdx] = {
+                segmentsOnLabelmap: Array.from(segmentsOnLabelmap),
+                pixelData,
+                rows,
+                columns,
+              };
             }
           }
 
@@ -286,17 +296,25 @@ const commandsModule = ({
         generatedSegmentation = generateSegmentation(referencedImages, labelmaps3DArray, metaData, options);
       } else {
         const labelmaps2D: any[] = new Array(N);
+        const primaryLayer = Object.values(labelmaps as Record<string, any>)[0];
 
-        for (let z = 0; z < N; z++) {
-          const primaryImage = segImages[z];
-          if (!primaryImage) continue;
-          const { rows, columns } = primaryImage;
-          const pixelData = primaryImage.getPixelData();
+        for (const layerImageId of (primaryLayer?.imageIds ?? imageIds)) {
+          const layerImage = cache.getImage(layerImageId);
+          if (!layerImage) continue;
+          const origIdx = sourceIndexById.get((layerImage as any).referencedImageId);
+          if (origIdx === undefined) continue;
+          const { rows, columns } = layerImage;
+          const pixelData = layerImage.getPixelData();
           const segmentsOnLabelmap = new Set<number>();
           for (let i = 0; i < pixelData.length; i++) {
             if (pixelData[i] !== 0) segmentsOnLabelmap.add(pixelData[i]);
           }
-          labelmaps2D[z] = { segmentsOnLabelmap: Array.from(segmentsOnLabelmap), pixelData, rows, columns };
+          labelmaps2D[origIdx] = {
+            segmentsOnLabelmap: Array.from(segmentsOnLabelmap),
+            pixelData,
+            rows,
+            columns,
+          };
         }
 
         const allSegments = Array.from(

--- a/Viewers/extensions/cornerstone-dicom-seg/src/commandsModule.ts
+++ b/Viewers/extensions/cornerstone-dicom-seg/src/commandsModule.ts
@@ -97,8 +97,10 @@ const commandsModule = ({
       const { imageIds, labelmaps } = lm;
 
       // Series geometry must come from allReferencedImageIds — the SOURCE slice list for the whole
-      // series, set by every producer and immune to syncLegacyLabelmapData because the adapter does
-      // not name it. Labelmap.imageIds AND referencedImageIds are both reverted by that adapter to
+      // series, set by every MULTI-BLOCK producer and immune to syncLegacyLabelmapData because the
+      // adapter does not name it. (Single-block non-AI representations don't set it and take the
+      // referencedImageIds branch below, which is safe: their primary layer spans the whole series.)
+      // Labelmap.imageIds AND referencedImageIds are both reverted by that adapter to
       // the PRIMARY LAYER's value on every entry into state, and that value is deliberately
       // block-scoped via refIdsFor, making both fields unreliable for series geometry once blocks
       // are z-cropped. Fall back to referencedImageIds (pre-Task-4.6 segmentations) then imageIds.

--- a/Viewers/extensions/cornerstone-dicom-seg/src/commandsModule.ts
+++ b/Viewers/extensions/cornerstone-dicom-seg/src/commandsModule.ts
@@ -96,11 +96,17 @@ const commandsModule = ({
       const lm = segmentation.representationData.Labelmap;
       const { imageIds, labelmaps } = lm;
 
-      // Series geometry comes from referencedImageIds — the SOURCE slice list for the whole series,
-      // which every producer sets (buildMultiBlockLabelmapRepresentation, SegmentationService, and
-      // buildOverlappingSegLayers). Labelmap.imageIds is NOT usable here: syncLegacyLabelmapData
-      // reverts it to the primary block, which is shorter than the series once blocks are z-cropped.
-      const sourceImageIds: string[] = (lm.referencedImageIds?.length ? lm.referencedImageIds : imageIds) as string[];
+      // Series geometry must come from allReferencedImageIds — the SOURCE slice list for the whole
+      // series, set by every producer and immune to syncLegacyLabelmapData because the adapter does
+      // not name it. Labelmap.imageIds AND referencedImageIds are both reverted by that adapter to
+      // the PRIMARY LAYER's value on every entry into state, and that value is deliberately
+      // block-scoped via refIdsFor, making both fields unreliable for series geometry once blocks
+      // are z-cropped. Fall back to referencedImageIds (pre-Task-4.6 segmentations) then imageIds.
+      const sourceImageIds: string[] = (
+        lm.allReferencedImageIds?.length ? lm.allReferencedImageIds
+        : lm.referencedImageIds?.length ? lm.referencedImageIds
+        : imageIds
+      ) as string[];
 
       // Indexed by SOURCE slice, so every layer lands on the right CT slice regardless of which
       // slices its own block covers.

--- a/Viewers/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
+++ b/Viewers/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
@@ -548,6 +548,7 @@ class SegmentationService extends PubSubService {
               imageIds: overlappingLayers.primaryImageIds,
               allImageIds: overlappingLayers.allImageIds,
               referencedImageIds: imageIds as string[],
+              allReferencedImageIds: imageIds as string[],
               labelmaps: overlappingLayers.labelmaps,
               segmentBindings: overlappingLayers.segmentBindings,
               primaryLabelmapId: overlappingLayers.primaryLabelmapId,
@@ -557,6 +558,7 @@ class SegmentationService extends PubSubService {
               imageIds: derivedImageIds,
               // referencedVolumeId: this._getVolumeIdForDisplaySet(referencedDisplaySet),
               referencedImageIds: imageIds as string[],
+              allReferencedImageIds: imageIds as string[],
             },
       },
       config: {

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -3575,11 +3575,13 @@ const commandsModule = ({
           // stays well inside it, a runaway does not. Measured against [_aw0, _aw1) — the range a
           // FRESH block would take — never the mask's own [_bw0, _bw1), because comparing against
           // the mask would reclaim exactly the headroom the grid deliberately reserved.
-          const _shrinkBlock =
+          // Named for what it MEASURES, not for the decision it feeds: it is true whenever the
+          // previous block is oversized, including on paths that would reallocate anyway.
+          const _blockOversized =
             !!_prevBlock &&
             shouldShrinkBlock(_prevBlock.imageIds.length, _aw1 - _aw0, BLOCK_SHRINK_FACTOR);
           const _reuseIdx = (_hasCropGeom && !toolboxState.getRefineNew() && _nMpr > 0 && _nStack === 0
-            && _fitsBlock && !_shrinkBlock) ? _blockIdxForSeg : -1;
+            && _fitsBlock && !_blockOversized) ? _blockIdxForSeg : -1;
 
           // Working-order offset of the block being written.
           // INVARIANT: on the REUSE path this MUST equal _prevBlock.z0, because _clearIdxs, the

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -37,19 +37,13 @@ import {
 import { parseMultipart } from './utils/multipart';
 import { callInputDialog } from './utils/callInputDialog';
 import { getNninterToken, clearNninterToken } from './utils/nninterSession';
-import { LabelmapBlock, describeBlocks, blockIndexForSegment, replaceBlockAt, appendBlock, flattenBlocks, flipIndex, withoutBlockAt, blockContains, clampRange, snapRangeToGrid, shouldShrinkBlock, sourceRangeForWorking, MIN_BLOCK_SLICES, BLOCK_GRID_SLICES, BLOCK_SHRINK_FACTOR } from './utils/labelmapBlocks';
+import { describeBlocks, blockIndexForSegment, replaceBlockAt, appendBlock, flattenBlocks, flipIndex, withoutBlockAt, blockContains, clampRange, snapRangeToGrid, shouldShrinkBlock, sourceRangeForWorking, MIN_BLOCK_SLICES, BLOCK_GRID_SLICES, BLOCK_SHRINK_FACTOR } from './utils/labelmapBlocks';
+// Separate: LabelmapBlock is a type, and isolatedModules requires type-only imports be marked so
+// the transpiler can erase them without resolving the module.
+import type { LabelmapBlock } from './utils/labelmapBlocks';
 
 /** Tracks the last series initialized by initNninter to detect study/series changes. */
 let _lastInitSeries: string | undefined = undefined;
-
-/** Safely parse a numeric timing field from multipart response metadata. */
-function metaNum(meta: Record<string, unknown>, key: string): number | undefined {
-  const v = meta[key];
-  if (v === undefined || v === null) return undefined;
-  const n = typeof v === 'number' ? v : parseFloat(String(v));
-  return isFinite(n) ? n : undefined;
-}
-
 
 export type HangingProtocolParams = {
   protocolId?: string;
@@ -209,7 +203,6 @@ const commandsModule = ({
     imageIds,
     currentDisplaySets,
     segments,
-    blockSegments,
     blocks,
   }: {
     segmentationId: string;
@@ -217,7 +210,6 @@ const commandsModule = ({
     imageIds: string[];
     currentDisplaySets: any;
     segments: { [segmentIndex: string]: cstTypes.Segment };
-    blockSegments?: number[];
     blocks?: LabelmapBlock[];
   }) {
     const N = imageIds.length;
@@ -228,21 +220,14 @@ const commandsModule = ({
     // series length and gets 0 — which produced an empty blockList, hence empty labelmaps and
     // segmentBindings, and the representation lost every layer.
     const blockCount = N > 0 ? Math.max(1, Math.floor(derivedImageIds.length / N)) : 1;
-    // EXPLICIT block -> segment map. This used to be positional (block b always held segment b+1),
-    // which is why a segment's block could never be removed: dropping a middle block shifted every
-    // later block and silently renumbered those segments. Callers now pass the mapping so blocks can
-    // be added/removed independently of segment numbering; we fall back to the old positional rule
-    // for representations built before this existed.
-    const blockSeg: number[] = (blockSegments && blockSegments.length === blockCount)
-      ? blockSegments.slice()
-      : Array.from({ length: blockCount }, (_, b) => b + 1);
-
-    // Explicit blocks (possibly VARIABLE length — a z-cropped block covers only its mask's slices).
-    // Without them we fall back to the legacy uniform layout: N-sized chunks of derivedImageIds.
+    // Explicit blocks (possibly VARIABLE length — a z-cropped block covers only its mask's slices)
+    // carry their own block -> segment mapping, so a block can be added or removed without
+    // renumbering the segments after it. Without them we fall back to the legacy uniform layout:
+    // N-sized chunks of derivedImageIds under the old positional rule (block b holds segment b+1).
     const blockList: LabelmapBlock[] = (blocks && blocks.length)
       ? blocks
       : Array.from({ length: blockCount }, (_, b) => ({
-          segmentIndex: blockSeg[b],
+          segmentIndex: b + 1,
           z0: 0,
           imageIds: derivedImageIds.slice(b * N, (b + 1) * N),
         }));
@@ -327,8 +312,10 @@ const commandsModule = ({
       labelmapRepresentation: {
         imageIds: flatImageIds,
         allImageIds: flatImageIds,
-        // Persisted so later refines/deletes know which segment each block holds, and (for sparse
-        // blocks) which slices it covers.
+        // `blocks` is what every reader uses; `blockSegments` is written for describeBlocks' LEGACY
+        // fallback, which reads it (labelmapBlocks.ts, the `labelmapData.blockSegments` branch) when
+        // a representation persisted by an earlier build has no `blocks` array. Nothing consumes it
+        // as an INPUT here any more — dropping it would only break those older representations.
         blockSegments: blockList.map(b => b.segmentIndex),
         blocks: blockList,
         referencedVolumeId: currentDisplaySets.displaySetInstanceUID,
@@ -363,14 +350,12 @@ const commandsModule = ({
         segImageIds: [] as string[],
         existingSegments: {} as { [segmentIndex: string]: cstTypes.Segment },
         existing: false,
-        blockSegments: null as number[] | null,
         blocks: [] as LabelmapBlock[],
       };
     }
 
     let existingSegments: { [segmentIndex: string]: cstTypes.Segment } = {};
     let segImageIds: string[] = [];
-    let blockSegments: number[] | null = null;
     let blocks: LabelmapBlock[] = [];
     let existing = false;
     let segmentationId = freshActiveSegmentation.segmentationId;
@@ -391,8 +376,6 @@ const commandsModule = ({
         freshActiveSegmentation.representationData?.Labelmap?.allImageIds ??
         freshActiveSegmentation.representationData?.Labelmap?.imageIds ??
         [];
-      blockSegments =
-        (freshActiveSegmentation.representationData?.Labelmap as any)?.blockSegments ?? null;
       blocks = describeBlocks(
         freshActiveSegmentation.representationData?.Labelmap,
         currentDisplaySets?.imageIds?.length ?? 0
@@ -406,7 +389,6 @@ const commandsModule = ({
       segImageIds,
       existingSegments,
       existing,
-      blockSegments,
       blocks,
     };
   }
@@ -894,7 +876,6 @@ const commandsModule = ({
     currentImageIdIndex,
     z_range,
     mprInPlaceDone = false,
-    blockSegments,
     blocks,
   }: {
     activeViewportId: string;
@@ -908,7 +889,6 @@ const commandsModule = ({
     existing: boolean;
     activeSegmentation: any;
     mprInPlaceDone?: boolean;
-    blockSegments?: number[] | null;
     blocks?: LabelmapBlock[] | null;
     currentImageIdIndex?: number;
     z_range: number[];
@@ -928,7 +908,6 @@ const commandsModule = ({
       imageIds,
       currentDisplaySets,
       segments,
-      blockSegments: blockSegments ?? undefined,
       blocks: blocks ?? undefined,
     });
     const mergedSegments = mergeSegmentsForUpdate(segmentationId, segments);
@@ -1767,6 +1746,10 @@ const commandsModule = ({
           let merged_derivedImages = [];
           let z_range = [];
           if(overlap){
+          // unreachable: `overlap` is a const `false` in this command, so this branch never runs.
+          // Mirror of the dead branch in nninter. Kept only as the historical multi-layer variant;
+          // do NOT read it as a live path — its `Math.floor(i / imgLength)` block arithmetic
+          // assumes every block spans the whole series, which is no longer true.
           let derivedImages_new = await imageLoader.createAndCacheDerivedLabelmapImages(imageIds);
           console.log(`Just after createAndCacheDerivedLabelmapImages: ${(Date.now() - start)/1000} Seconds`);
           let derivedImages = [];
@@ -2160,7 +2143,6 @@ const commandsModule = ({
       };
       const data = MonaiLabelClient.constructFormData(params, null);
 
-      const beforePost = Date.now();
       const undoPromise = axios.post(url, data, {
         responseType: 'arraybuffer',
         headers: { accept: 'application/octet-stream' },
@@ -2179,7 +2161,6 @@ const commandsModule = ({
 
       try {
         const response = await undoPromise;
-        const afterPost = Date.now();
         if (response.status !== 200) {
           return;
         }
@@ -2203,20 +2184,6 @@ const commandsModule = ({
           });
           return;
         }
-        const afterParse = Date.now();
-
-        // --- round-trip timing breakdown (mirrors the normal nninter path) ---
-        const networkRoundTripMs = afterPost - beforePost;
-        const sRequestTs = metaNum(meta as Record<string, unknown>, 'server_request_ts');
-        const sBeginTs   = metaNum(meta as Record<string, unknown>, 'server_begin_ts');
-        const sEndTs     = metaNum(meta as Record<string, unknown>, 'server_end_ts');
-        const sUndoCore  = metaNum(meta as Record<string, unknown>, 'nninter_core_elapsed');
-        const sResult    = metaNum(meta as Record<string, unknown>, 'server_result_elapsed');
-        const postInFlightMs     = (sRequestTs != null) ? sRequestTs * 1000 - beforePost : undefined;
-        const monaiPrepMs        = (sRequestTs != null && sBeginTs != null) ? (sBeginTs - sRequestTs) * 1000 : undefined;
-        const serverProcessMs    = (sBeginTs != null && sEndTs != null) ? (sEndTs - sBeginTs) * 1000 : undefined;
-        const responseInFlightMs = (sEndTs != null) ? afterPost - sEndTs * 1000 : undefined;
-
         const undone = String((meta as any).undone).toLowerCase() === 'true';
         if (!undone) {
           uiNotificationService.show({
@@ -2410,14 +2377,16 @@ const commandsModule = ({
     /**
      * Release the labelmap block owned by a deleted segment.
      *
-     * Each segment owns a full-volume block of derived labelmap images (~84MB). Deleting a segment
-     * goes through cornerstone's generic removeSegment, which only zeroes the segment's pixel VALUES
-     * — it knows nothing about our multi-block scheme, so the block's imageIds stayed in the
-     * representation and its images stayed in the cache forever (cacheMB never dropped after a
-     * delete). This rebuilds the representation without that block and evicts its images.
+     * Each segment owns a block of derived labelmap images covering the slices its mask touches.
+     * Deleting a segment goes through cornerstone's generic removeSegment, which only zeroes the
+     * segment's pixel VALUES — it knows nothing about our multi-block scheme, so the block's
+     * imageIds stayed in the representation and its images stayed in the cache forever (cacheMB
+     * never dropped after a delete). This rebuilds the representation without that block and
+     * evicts its images.
      *
-     * Safe for middle segments now that block -> segment is an explicit map: dropping a block no
-     * longer renumbers the segments after it (which is why this could not be done before).
+     * Safe for middle segments now that the block list carries an explicit block -> segment
+     * mapping: dropping a block no longer renumbers the segments after it (which is why this
+     * could not be done before).
      */
     async releaseSegmentBlock({ segmentationId, segmentIndex }: { segmentationId: string; segmentIndex: number }) {
       const seg = csToolsSegmentation.state.getSegmentation(segmentationId);
@@ -2461,9 +2430,10 @@ const commandsModule = ({
       const _staleLayerIds = [..._oldOwners.keys(), ..._newOwners.keys()].filter(
         id => _oldOwners.get(id) !== _newOwners.get(id)
       );
-      // Same purge remountSegmentationRepresentations does (~:753-763): the explicit
-      // geometryVolumeId the layer store stamped on the layer, plus the `${labelmapId}-geometry`
-      // key it defaults to. Read from the OLD labelmaps, before updateSegmentations replaces them.
+      // Same purge remountSegmentationRepresentations does in its stale-MPR-volume loop: the
+      // explicit geometryVolumeId the layer store stamped on the layer, plus the
+      // `${labelmapId}-geometry` key it defaults to. Read from the OLD labelmaps, before
+      // updateSegmentations replaces them.
       const _oldLayers = (lm.labelmaps ?? {}) as Record<string, any>;
       const _purgeLayerVolumes = () => {
         for (const labelmapId of new Set(_staleLayerIds)) {
@@ -2514,7 +2484,7 @@ const commandsModule = ({
       // Let the reconcile settle before the images backing the dropped layer are freed below.
       await new Promise(resolve => requestAnimationFrame(() => resolve(null)));
 
-      // Nothing references these now — reclaim the block (~84MB).
+      // Nothing references these now — reclaim the block's images.
       for (const id of removed) {
         try { cache.removeImageLoadObject(id, { force: true }); } catch { /* already gone */ }
       }
@@ -3507,12 +3477,12 @@ const commandsModule = ({
 
           let merged_derivedImages = [];
           let z_range = [];
-          // Old block's imageIds when this is a refine — evicted from the cornerstone cache
-          // AFTER the representation swap below, so the ~84MB fresh block minted each refine
-          // doesn't accumulate (leak was ~+84MB/refine, inflating MPR remount + GC pauses).
+          // Images the NEXT representation no longer references — evicted from the cornerstone
+          // cache after the representation swap below, so blocks superseded by a reallocation
+          // don't accumulate. (Before blocks were z-cropped this was a whole fresh ~84MB block
+          // every refine; reuse and cropping have shrunk it, but a reallocation still orphans one.)
           let _orphanedImageIds: string[] = [];
-          // Block -> segment map for the representation we are about to write.
-          let _nextBlockSegments: number[] | null = null;
+          // The block list for the representation we are about to write.
           let _nextBlocks: LabelmapBlock[] | null = null;
           // Set when the refined crop was written straight into the on-screen MPR labelmap volume,
           // which lets us skip the remount (the remount is what orphans a volume every refine).
@@ -3845,7 +3815,6 @@ const commandsModule = ({
                 _prevBlocks.filter(b => b.segmentIndex !== segmentNumber),
                 _newBlock
               );
-          _nextBlockSegments = _nextBlocks.map(b => b.segmentIndex);
           // EVICT WHATEVER THE NEXT REPRESENTATION NO LONGER REFERENCES. Stated as a set
           // difference rather than as a list of the cases that produce orphans: the previous
           // formulation gated on `_isRefine && _reuseIdx < 0 && _prevBlock`, which silently
@@ -3872,6 +3841,11 @@ const commandsModule = ({
           }
           merged_derivedImages = flattenBlocks(_nextBlocks).map(id => cache.getImage(id));
         } else {
+          // unreachable: `overlap` is a const `true` in this command, so nothing below runs.
+          // Kept only as the historical single-layer variant. Do NOT read it as a live path or
+          // copy from it — it indexes `merged_derivedImages` (a flattened MULTI-block list) with
+          // full-series working indices and flips with that list's length rather than the series
+          // length, both of which are wrong now that blocks are z-cropped and z-offset.
           if (segImageIds.length == 0){
             const _tCreate2 = Date.now();
             let derivedImages_new = await imageLoader.createAndCacheDerivedLabelmapImages(imageIds);
@@ -4036,7 +4010,6 @@ const commandsModule = ({
             currentImageIdIndex,
             z_range,
             mprInPlaceDone: _mprInPlaceDone,
-            blockSegments: _nextBlockSegments,
             blocks: _nextBlocks,
           });
           // Evict the orphaned old block now that the representation swap + volume rebuild are

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -37,7 +37,7 @@ import {
 import { parseMultipart } from './utils/multipart';
 import { callInputDialog } from './utils/callInputDialog';
 import { getNninterToken, clearNninterToken } from './utils/nninterSession';
-import { LabelmapBlock, describeBlocks, blockIndexForSegment, replaceBlockAt, appendBlock, flattenBlocks, flipIndex, withoutBlockAt, blockContains, clampRange, snapRangeToGrid, sourceRangeForWorking, MIN_BLOCK_SLICES, BLOCK_GRID_SLICES } from './utils/labelmapBlocks';
+import { LabelmapBlock, describeBlocks, blockIndexForSegment, replaceBlockAt, appendBlock, flattenBlocks, flipIndex, withoutBlockAt, blockContains, clampRange, snapRangeToGrid, shouldShrinkBlock, sourceRangeForWorking, MIN_BLOCK_SLICES, BLOCK_GRID_SLICES, BLOCK_SHRINK_FACTOR } from './utils/labelmapBlocks';
 
 /** Tracks the last series initialized by initNninter to detect study/series changes. */
 let _lastInitSeries: string | undefined = undefined;
@@ -3565,11 +3565,21 @@ const commandsModule = ({
           // Reuse requires the existing block to still COVER the new mask. nnInteractive returns the
           // full current mask each refine, so a mask that grew past the block's z-range needs a
           // bigger block — which changes imageIds, so that refine takes the normal remount path.
-          // A block is never shrunk: staying at the high-water mark avoids realloc churn when a mask
-          // oscillates across a slice boundary.
           const _fitsBlock = !!_prevBlock && blockContains(_prevBlock, _bw0, _bw1);
+          // ...and, since a block would otherwise never shrink, that it is not GROSSLY oversized.
+          // Staying at the high-water mark is what absorbs a mask oscillating across a slice
+          // boundary, but a single runaway inference (a mis-click that segments air) can inflate a
+          // block to the whole series in one step — observed 96 -> 321 slices — and the segment
+          // then held ~84 MB for the rest of the session even once the mask was small again.
+          // BLOCK_SHRINK_FACTOR is the hysteresis that separates the two: ordinary oscillation
+          // stays well inside it, a runaway does not. Measured against [_aw0, _aw1) — the range a
+          // FRESH block would take — never the mask's own [_bw0, _bw1), because comparing against
+          // the mask would reclaim exactly the headroom the grid deliberately reserved.
+          const _shrinkBlock =
+            !!_prevBlock &&
+            shouldShrinkBlock(_prevBlock.imageIds.length, _aw1 - _aw0, BLOCK_SHRINK_FACTOR);
           const _reuseIdx = (_hasCropGeom && !toolboxState.getRefineNew() && _nMpr > 0 && _nStack === 0
-            && _fitsBlock) ? _blockIdxForSeg : -1;
+            && _fitsBlock && !_shrinkBlock) ? _blockIdxForSeg : -1;
 
           // Working-order offset of the block being written.
           // INVARIANT: on the REUSE path this MUST equal _prevBlock.z0, because _clearIdxs, the

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -252,12 +252,40 @@ const commandsModule = ({
     // with the wrong source slice and render the overlay z-mirrored. Derive referencedImageIds
     // from each labelmap image's own referencedImageId so the mapping is order-safe
     // (identity for a non-flipped series where blockImageIds are already in display order).
-    const refIdsFor = (ids: string[]): string[] => {
+    //
+    // PREFERENCE ORDER:
+    //   1. the block's own `referencedImageIds` — recorded at allocation from the exact source
+    //      slices, so it survives an LRU purge of the block's labelmap images;
+    //   2. the cache-derived ids, for blocks predating (1);
+    //   3. the whole-series list, and ONLY for a block that actually spans the series. For a
+    //      z-cropped block that fallback pairs block slice 0 with display slice 0 and renders the
+    //      segment at the wrong anatomical depth, so it is refused loudly instead.
+    const refIdsFor = (block: LabelmapBlock): string[] => {
+      const ids = block.imageIds;
+      if (block.referencedImageIds?.length === ids.length) {
+        return block.referencedImageIds;
+      }
       const refs = ids.map(id => (cache.getImage(id) as any)?.referencedImageId);
       // Compare against the BLOCK's own length: a sparse (z-cropped) block is shorter than N, and
       // the old `refs.length === N` guard would silently fall back to the full source list, pairing
       // its slices with the wrong source images.
-      return refs.length === ids.length && refs.every(Boolean) ? (refs as string[]) : imageIds;
+      if (refs.length === ids.length && refs.every(Boolean)) {
+        return refs as string[];
+      }
+      if (ids.length === imageIds.length) {
+        return imageIds;
+      }
+      console.error(
+        `[labelmap] segment ${block.segmentIndex}: cannot resolve referencedImageIds for its ` +
+        `${ids.length}-slice block (series has ${imageIds.length}); its labelmap images are no ` +
+        `longer cached and the block records none. Refusing to substitute the full-series list, ` +
+        `which would render this segment at the wrong depth.`
+      );
+      // Length-matched placeholder only: cornerstone pairs by index and a short/empty list would
+      // throw rather than degrade. The depth is still not trustworthy — that is what the error above
+      // is for. Unreachable in practice: allocation records referencedImageIds, and the LRU-touch
+      // loop keeps live blocks' images cached.
+      return imageIds.slice(0, ids.length);
     };
 
     for (let b = 0; b < blockList.length; b++) {
@@ -269,7 +297,7 @@ const commandsModule = ({
         type: 'stack',
         imageIds: blockImageIds,
         referencedVolumeId: currentDisplaySets.displaySetInstanceUID,
-        referencedImageIds: refIdsFor(blockImageIds),
+        referencedImageIds: refIdsFor(blockList[b]),
         labelToSegmentIndex: {},
       };
       segmentBindings[segIdx] = { labelmapId, labelValue: segIdx };
@@ -2348,6 +2376,44 @@ const commandsModule = ({
       const removed = blocks[bIdx].imageIds.slice();
       const nextBlocks = withoutBlockAt(blocks, bIdx);
 
+      // Which labelmapIds change hands. Mirrors buildMultiBlockLabelmapRepresentation exactly:
+      // block 0 is the PRIMARY (`-storage-0`), every other block is `-private-${segmentIndex}`.
+      const _layerOwners = (bs: LabelmapBlock[]) => {
+        const m = new Map<string, number>();
+        bs.forEach((b, i) =>
+          m.set(i === 0 ? `${segmentationId}-storage-0` : `${segmentationId}-private-${b.segmentIndex}`, b.segmentIndex)
+        );
+        return m;
+      };
+      const _oldOwners = _layerOwners(blocks);
+      const _newOwners = _layerOwners(nextBlocks);
+      // Any id whose owning segment is not the same before and after. That is:
+      //   - the dropped block's own id (gone from _newOwners);
+      //   - `-storage-0` when block 0 itself was dropped, because the next block is PROMOTED into
+      //     position 0 and inherits that id — it must not inherit the deleted segment's volume;
+      //   - the promoted block's former `-private-N` id, now orphaned.
+      // Ids that keep the same owner are untouched: not purging them is the whole point of taking
+      // the light reconcile path instead of a full remount.
+      const _staleLayerIds = [..._oldOwners.keys(), ..._newOwners.keys()].filter(
+        id => _oldOwners.get(id) !== _newOwners.get(id)
+      );
+      // Same purge remountSegmentationRepresentations does (~:753-763): the explicit
+      // geometryVolumeId the layer store stamped on the layer, plus the `${labelmapId}-geometry`
+      // key it defaults to. Read from the OLD labelmaps, before updateSegmentations replaces them.
+      const _oldLayers = (lm.labelmaps ?? {}) as Record<string, any>;
+      const _purgeLayerVolumes = () => {
+        for (const labelmapId of new Set(_staleLayerIds)) {
+          const explicitId = _oldLayers[labelmapId]?.geometryVolumeId;
+          if (explicitId && cache.getVolume(explicitId)) {
+            cache.removeVolumeLoadObject(explicitId);
+          }
+          const defaultKey = `${labelmapId}-geometry`;
+          if (cache.getVolume(defaultKey)) {
+            cache.removeVolumeLoadObject(defaultKey);
+          }
+        }
+      };
+
       const { labelmapRepresentation } = buildMultiBlockLabelmapRepresentation({
         segmentationId,
         derivedImageIds: flattenBlocks(nextBlocks),
@@ -2366,6 +2432,16 @@ const commandsModule = ({
           },
         },
       ]);
+
+      // MUST run before the reconcile below. Segment numbers are REUSED (getRefineNew assigns
+      // minAvailableNumber), so deleting segment 2 and creating a new one lands on the same
+      // `-private-2` labelmapId; cornerstone's getOrCreateLabelmapVolume would then hand back the
+      // deleted segment's cached volume. Neither releaseSegmentBlock's image eviction nor
+      // cornerstone's unmount path purges the VOLUME cache — only remountSegmentationRepresentations
+      // did, and we deliberately take the lighter reconcile path here. With z-cropped blocks a
+      // resurrected volume no longer even has the right depth, so this became a wrong-render bug
+      // rather than merely stale pixels.
+      _purgeLayerVolumes();
 
       // Removing a block is a LAYER-SET change, so cornerstone's reconcile can unmount just that
       // layer — no need to tear down and rebuild every other block's volume (that full remount is
@@ -3450,12 +3526,31 @@ const commandsModule = ({
             );
           }
 
+          // THE working range this refine needs, clamped to the series and widened to
+          // MIN_BLOCK_SLICES. Computed ONCE, here, and used for BOTH the containment test below and
+          // the allocation further down — they must agree.
+          //
+          // Testing containment against the raw server geometry instead was a trap: if the server
+          // ever returned _segZ1 > _imgLen0 (or _segZ0 < 0), allocation would truncate the block to
+          // the series, so the block could never satisfy blockContains(_prevBlock, _segZ0, _segZ1) —
+          // and the segment would reallocate and remount on EVERY subsequent refine, forever, with
+          // no error and no visual symptom. Comparing like with like removes that failure mode.
+          //
+          // The MIN_BLOCK_SLICES widening is centred, so a mask that shrinks to a SINGLE slice
+          // sitting on a block's first slice widens one below it and misses containment by one.
+          // That costs one reallocation and then converges — the replacement block is cut from this
+          // same range, so the next refine fits. Bounded, unlike the unclamped comparison above.
+          // Without crop geometry the mask extent is unknown, so fall back to the full series.
+          const [_bw0, _bw1] = _hasCropGeom
+            ? clampRange(_segZ0, _segZ1, _imgLen0, MIN_BLOCK_SLICES)
+            : [0, _imgLen0];
+
           // Reuse requires the existing block to still COVER the new mask. nnInteractive returns the
           // full current mask each refine, so a mask that grew past the block's z-range needs a
           // bigger block — which changes imageIds, so that refine takes the normal remount path.
           // A block is never shrunk: staying at the high-water mark avoids realloc churn when a mask
           // oscillates across a slice boundary.
-          const _fitsBlock = !!_prevBlock && blockContains(_prevBlock, _segZ0, _segZ1);
+          const _fitsBlock = !!_prevBlock && blockContains(_prevBlock, _bw0, _bw1);
           const _reuseIdx = (_hasCropGeom && !toolboxState.getRefineNew() && _nMpr > 0 && _nStack === 0
             && _fitsBlock) ? _blockIdxForSeg : -1;
 
@@ -3465,6 +3560,9 @@ const commandsModule = ({
           // _prevBlock's own images/volume through it — and _newBlock.z0 is paired with
           // _prevBlock.imageIds. A fresh block sets it to that block's own crop-aligned start instead.
           let _newBlockZ0 = 0;
+          // The source slices backing the block being written, in working order. Set on both paths
+          // below and stored on _newBlock; see LabelmapBlock.referencedImageIds.
+          let _newBlockRefIds: string[] | undefined;
           const _tCreateStart = performance.now();
           let derivedImages_new: any[];
           let _clearIdxs: number[] = [];
@@ -3472,6 +3570,8 @@ const commandsModule = ({
             // Reuse the block as-is: NO image reads/writes here (that is the ~2.5s getScalarData tax).
             // The crop goes into the volume below; the images are synced lazily via _pendingImageSync.
             _newBlockZ0 = _prevBlock!.z0;
+            // Same block, same slices: carry the recorded pairing forward untouched.
+            _newBlockRefIds = _prevBlock!.referencedImageIds;
             derivedImages_new = _prevBlock!.imageIds.map(id => cache.getImage(id));
             const _ps = (existingSegments[segmentNumber] as any)?.cachedStats;
             const _pd = _ps?.dirtySlices as number[] | undefined;
@@ -3517,18 +3617,22 @@ const commandsModule = ({
             // resident heap is what drives the GC pauses. Cornerstone sizes the MPR volume from the
             // block's own images (dimensions[2] = imageIds.length) and takes its origin from their
             // positions, so a shorter block renders at the correct place.
-            // Without crop geometry the mask extent is unknown, so fall back to the full series.
-            const [_bw0, _bw1] = _hasCropGeom
-              ? clampRange(_segZ0, _segZ1, _imgLen0, MIN_BLOCK_SLICES)
-              : [0, _imgLen0];
+            // [_bw0, _bw1] was computed ABOVE, so the range allocation uses and the range
+            // containment was tested against are one and the same value.
+            //
             // imageIds are in DISPLAY order; a flipped series mirrors the working range onto them
             // and the result needs reversing to come back in working order. This replaces the old
             // blanket `if (flipped) derivedImages_new.reverse()`, which assumed a full-length block.
             const _src = sourceRangeForWorking(_bw0, _bw1, _imgLen0, flipped);
+            // The block's SOURCE slices. Recorded on the block below so the labelmap -> series
+            // pairing never has to be re-derived from the (LRU-purgeable) image cache.
+            _newBlockRefIds = imageIds.slice(_src.start, _src.end);
             derivedImages_new = await imageLoader.createAndCacheDerivedLabelmapImages(
-              imageIds.slice(_src.start, _src.end)
+              _newBlockRefIds
             );
             if (_src.reverse) {
+              // Both lists flip together: they must stay index-aligned in working order.
+              _newBlockRefIds = _newBlockRefIds.slice().reverse();
               derivedImages_new.reverse();
             }
             _newBlockZ0 = _bw0;
@@ -3662,6 +3766,7 @@ const commandsModule = ({
             imageIds: _reuseIdx >= 0
               ? _prevBlock!.imageIds.slice()
               : derivedImages_new.map((img: any) => img.imageId),
+            referencedImageIds: _newBlockRefIds,
           };
           _nextBlocks = _isRefine
             ? replaceBlockAt(_prevBlocks, _blockIdxForSeg, _newBlock)

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -3428,7 +3428,11 @@ const commandsModule = ({
           const _reuseIdx = (_hasCropGeom && !toolboxState.getRefineNew() && _nMpr > 0 && _nStack === 0
             && !!_prevBlock) ? _blockIdxForSeg : -1;
 
-          // Always 0 for now; Task 5 will assign the real crop-aligned z0 here.
+          // Working-order offset of the block being written. Always 0 while blocks span the whole series.
+          // INVARIANT for the sparse rework: on the REUSE path this MUST equal _prevBlock.z0, because
+          // _clearIdxs, the blockZ0 argument, the _pendingImageSync payload and the fallback write loop
+          // all index _prevBlock's own images/volume through it — and _newBlock.z0 is paired with
+          // _prevBlock.imageIds. A fresh block sets it to that block's own crop-aligned start instead.
           let _newBlockZ0 = 0;
           const _tCreateStart = performance.now();
           let derivedImages_new: any[];
@@ -3450,6 +3454,9 @@ const commandsModule = ({
                   { length: Math.max(0, (_ps?.segZ1 ?? _imgLen0) - (_ps?.segZ0 ?? 0)) },
                   (_, k) => (_ps?.segZ0 ?? 0) + k
                 );
+            // FIXME(sparse): the segZ0/segZ1 fallback below yields WORKING indices but is flipped as if
+            // they were display indices — wrong for a flipped series with no recorded dirtySlices.
+            // Pre-existing; becomes materially wrong once blocks are z-cropped.
             // dirtySlices are DISPLAY indices into the full series. Convert to working order (N is
             // the SERIES length, not the block's), then to this block's array index.
             _clearIdxs = _prevIdxs
@@ -3473,7 +3480,7 @@ const commandsModule = ({
               const _base = (z - _segZ0) * _sliceArea;
               for (let k = 0; k < _sliceArea; k++) {
                 if (cropBytes[_base + k] === 1) {
-                  z_range.push(flipped ? derivedImages_new.length - z - 1 : z);
+                  z_range.push(flipIndex(z, _imgLen0, flipped));
                   break;
                 }
               }

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -37,6 +37,7 @@ import {
 import { parseMultipart } from './utils/multipart';
 import { callInputDialog } from './utils/callInputDialog';
 import { getNninterToken, clearNninterToken } from './utils/nninterSession';
+import { LabelmapBlock, describeBlocks } from './utils/labelmapBlocks';
 
 /** Tracks the last series initialized by initNninter to detect study/series changes. */
 let _lastInitSeries: string | undefined = undefined;
@@ -200,45 +201,6 @@ const commandsModule = ({
       }
     }, 400);
     _statsDebounceTimers.set(key, timer);
-  }
-
-  /**
-   * A labelmap block: the slices of ONE segment's mask.
-   *
-   * Blocks used to be uniform — every segment allocated a full-volume block (N slices, ~84MB) even
-   * though its mask typically covers ~40 of 321 slices (~95% zeros). That fixed size is what drives
-   * the resident memory and therefore the GC pauses. A block is now described explicitly so it can
-   * cover only [z0, z0+imageIds.length) — cornerstone builds the MPR volume from the block's own
-   * images (dimensions = imageIds.length, origin = first image's position), so a z-cropped block
-   * still renders at the correct place.
-   */
-  type LabelmapBlock = { segmentIndex: number; z0: number; imageIds: string[] };
-
-  /**
-   * Describe an existing representation as explicit blocks.
-   * Handles the legacy uniform layout (flat allImageIds in N-sized chunks, optionally with the
-   * blockSegments map) so representations built before sparse blocks keep working.
-   */
-  function describeBlocks(labelmapData: any, sourceCount: number): LabelmapBlock[] {
-    if (!labelmapData) return [];
-    if (Array.isArray(labelmapData.blocks) && labelmapData.blocks.length) {
-      return labelmapData.blocks.map((b: any) => ({
-        segmentIndex: b.segmentIndex,
-        z0: b.z0 ?? 0,
-        imageIds: b.imageIds ?? [],
-      }));
-    }
-    const all: string[] = labelmapData.allImageIds ?? labelmapData.imageIds ?? [];
-    if (!sourceCount || all.length < sourceCount) return [];
-    const count = Math.floor(all.length / sourceCount);
-    const segs: number[] = (labelmapData.blockSegments?.length === count)
-      ? labelmapData.blockSegments
-      : Array.from({ length: count }, (_, b) => b + 1);
-    return Array.from({ length: count }, (_, b) => ({
-      segmentIndex: segs[b],
-      z0: 0,
-      imageIds: all.slice(b * sourceCount, (b + 1) * sourceCount),
-    }));
   }
 
   function buildMultiBlockLabelmapRepresentation({

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -863,7 +863,6 @@ const commandsModule = ({
       await activeVp.setImageIdIndex(currentImageIdIndex);
     }
 
-
     eventTarget.dispatchEvent(
       new CustomEvent(csToolsEnums.Events.SEGMENTATION_DATA_MODIFIED, {
         detail: { segmentationId },
@@ -3322,9 +3321,6 @@ const commandsModule = ({
 
       let data = MonaiLabelClient.constructFormData(params, null);
 
-      
-      const beforePost = Date.now();
-
       // Create the axios promise
       const segmentationPromise = axios.post(url, data, {
         responseType: 'arraybuffer',
@@ -3356,8 +3352,6 @@ const commandsModule = ({
         // Process the response
         const response = await segmentationPromise;
         if (response.status === 200) {
-            const afterPost = Date.now();
-            const networkRoundTripMs = afterPost - beforePost;
             const ct = response.headers["content-type"] as string;
             const { meta, seg } = await parseMultipart(response.data, ct, { allowEmptySeg: true });
             // Server-side session was evicted/timed out. Reclaim, re-init, and
@@ -3390,30 +3384,6 @@ const commandsModule = ({
             if (!seg.length) {
               throw new Error('seg part not found');
             }
-            const afterParse = Date.now();
-
-            // --- server-side timing breakdown ---
-            const sRequestTs     = metaNum(meta as Record<string,unknown>, 'server_request_ts');
-            const sBeginTs       = metaNum(meta as Record<string,unknown>, 'server_begin_ts');
-            const sEndTs         = metaNum(meta as Record<string,unknown>, 'server_end_ts');
-            const sLoad          = metaNum(meta as Record<string,unknown>, 'server_load_elapsed');
-            const sImgConvert    = metaNum(meta as Record<string,unknown>, 'server_img_convert_elapsed');
-            const sPromptPrep    = metaNum(meta as Record<string,unknown>, 'server_prompt_prep_elapsed');
-            const sModelCore     = metaNum(meta as Record<string,unknown>, 'nninter_core_elapsed');
-            const sResult        = metaNum(meta as Record<string,unknown>, 'server_result_elapsed');
-            const sTotal         = metaNum(meta as Record<string,unknown>, 'nninter_elapsed');
-            const sFirstTs       = metaNum(meta as Record<string,unknown>, 'nninter_first_interaction_ts');
-
-            // Four-leg split (all server timestamps share the same host clock as the container):
-            //   leg1: POST in flight          = server_request_ts - beforePost (client clock vs server clock; same host → accurate)
-            //   leg2: MONAI pre-processing    = server_begin_ts - server_request_ts (DICOM download from Orthanc, entirely server-side)
-            //   leg3: our infer()             = server_end_ts - server_begin_ts (same clock, exact)
-            //   leg4: response in flight      = afterPost - server_end_ts (same host → accurate)
-            const postInFlightMs    = (sRequestTs != null) ? sRequestTs * 1000 - beforePost                     : undefined;
-            const monaiPrepMs       = (sRequestTs != null && sBeginTs != null) ? (sBeginTs - sRequestTs) * 1000 : undefined;
-            const serverProcessMs   = (sBeginTs   != null && sEndTs   != null) ? (sEndTs   - sBeginTs)   * 1000 : undefined;
-            const responseInFlightMs= (sEndTs     != null)                     ? afterPost - sEndTs * 1000      : undefined;
-
 
             const flipped = meta.flipped.toLowerCase() === "true"
             const nninter_elapsed = meta.nninter_elapsed
@@ -3592,7 +3562,6 @@ const commandsModule = ({
           // The source slices backing the block being written, in working order. Set on both paths
           // below and stored on _newBlock; see LabelmapBlock.referencedImageIds.
           let _newBlockRefIds: string[] | undefined;
-          const _tCreateStart = performance.now();
           let derivedImages_new: any[];
           let _clearIdxs: number[] = [];
           if (_reuseIdx >= 0) {
@@ -3783,7 +3752,6 @@ const commandsModule = ({
               }
             }
           }
-
 
           // The refined segment's block is REPLACED in the list (keeping its position, so no other
           // segment is renumbered); a new segment APPENDS one. This used to be done by slicing the

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -37,7 +37,7 @@ import {
 import { parseMultipart } from './utils/multipart';
 import { callInputDialog } from './utils/callInputDialog';
 import { getNninterToken, clearNninterToken } from './utils/nninterSession';
-import { LabelmapBlock, describeBlocks, blockIndexForSegment, replaceBlockAt, appendBlock, flattenBlocks } from './utils/labelmapBlocks';
+import { LabelmapBlock, describeBlocks, blockIndexForSegment, replaceBlockAt, appendBlock, flattenBlocks, flipIndex, withoutBlockAt } from './utils/labelmapBlocks';
 
 /** Tracks the last series initialized by initNninter to detect study/series changes. */
 let _lastInitSeries: string | undefined = undefined;
@@ -451,7 +451,9 @@ const commandsModule = ({
           for (let j = 0; j < sd.length; j++) if (sd[j] === p.segmentNumber) sd[j] = 0;
         }
         for (let z = p.segZ0; z < p.segZ1; z++) {
-          const vm = cache.getImage(p.blockImageIds[z])?.voxelManager as csTypes.IVoxelManager<number>;
+          const arrIdx = z - p.z0;
+          if (arrIdx < 0 || arrIdx >= p.blockImageIds.length) continue;
+          const vm = cache.getImage(p.blockImageIds[arrIdx])?.voxelManager as csTypes.IVoxelManager<number>;
           if (!vm) continue;
           const sd = vm.getScalarData();
           const cropSliceBase = (z - p.segZ0) * p.cropY * p.cropX;
@@ -503,6 +505,7 @@ const commandsModule = ({
     prevZ0,
     prevZ1,
     prevBox,
+    blockZ0,
   }: {
     segmentNumber: number;
     cropBytes: Uint8Array;
@@ -512,6 +515,11 @@ const commandsModule = ({
     fullX: number; fullY: number;
     prevZ0: number; prevZ1: number;
     prevBox?: { y0: number; x0: number; cropY: number; cropX: number } | null;
+    /**
+     * Working-order offset of this block's first slice. The volume is built from the block's own
+     * images, so its z index is block-relative: volume z = working z - blockZ0.
+     */
+    blockZ0: number;
   }): boolean {
     const vpSvc = servicesManager.services.cornerstoneViewportService;
     const sliceLen = fullY * fullX;
@@ -539,8 +547,9 @@ const commandsModule = ({
         // occupies its crop bbox, so scanning full 512x512 slices was ~10M redundant checks/refine
         // (measured 46-149ms). prevBox is the previous refine's bbox (union'd with the new crop so a
         // moved/shrunk mask is fully cleared); without it we fall back to the full slice.
-        const clearZ0 = Math.max(0, Math.min(prevZ0, segZ0));
-        const clearZ1 = Math.min(Math.floor(data.length / sliceLen), Math.max(prevZ1, segZ1));
+        const blockDepth = Math.floor(data.length / sliceLen);
+        const clearZ0 = Math.max(0, Math.min(prevZ0, segZ0) - blockZ0);
+        const clearZ1 = Math.min(blockDepth, Math.max(prevZ1, segZ1) - blockZ0);
         const bx0 = prevBox ? Math.max(0, Math.min(prevBox.x0, x0)) : 0;
         const bx1 = prevBox ? Math.min(fullX, Math.max(prevBox.x0 + prevBox.cropX, x0 + cropX)) : fullX;
         const by0 = prevBox ? Math.max(0, Math.min(prevBox.y0, y0)) : 0;
@@ -558,7 +567,9 @@ const commandsModule = ({
         // Pass 2: write the new crop.
         for (let z = segZ0; z < segZ1; z++) {
           const cropSliceBase = (z - segZ0) * cropY * cropX;
-          const volSliceBase = z * sliceLen;
+          const volZ = z - blockZ0;
+          if (volZ < 0 || volZ >= blockDepth) continue;
+          const volSliceBase = volZ * sliceLen;
           for (let cy = 0; cy < cropY; cy++) {
             const srcRow = cropSliceBase + cy * cropX;
             const dstRow = volSliceBase + (y0 + cy) * fullX + x0;
@@ -2315,33 +2326,26 @@ const commandsModule = ({
       const seg = csToolsSegmentation.state.getSegmentation(segmentationId);
       const lm = seg?.representationData?.Labelmap as any;
       if (!lm) return;
-      const all: string[] = lm.allImageIds ?? lm.imageIds ?? [];
       const srcIds: string[] = lm.referencedImageIds ?? [];
-      const N = srcIds.length;
-      if (!N || all.length < N) return;
-      const blockCount = Math.floor(all.length / N);
+      const blocks = describeBlocks(lm, srcIds.length);
       // Keep at least one block: cornerstone needs a primary labelmap to render at all.
-      if (blockCount <= 1) return;
-      const blockSeg: number[] = (lm.blockSegments?.length === blockCount)
-        ? lm.blockSegments.slice()
-        : Array.from({ length: blockCount }, (_, b) => b + 1);
-      const bIdx = blockSeg.indexOf(segmentIndex);
+      if (blocks.length <= 1) return;
+      const bIdx = blockIndexForSegment(blocks, segmentIndex);
       if (bIdx < 0) return;   // segment has no dedicated block (e.g. single-layer SAM2 labelmap)
 
       // Drop any deferred in-place write for this segment — its block is going away.
       _pendingImageSync.get(segmentationId)?.delete(segmentIndex);
 
-      const removed = all.slice(bIdx * N, (bIdx + 1) * N);
-      const remaining = [...all.slice(0, bIdx * N), ...all.slice((bIdx + 1) * N)];
-      const nextBlockSeg = blockSeg.filter((_, i) => i !== bIdx);
+      const removed = blocks[bIdx].imageIds.slice();
+      const nextBlocks = withoutBlockAt(blocks, bIdx);
 
       const { labelmapRepresentation } = buildMultiBlockLabelmapRepresentation({
         segmentationId,
-        derivedImageIds: remaining,
+        derivedImageIds: flattenBlocks(nextBlocks),
         imageIds: srcIds,
         currentDisplaySets: { displaySetInstanceUID: lm.referencedVolumeId },
         segments: seg?.segments ?? {},
-        blockSegments: nextBlockSeg,
+        blocks: nextBlocks,
       });
 
       const existingRepresentationData = seg?.representationData || {};
@@ -3446,7 +3450,11 @@ const commandsModule = ({
                   { length: Math.max(0, (_ps?.segZ1 ?? _imgLen0) - (_ps?.segZ0 ?? 0)) },
                   (_, k) => (_ps?.segZ0 ?? 0) + k
                 );
-            _clearIdxs = _prevIdxs.map((d: number) => (flipped ? (_imgLen0 - 1 - d) : d));
+            // dirtySlices are DISPLAY indices into the full series. Convert to working order (N is
+            // the SERIES length, not the block's), then to this block's array index.
+            _clearIdxs = _prevIdxs
+              .map((d: number) => flipIndex(d, _imgLen0, flipped) - _newBlockZ0)
+              .filter((i: number) => i >= 0 && i < derivedImages_new.length);
           } else {
             derivedImages_new = await imageLoader.createAndCacheDerivedLabelmapImages(imageIds);
           }
@@ -3525,6 +3533,7 @@ const commandsModule = ({
               prevZ0: (_prevStats?.segZ0 != null) ? _prevStats.segZ0 as number : _segZ0,
               prevZ1: (_prevStats?.segZ1 != null) ? _prevStats.segZ1 as number : _segZ1,
               prevBox: (_prevStats?.cropBox ?? null) as any,
+              blockZ0: _newBlockZ0,
             });
             if (_mprInPlaceDone) {
               // Queue the image write we skipped. Latest payload per segment wins (the server sends
@@ -3537,6 +3546,7 @@ const commandsModule = ({
                 segZ0: _segZ0, segZ1: _segZ1, cropY: _cropY, cropX: _cropX,
                 y0: _y0, x0: _x0, fullX: _fullX,
                 clearIdxs: _clearIdxs,
+                z0: _newBlockZ0,
               });
             } else {
               // Volume not found: nothing was written anywhere, so fall back to the normal path by
@@ -3548,7 +3558,8 @@ const commandsModule = ({
                 for (let j = 0; j < _sd.length; j++) if (_sd[j] === segmentNumber) _sd[j] = 0;
               }
               for (let z = _segZ0; z < _segZ1; z++) {
-                const _vm = derivedImages_new[z]?.voxelManager as csTypes.IVoxelManager<number>;
+                const _ai = z - _newBlockZ0;
+                const _vm = derivedImages_new[_ai]?.voxelManager as csTypes.IVoxelManager<number>;
                 if (!_vm) continue;
                 const _sd = _vm.getScalarData();
                 const _cb = (z - _segZ0) * _cropY * _cropX;

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -221,7 +221,13 @@ const commandsModule = ({
     blocks?: LabelmapBlock[];
   }) {
     const N = imageIds.length;
-    const blockCount = N > 0 ? Math.floor(derivedImageIds.length / N) : 1;
+    // Only meaningful for the LEGACY uniform layout (every block one image per series slice).
+    // Callers that pass explicit `blocks` ignore it. Math.max(1, ...) because a caller that
+    // supplies no blocks but takes its images from a SPARSE representation (the SAM2 path, whose
+    // derivedImageIds are the flattened sparse blocks) divides a short flat list by the full
+    // series length and gets 0 — which produced an empty blockList, hence empty labelmaps and
+    // segmentBindings, and the representation lost every layer.
+    const blockCount = N > 0 ? Math.max(1, Math.floor(derivedImageIds.length / N)) : 1;
     // EXPLICIT block -> segment map. This used to be positional (block b always held segment b+1),
     // which is why a segment's block could never be removed: dropping a middle block shifted every
     // later block and silently renumbered those segments. Callers now pass the mapping so blocks can
@@ -2091,6 +2097,48 @@ const commandsModule = ({
         return;
       }
 
+      // segImageIds is this segment's BLOCK: z-cropped and z-offset, so it is NOT the series.
+      // Three spaces meet in the write passes below and must never be conflated:
+      //   working     — index into the full series; the space the server's crop geometry
+      //                 (_segZ0/_segZ1) and cachedStats.segZ0/segZ1 are expressed in;
+      //   display     — index into the source series; the space cachedStats.dirtySlices and
+      //                 z_range are expressed in. Convert with flipIndex(_, _seriesLen, flipped),
+      //                 whose N is ALWAYS the series length, never the block's;
+      //   block-array — index into `merged` / segImageIds, i.e. `working - _blockZ0`.
+      //
+      // The series length must come from allReferencedImageIds: syncLegacyLabelmapData reverts
+      // both `imageIds` and `referencedImageIds` to the PRIMARY LAYER's (block-scoped) value on
+      // every entry into state, so neither of those is the series.
+      const _seriesLen: number =
+        (labelmapState?.allReferencedImageIds ?? labelmapState?.referencedImageIds ?? []).length;
+      const _undoBlocks = describeBlocks(labelmapState, _seriesLen);
+      const _undoBlockIdx = blockIndexForSegment(_undoBlocks, segmentNumber);
+      // Fall back to z0 = 0 ONLY for the legacy uniform layout, where the layer genuinely spans
+      // the whole series. Guessing 0 for a cropped block would clear and rewrite the wrong slices.
+      const _resolvedZ0: number | null =
+        _undoBlockIdx >= 0
+          ? _undoBlocks[_undoBlockIdx].z0
+          : _seriesLen > 0 && segImageIds.length === _seriesLen
+            ? 0
+            : null;
+      if (_resolvedZ0 === null) {
+        // Refuse BEFORE the request so the server's interaction stack and the on-screen mask stay
+        // in agreement — a server-side undo we cannot apply locally is worse than no undo at all.
+        console.error(
+          `[labelmap] undo: cannot locate segment ${segmentNumber}'s block ` +
+          `(${segImageIds.length} slices) within its ${_seriesLen}-slice series; ` +
+          `refusing to write to unverified slices.`
+        );
+        uiNotificationService.show({
+          title: 'MONAI Label',
+          message: 'Undo - Failed: cannot locate this segment\'s labelmap block.',
+          type: 'error',
+          duration: 5000,
+        });
+        return;
+      }
+      const _blockZ0: number = _resolvedZ0;
+
       let nninterToken = '';
       try {
         nninterToken = await getNninterToken();
@@ -2198,13 +2246,15 @@ const commandsModule = ({
         }
 
         // segImageIds is the stored block order. The running (overlap) inference path already
-        // leaves it in reversed z-order for a flipped series — the same order the crop is
-        // written by index. Do NOT reverse here: doing so double-flips and lands the restored
-        // crop on the mirrored slice. The `flipped ? merged.length-1-x : x` formulas below map
-        // array index <-> display-slice index within this stored order.
+        // leaves it in WORKING order for a flipped series — the same order the crop is written
+        // by index. Do NOT reverse here: doing so double-flips and lands the restored crop on
+        // the mirrored slice. The passes below convert display <-> working with flipIndex over
+        // _seriesLen, then subtract _blockZ0 to reach this array.
         const merged = segImageIds.map(imageId => cache.getImage(imageId));
 
         // Pass 1: clear all voxels of the active segment (use dirtySlices when available).
+        // ALWAYS runs, including the undo-to-empty case (!_hasCropGeom), which has no pass 2 —
+        // getting the indices wrong there removed nothing and reported success anyway.
         const prevStats = (activeSegmentation.segments?.[segmentNumber] as any)?.cachedStats;
         const prevDirty: number[] | undefined = prevStats?.dirtySlices;
         const clearSlice = (arrIdx: number) => {
@@ -2217,19 +2267,31 @@ const commandsModule = ({
         };
         if (prevDirty?.length) {
           for (const origIdx of prevDirty) {
-            clearSlice(flipped ? merged.length - 1 - origIdx : origIdx);
+            // display -> working (series length!) -> this block's array index, bounds-guarded:
+            // a slice recorded for this segment can legitimately fall outside its current block.
+            const w = flipIndex(origIdx, _seriesLen, flipped);
+            const ai = w - _blockZ0;
+            if (ai >= 0 && ai < merged.length) {
+              clearSlice(ai);
+            }
           }
         } else {
+          // No recorded extent: sweep the whole BLOCK. `i` is already a block-array index.
           for (let i = 0; i < merged.length; i++) clearSlice(i);
         }
 
         // Pass 2: write the restored crop (skipped entirely when the object is now empty).
         const z_range: number[] = [];
         if (_hasCropGeom) {
-          for (let i = _segZ0; i < _segZ1; i++) {
-            const sd = merged[i].voxelManager.getScalarData();
-            const c = i - _segZ0;
-            const cropSliceBase = c * _cropY * _cropX;
+          // `w` is a WORKING index into the full series — the space _segZ0/_segZ1 and cropBytes
+          // are expressed in. `ai` is the corresponding index into this block's own images.
+          for (let w = _segZ0; w < _segZ1; w++) {
+            const ai = w - _blockZ0;
+            if (ai < 0 || ai >= merged.length) continue;
+            const vm = merged[ai]?.voxelManager;
+            if (!vm) continue;
+            const sd = vm.getScalarData();
+            const cropSliceBase = (w - _segZ0) * _cropY * _cropX;
             let wrote = false;
             for (let cy = 0; cy < _cropY; cy++) {
               const srcRow = cropSliceBase + cy * _cropX;
@@ -2241,15 +2303,18 @@ const commandsModule = ({
                 }
               }
             }
-            if (wrote) z_range.push(flipped ? merged.length - i - 1 : i);
+            // dirtySlices is read back as DISPLAY indices into the full series.
+            if (wrote) z_range.push(flipIndex(w, _seriesLen, flipped));
           }
         }
 
-        // Keep cachedStats.dirtySlices in sync so the next interaction clears correctly.
+        // Keep cachedStats in sync so the next interaction clears correctly. dirtySlices stays
+        // DISPLAY-into-the-series; segZ0/segZ1 stay WORKING-into-the-series (never block-relative,
+        // and never the block's length — the refine path reads both back in exactly those spaces).
         if ((activeSegmentation.segments?.[segmentNumber] as any)?.cachedStats) {
           (activeSegmentation.segments[segmentNumber] as any).cachedStats.dirtySlices = z_range;
           (activeSegmentation.segments[segmentNumber] as any).cachedStats.segZ0 = _hasCropGeom ? _segZ0 : 0;
-          (activeSegmentation.segments[segmentNumber] as any).cachedStats.segZ1 = _hasCropGeom ? _segZ1 : merged.length;
+          (activeSegmentation.segments[segmentNumber] as any).cachedStats.segZ1 = _hasCropGeom ? _segZ1 : _seriesLen;
         }
 
         // Remove the most-recently-added prompt measurement for this series.
@@ -3770,26 +3835,35 @@ const commandsModule = ({
             ? replaceBlockAt(_prevBlocks, _blockIdxForSeg, _newBlock)
             : appendBlock(
                 // Filter out any pre-existing block for this segment before appending the new one.
-                // This cannot strand a block without evicting it: when getRefineNew() is true,
-                // segmentNumber is assigned minAvailableNumber (see ~line 3120-3130), so it never
-                // collides with an existing block's segmentIndex. And releaseSegmentBlock already
-                // drops blocks on segment delete. The filter is correct defence-in-depth; the
-                // _orphanedImageIds gate below is only reached on the _isRefine path.
+                // A collision is not supposed to happen — when getRefineNew() is true segmentNumber
+                // is assigned minAvailableNumber (see the segment-numbering block at the top of
+                // nninter), and releaseSegmentBlock drops a block on segment delete — but the two
+                // are derived from DIFFERENT sources (the segments map vs the block list) and
+                // releaseSegmentBlock early-returns in several cases, so they can drift. The
+                // eviction gate below is computed from the whole previous block list precisely so
+                // a block dropped here is reclaimed rather than leaked.
                 _prevBlocks.filter(b => b.segmentIndex !== segmentNumber),
                 _newBlock
               );
           _nextBlockSegments = _nextBlocks.map(b => b.segmentIndex);
-          // NEVER evict when reusing: the old block IS derivedImages_new (still live and on screen).
-          // Only a freshly allocated block orphans the previous one. Images the representation held
-          // but could not attribute to any block (_strandedImageIds) are dropped by the rebuild
-          // below, so they are evicted here too rather than left to leak. Belt-and-braces: never
-          // evict an id the block we just wrote is using.
+          // EVICT WHATEVER THE NEXT REPRESENTATION NO LONGER REFERENCES. Stated as a set
+          // difference rather than as a list of the cases that produce orphans: the previous
+          // formulation gated on `_isRefine && _reuseIdx < 0 && _prevBlock`, which silently
+          // assumed the segment-numbering and the block list could never disagree — but the
+          // append path's `.filter()` above can drop another block entirely, and then that
+          // block's images were removed from the representation without ever being freed.
+          //
+          // This is a genuine no-op wherever the old gate was: on the REUSE path _newBlock keeps
+          // _prevBlock's exact imageIds, so every previous id is in _keepIds; and every OTHER
+          // segment's block is carried into _nextBlocks unchanged, so its ids are too. It differs
+          // only where a block really did leave the representation — growth, move and shrink all
+          // mint fresh imageIds and are handled identically, plus the drift case above.
+          // _strandedImageIds (held by the representation, attributable to no block) are dropped
+          // by the rebuild below, so they are freed here rather than left to leak.
           const _keepIds = new Set(flattenBlocks(_nextBlocks));
-          _orphanedImageIds = (
-            _isRefine && _reuseIdx < 0 && _prevBlock
-              ? _prevBlock.imageIds.concat(_strandedImageIds)
-              : _strandedImageIds
-          ).filter(id => !_keepIds.has(id));
+          _orphanedImageIds = flattenBlocks(_prevBlocks)
+            .concat(_strandedImageIds)
+            .filter(id => !_keepIds.has(id));
           if (_orphanedImageIds.length) {
             // A deferred image write queued against the block we are about to evict is dead work:
             // its blockImageIds no longer resolve, and this refine wrote the new block's images

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -37,7 +37,7 @@ import {
 import { parseMultipart } from './utils/multipart';
 import { callInputDialog } from './utils/callInputDialog';
 import { getNninterToken, clearNninterToken } from './utils/nninterSession';
-import { LabelmapBlock, describeBlocks } from './utils/labelmapBlocks';
+import { LabelmapBlock, describeBlocks, blockIndexForSegment, replaceBlockAt, appendBlock, flattenBlocks } from './utils/labelmapBlocks';
 
 /** Tracks the last series initialized by initNninter to detect study/series changes. */
 let _lastInitSeries: string | undefined = undefined;
@@ -3373,12 +3373,13 @@ const commandsModule = ({
             const segImageIds = refreshedContext.segImageIds;
             const existingSegments = refreshedContext.existingSegments;
             const existing = refreshedContext.existing;
-            // Which segment each existing block holds. Null for representations built before the
-            // explicit map existed -> the positional fallback (block b = segment b+1) applies.
-            const _prevBlockSegments: number[] | null = refreshedContext.blockSegments;
-            const _blockIdxForSeg = _prevBlockSegments
-              ? _prevBlockSegments.indexOf(segmentNumber)
-              : segmentNumber - 1;
+            // Block list is the source of truth for layout. describeBlocks already normalises a
+            // pre-sparse representation to full-length blocks, so the old positional fallback
+            // (block b holds segment b+1) is no longer needed here.
+            const _prevBlocks: LabelmapBlock[] = refreshedContext.blocks ?? [];
+            const _blockIdxForSeg = blockIndexForSegment(_prevBlocks, segmentNumber);
+            const _prevBlock: LabelmapBlock | null =
+              _blockIdxForSeg >= 0 ? _prevBlocks[_blockIdxForSeg] : null;
 
           let merged_derivedImages = [];
           let z_range = [];
@@ -3388,6 +3389,7 @@ const commandsModule = ({
           let _orphanedImageIds: string[] = [];
           // Block -> segment map for the representation we are about to write.
           let _nextBlockSegments: number[] | null = null;
+          let _nextBlocks: LabelmapBlock[] | null = null;
           // Set when the refined crop was written straight into the on-screen MPR labelmap volume,
           // which lets us skip the remount (the remount is what orphans a volume every refine).
           let _mprInPlaceDone = false;
@@ -3404,7 +3406,6 @@ const commandsModule = ({
           // representation point at the new block while the screen still showed the volume built from
           // the old one — the refined segment disappeared. Reuse keeps both in agreement.)
           const _imgLen0 = imageIds.length;
-          const _numBlocks0 = _imgLen0 > 0 ? Math.floor(derivedImages.length / _imgLen0) : 0;
           // Only take the in-place path in an MPR-ONLY layout. With a stack viewport on screen the
           // images must stay current every frame, so deferring their write would show stale pixels;
           // there the fresh-block path is used (its images are cheap to write and its remount is
@@ -3417,15 +3418,17 @@ const commandsModule = ({
             else if (!(_vp instanceof VolumeViewport3D)) _nStack++;
           }
           const _reuseIdx = (_hasCropGeom && !toolboxState.getRefineNew() && _nMpr > 0 && _nStack === 0
-            && _blockIdxForSeg >= 0 && _blockIdxForSeg < _numBlocks0) ? _blockIdxForSeg : -1;
+            && !!_prevBlock) ? _blockIdxForSeg : -1;
 
+          // Always 0 for now; Task 5 will assign the real crop-aligned z0 here.
+          let _newBlockZ0 = 0;
+          const _tCreateStart = performance.now();
           let derivedImages_new: any[];
           let _clearIdxs: number[] = [];
           if (_reuseIdx >= 0) {
             // Reuse the block as-is: NO image reads/writes here (that is the ~2.5s getScalarData tax).
             // The crop goes into the volume below; the images are synced lazily via _pendingImageSync.
-            const _bStart = _reuseIdx * _imgLen0;
-            derivedImages_new = derivedImages.slice(_bStart, _bStart + _imgLen0);
+            derivedImages_new = _prevBlock!.imageIds.map(id => cache.getImage(id));
             const _ps = (existingSegments[segmentNumber] as any)?.cachedStats;
             const _pd = _ps?.dirtySlices as number[] | undefined;
             // Bound the clear to slices that actually held pixels. With NO recorded extent there is
@@ -3557,54 +3560,28 @@ const commandsModule = ({
           }
 
 
-          let filteredDerivedImages = [];
-          const imgLength = imageIds.length;
-          let excludedBlockIndex = -1; // 0-based block index of the segment being refined
-
-          // buildMultiBlockLabelmapRepresentation assigns block b → segment b+1, so we can
-          // compute the excluded block directly instead of scanning all images pixel-by-pixel.
-          // Old approach: O(N_segments × N_slices × pixels) — grows with every new segment.
-          // New approach: O(N_slices × pixels) — clears only the one target block.
-          if (!toolboxState.getRefineNew() && derivedImages.length > 0) {
-            const numBlocks = Math.ceil(derivedImages.length / imgLength);
-            const candidateBlock = _blockIdxForSeg;
-            if (candidateBlock >= 0 && candidateBlock < numBlocks) {
-              excludedBlockIndex = candidateBlock;
-              // NEVER evict when reusing: that block IS derivedImages_new (still live/on screen).
-              // Only a fresh block orphans the old one.
-              _orphanedImageIds = _reuseIdx >= 0 ? [] : derivedImages
-                .slice(excludedBlockIndex * imgLength, (excludedBlockIndex + 1) * imgLength)
-                .map((img: any) => img?.imageId)
-                .filter(Boolean);
-              // No pixel-clear needed: this old block is EXCLUDED below and replaced wholesale by
-              // the freshly-created all-zero derivedImages_new (which already holds the new crop
-              // from the slice loop above). createAndCacheDerivedLabelmapImages mints fresh
-              // derived:uuid images every call, so the old block is orphaned, and nnInteractive
-              // returns the full current mask each refine — the old pixels are superseded anyway.
-            }
-            for (let i = 0; i < derivedImages.length; i++) {
-              if (Math.floor(i / imgLength) !== excludedBlockIndex) filteredDerivedImages.push(derivedImages[i]);
-            }
-          } else if (derivedImages.length > 0) {
-            filteredDerivedImages = derivedImages;
-          }
-
-          // Insert derivedImages_new at the excluded block's original position to preserve
-          // the block-index → segment-index invariant used by buildMultiBlockLabelmapRepresentation.
-          if (excludedBlockIndex >= 0) {
-            const blocksBefore = filteredDerivedImages.slice(0, excludedBlockIndex * imgLength);
-            const blocksAfter = filteredDerivedImages.slice(excludedBlockIndex * imgLength);
-            merged_derivedImages = [...blocksBefore, ...derivedImages_new, ...blocksAfter];
-          } else {
-            merged_derivedImages = [...filteredDerivedImages, ...derivedImages_new];
-          }
-          // Track which segment each block now holds. Refining an existing segment replaces its
-          // block in place (map unchanged); a new segment appends a block at the end.
-          const _basePrev = _prevBlockSegments
-            ?? Array.from({ length: _numBlocks0 }, (_, b) => b + 1);
-          _nextBlockSegments = excludedBlockIndex >= 0
-            ? _basePrev.slice()
-            : [..._basePrev.filter(sg => sg !== segmentNumber), segmentNumber];
+          // The refined segment's block is REPLACED in the list (keeping its position, so no other
+          // segment is renumbered); a new segment APPENDS one. This used to be done by slicing the
+          // flat image array at N-sized boundaries, which only worked while every block was the
+          // full series length.
+          const _isRefine = !toolboxState.getRefineNew() && _blockIdxForSeg >= 0;
+          const _newBlock: LabelmapBlock = {
+            segmentIndex: segmentNumber,
+            z0: _newBlockZ0,
+            imageIds: derivedImages_new.map((img: any) => img?.imageId).filter(Boolean),
+          };
+          _nextBlocks = _isRefine
+            ? replaceBlockAt(_prevBlocks, _blockIdxForSeg, _newBlock)
+            : appendBlock(
+                _prevBlocks.filter(b => b.segmentIndex !== segmentNumber),
+                _newBlock
+              );
+          _nextBlockSegments = _nextBlocks.map(b => b.segmentIndex);
+          // NEVER evict when reusing: the old block IS derivedImages_new (still live and on screen).
+          // Only a freshly allocated block orphans the previous one.
+          _orphanedImageIds =
+            _isRefine && _reuseIdx < 0 && _prevBlock ? _prevBlock.imageIds.slice() : [];
+          merged_derivedImages = flattenBlocks(_nextBlocks).map(id => cache.getImage(id));
         } else {
           if (segImageIds.length == 0){
             const _tCreate2 = Date.now();
@@ -3768,7 +3745,7 @@ const commandsModule = ({
             z_range,
             mprInPlaceDone: _mprInPlaceDone,
             blockSegments: _nextBlockSegments,
-            blocks: null,
+            blocks: _nextBlocks,
           });
           // Evict the orphaned old block now that the representation swap + volume rebuild are
           // done and nothing references these imageIds. Caps the ~84MB/refine cache growth that

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -37,7 +37,7 @@ import {
 import { parseMultipart } from './utils/multipart';
 import { callInputDialog } from './utils/callInputDialog';
 import { getNninterToken, clearNninterToken } from './utils/nninterSession';
-import { LabelmapBlock, describeBlocks, blockIndexForSegment, replaceBlockAt, appendBlock, flattenBlocks, flipIndex, withoutBlockAt, blockContains, clampRange, sourceRangeForWorking, MIN_BLOCK_SLICES } from './utils/labelmapBlocks';
+import { LabelmapBlock, describeBlocks, blockIndexForSegment, replaceBlockAt, appendBlock, flattenBlocks, flipIndex, withoutBlockAt, blockContains, clampRange, snapRangeToGrid, sourceRangeForWorking, MIN_BLOCK_SLICES, BLOCK_GRID_SLICES } from './utils/labelmapBlocks';
 
 /** Tracks the last series initialized by initNninter to detect study/series changes. */
 let _lastInitSeries: string | undefined = undefined;
@@ -3526,9 +3526,10 @@ const commandsModule = ({
             );
           }
 
-          // THE working range this refine needs, clamped to the series and widened to
-          // MIN_BLOCK_SLICES. Computed ONCE, here, and used for BOTH the containment test below and
-          // the allocation further down — they must agree.
+          // THE working range this refine needs — the MASK's own extent, clamped to the series and
+          // widened to MIN_BLOCK_SLICES. Computed ONCE, here. This is what CONTAINMENT is tested
+          // against, and it is the input the allocation range below is derived from, so the two can
+          // never drift apart.
           //
           // Testing containment against the raw server geometry instead was a trap: if the server
           // ever returned _segZ1 > _imgLen0 (or _segZ0 < 0), allocation would truncate the block to
@@ -3543,6 +3544,22 @@ const commandsModule = ({
           // Without crop geometry the mask extent is unknown, so fall back to the full series.
           const [_bw0, _bw1] = _hasCropGeom
             ? clampRange(_segZ0, _segZ1, _imgLen0, MIN_BLOCK_SLICES)
+            : [0, _imgLen0];
+
+          // How much room a FRESH block reserves — the same range, snapped outward onto a fixed
+          // grid. Two DIFFERENT questions, deliberately answered by two different ranges:
+          //   [_bw0, _bw1)  "does the block I already have still cover this mask?"   (containment)
+          //   [_aw0, _aw1)  "how much room should a new block reserve?"              (allocation)
+          // Allocating to the mask's exact extent meant a mask that grows a slice per refine
+          // outgrew its block every refine, and every reallocation remounts and orphans an MPR
+          // volume (vols climbed to 25; syncRepr 12ms -> 61ms). Reserving to the grid absorbs that
+          // growth. Containment must NOT be tested against this range: a block cut from an earlier
+          // grid cell, or a pre-existing full-length block, can genuinely cover the mask without
+          // covering this whole cell, and testing it here would force the very reallocations the
+          // grid exists to prevent. Superset of [_bw0, _bw1), so MIN_BLOCK_SLICES still holds even
+          // when snapRangeToGrid degrades.
+          const [_aw0, _aw1] = _hasCropGeom
+            ? snapRangeToGrid(_bw0, _bw1, _imgLen0, BLOCK_GRID_SLICES)
             : [0, _imgLen0];
 
           // Reuse requires the existing block to still COVER the new mask. nnInteractive returns the
@@ -3617,13 +3634,13 @@ const commandsModule = ({
             // resident heap is what drives the GC pauses. Cornerstone sizes the MPR volume from the
             // block's own images (dimensions[2] = imageIds.length) and takes its origin from their
             // positions, so a shorter block renders at the correct place.
-            // [_bw0, _bw1] was computed ABOVE, so the range allocation uses and the range
-            // containment was tested against are one and the same value.
+            // [_aw0, _aw1) — the grid-snapped superset of the containment range, computed ABOVE.
+            // Reserving the extra room here is what lets the NEXT few refines take the reuse path.
             //
             // imageIds are in DISPLAY order; a flipped series mirrors the working range onto them
             // and the result needs reversing to come back in working order. This replaces the old
             // blanket `if (flipped) derivedImages_new.reverse()`, which assumed a full-length block.
-            const _src = sourceRangeForWorking(_bw0, _bw1, _imgLen0, flipped);
+            const _src = sourceRangeForWorking(_aw0, _aw1, _imgLen0, flipped);
             // The block's SOURCE slices. Recorded on the block below so the labelmap -> series
             // pairing never has to be re-derived from the (LRU-purgeable) image cache.
             _newBlockRefIds = imageIds.slice(_src.start, _src.end);
@@ -3635,7 +3652,8 @@ const commandsModule = ({
               _newBlockRefIds = _newBlockRefIds.slice().reverse();
               derivedImages_new.reverse();
             }
-            _newBlockZ0 = _bw0;
+            // Fresh block: its own start is the SNAPPED lower bound, matching the images just cut.
+            _newBlockZ0 = _aw0;
           }
 
           if (_reuseIdx >= 0) {

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -3394,9 +3394,13 @@ const commandsModule = ({
           // which lets us skip the remount (the remount is what orphans a volume every refine).
           let _mprInPlaceDone = false;
           if(overlap){
-          let derivedImages = [];
-          if (segImageIds.length > 0){
-            derivedImages = segImageIds.map(imageId => cache.getImage(imageId));
+          // LRU-touch every existing block's images before the fresh allocation below. cache.getImage
+          // refreshes each image's timeStamp, and cornerstone purges strictly by oldest timestamp when
+          // decacheIfNecessaryUntilBytesAvailable runs — so without this a live block could be evicted
+          // out from under the representation. (Previously an incidental side-effect of building a
+          // `derivedImages` array that no longer has any readers.)
+          for (const id of segImageIds) {
+            cache.getImage(id);
           }
 
           // TRUE IN-PLACE REFINE: reuse this segment's EXISTING block instead of minting a fresh one.
@@ -3568,11 +3572,19 @@ const commandsModule = ({
           const _newBlock: LabelmapBlock = {
             segmentIndex: segmentNumber,
             z0: _newBlockZ0,
-            imageIds: derivedImages_new.map((img: any) => img?.imageId).filter(Boolean),
+            imageIds: _reuseIdx >= 0
+              ? _prevBlock!.imageIds.slice()
+              : derivedImages_new.map((img: any) => img.imageId),
           };
           _nextBlocks = _isRefine
             ? replaceBlockAt(_prevBlocks, _blockIdxForSeg, _newBlock)
             : appendBlock(
+                // Filter out any pre-existing block for this segment before appending the new one.
+                // This cannot strand a block without evicting it: when getRefineNew() is true,
+                // segmentNumber is assigned minAvailableNumber (see ~line 3120-3130), so it never
+                // collides with an existing block's segmentIndex. And releaseSegmentBlock already
+                // drops blocks on segment delete. The filter is correct defence-in-depth; the
+                // _orphanedImageIds gate below is only reached on the _isRefine path.
                 _prevBlocks.filter(b => b.segmentIndex !== segmentNumber),
                 _newBlock
               );

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -37,7 +37,7 @@ import {
 import { parseMultipart } from './utils/multipart';
 import { callInputDialog } from './utils/callInputDialog';
 import { getNninterToken, clearNninterToken } from './utils/nninterSession';
-import { LabelmapBlock, describeBlocks, blockIndexForSegment, replaceBlockAt, appendBlock, flattenBlocks, flipIndex, withoutBlockAt } from './utils/labelmapBlocks';
+import { LabelmapBlock, describeBlocks, blockIndexForSegment, replaceBlockAt, appendBlock, flattenBlocks, flipIndex, withoutBlockAt, blockContains, clampRange, sourceRangeForWorking, MIN_BLOCK_SLICES } from './utils/labelmapBlocks';
 
 /** Tracks the last series initialized by initNninter to detect study/series changes. */
 let _lastInitSeries: string | undefined = undefined;
@@ -3434,13 +3434,35 @@ const commandsModule = ({
             if (_vp instanceof VolumeViewport && !(_vp instanceof VolumeViewport3D)) _nMpr++;
             else if (!(_vp instanceof VolumeViewport3D)) _nStack++;
           }
-          const _reuseIdx = (_hasCropGeom && !toolboxState.getRefineNew() && _nMpr > 0 && _nStack === 0
-            && !!_prevBlock) ? _blockIdxForSeg : -1;
+          // DEGENERATE REPRESENTATION. describeBlocks yields no blocks while the labelmap still holds
+          // images when there is no `blocks` array AND the flat list is shorter than the series — a
+          // state that only became reachable now that blocks are z-cropped. Those ids cannot be
+          // attributed to a segment, and the representation written below is rebuilt from _nextBlocks
+          // alone, so they are unreachable from here on. Evict them (see _orphanedImageIds) rather
+          // than strand them in the cache: a silent per-run leak is worse than a bounded reset, and
+          // the alternative — guessing an owner/z0 — would render masks at the wrong depth.
+          const _strandedImageIds: string[] =
+            _prevBlocks.length === 0 && segImageIds.length > 0 ? segImageIds.slice() : [];
+          if (_strandedImageIds.length) {
+            console.warn(
+              `[labelmap] ${_strandedImageIds.length} labelmap image(s) have no block mapping; ` +
+              `rebuilding the representation from this segment's block and evicting the rest.`
+            );
+          }
 
-          // Working-order offset of the block being written. Always 0 while blocks span the whole series.
-          // INVARIANT for the sparse rework: on the REUSE path this MUST equal _prevBlock.z0, because
-          // _clearIdxs, the blockZ0 argument, the _pendingImageSync payload and the fallback write loop
-          // all index _prevBlock's own images/volume through it — and _newBlock.z0 is paired with
+          // Reuse requires the existing block to still COVER the new mask. nnInteractive returns the
+          // full current mask each refine, so a mask that grew past the block's z-range needs a
+          // bigger block — which changes imageIds, so that refine takes the normal remount path.
+          // A block is never shrunk: staying at the high-water mark avoids realloc churn when a mask
+          // oscillates across a slice boundary.
+          const _fitsBlock = !!_prevBlock && blockContains(_prevBlock, _segZ0, _segZ1);
+          const _reuseIdx = (_hasCropGeom && !toolboxState.getRefineNew() && _nMpr > 0 && _nStack === 0
+            && _fitsBlock) ? _blockIdxForSeg : -1;
+
+          // Working-order offset of the block being written.
+          // INVARIANT: on the REUSE path this MUST equal _prevBlock.z0, because _clearIdxs, the
+          // blockZ0 argument, the _pendingImageSync payload and the fallback write loop all index
+          // _prevBlock's own images/volume through it — and _newBlock.z0 is paired with
           // _prevBlock.imageIds. A fresh block sets it to that block's own crop-aligned start instead.
           let _newBlockZ0 = 0;
           const _tCreateStart = performance.now();
@@ -3449,37 +3471,69 @@ const commandsModule = ({
           if (_reuseIdx >= 0) {
             // Reuse the block as-is: NO image reads/writes here (that is the ~2.5s getScalarData tax).
             // The crop goes into the volume below; the images are synced lazily via _pendingImageSync.
+            _newBlockZ0 = _prevBlock!.z0;
             derivedImages_new = _prevBlock!.imageIds.map(id => cache.getImage(id));
             const _ps = (existingSegments[segmentNumber] as any)?.cachedStats;
             const _pd = _ps?.dirtySlices as number[] | undefined;
             // Bound the clear to slices that actually held pixels. With NO recorded extent there is
             // no prior mask to clear — the old code swept every slice at ~7ms each (321 slices was
             // the ~5s stall seen whenever the volume lookup missed), for nothing.
-            const _prevIdxs: number[] = (!_pd?.length && (_ps?.segZ0 == null || _ps?.segZ1 == null))
-              ? []
-              : _pd?.length
-              ? _pd
-              : Array.from(
-                  { length: Math.max(0, (_ps?.segZ1 ?? _imgLen0) - (_ps?.segZ0 ?? 0)) },
-                  (_, k) => (_ps?.segZ0 ?? 0) + k
-                );
-            // FIXME(sparse): the segZ0/segZ1 fallback below yields WORKING indices but is flipped as if
-            // they were display indices — wrong for a flipped series with no recorded dirtySlices.
-            // Pre-existing; becomes materially wrong once blocks are z-cropped.
-            // dirtySlices are DISPLAY indices into the full series. Convert to working order (N is
-            // the SERIES length, not the block's), then to this block's array index.
-            _clearIdxs = _prevIdxs
-              .map((d: number) => flipIndex(d, _imgLen0, flipped) - _newBlockZ0)
+            //
+            // The two sources live in DIFFERENT spaces and must be converted separately:
+            //   dirtySlices  — DISPLAY indices into the full series, so they need flipIndex with the
+            //                  SERIES length (never the block's). The old code got this right.
+            //   segZ0/segZ1  — WORKING indices when written by this (nnInteractive) path, since they
+            //                  come straight from the server's crop geometry. The old code flipped
+            //                  them as if they were display indices: a pre-existing bug, invisible
+            //                  only because flipIndex is the identity on a non-flipped series.
+            // The segZ0/segZ1 fallback is ambiguous across producers — the SAM2 path (~:1894) stores
+            // the DISPLAY-space z_range bounds under the same names and never writes dirtySlices — so
+            // when it is used at all we clear the UNION of both readings. Over-clearing is safe here:
+            // the server returns the segment's full current mask each refine, so every slice is
+            // rewritten below, and the clear only ever zeroes THIS segment's own voxels. The union is
+            // two extents (~2x40 slices), not the span between them.
+            const _prevWorking: number[] = _pd?.length
+              ? _pd.map((d: number) => flipIndex(d, _imgLen0, flipped))
+              : (_ps?.segZ0 != null && _ps?.segZ1 != null)
+              ? (() => {
+                  const _a = Math.max(0, _ps.segZ0 as number);
+                  const _b = Math.min(_imgLen0, _ps.segZ1 as number);
+                  const _out = new Set<number>();
+                  for (let k = _a; k < _b; k++) {
+                    _out.add(k);                              // read as WORKING
+                    _out.add(flipIndex(k, _imgLen0, flipped));// read as DISPLAY -> working
+                  }
+                  return Array.from(_out);
+                })()
+              : [];
+            // Working -> this block's array index, bounds-guarded (a sparse block covers only part
+            // of the series, so a prior slice can legitimately fall outside it).
+            _clearIdxs = _prevWorking
+              .map((w: number) => w - _newBlockZ0)
               .filter((i: number) => i >= 0 && i < derivedImages_new.length);
           } else {
-            derivedImages_new = await imageLoader.createAndCacheDerivedLabelmapImages(imageIds);
+            // Z-CROP: allocate one derived image per slice the mask touches, not one per series
+            // slice. A full-volume block is ~84 MB against a typical mask's ~40 of 321 slices; that
+            // resident heap is what drives the GC pauses. Cornerstone sizes the MPR volume from the
+            // block's own images (dimensions[2] = imageIds.length) and takes its origin from their
+            // positions, so a shorter block renders at the correct place.
+            // Without crop geometry the mask extent is unknown, so fall back to the full series.
+            const [_bw0, _bw1] = _hasCropGeom
+              ? clampRange(_segZ0, _segZ1, _imgLen0, MIN_BLOCK_SLICES)
+              : [0, _imgLen0];
+            // imageIds are in DISPLAY order; a flipped series mirrors the working range onto them
+            // and the result needs reversing to come back in working order. This replaces the old
+            // blanket `if (flipped) derivedImages_new.reverse()`, which assumed a full-length block.
+            const _src = sourceRangeForWorking(_bw0, _bw1, _imgLen0, flipped);
+            derivedImages_new = await imageLoader.createAndCacheDerivedLabelmapImages(
+              imageIds.slice(_src.start, _src.end)
+            );
+            if (_src.reverse) {
+              derivedImages_new.reverse();
+            }
+            _newBlockZ0 = _bw0;
           }
 
-          // A freshly-created block is in display order and needs reversing for a flipped series;
-          // a reused block is already stored in working order, so it must NOT be reversed again.
-          if(flipped && _reuseIdx < 0){
-            derivedImages_new.reverse();
-          }
           if (_reuseIdx >= 0) {
             // Volume-only path: derive z_range straight from the crop bytes (which slices actually
             // contain mask) instead of from the image writes we just skipped. Same values the write
@@ -3495,13 +3549,16 @@ const commandsModule = ({
               }
             }
           }
-          for (let i = 0; _reuseIdx < 0 && i < derivedImages_new.length; i++) {
-            if (_hasCropGeom && (i < _segZ0 || i >= _segZ1)) continue;
-            const voxelManager = derivedImages_new[i].voxelManager as csTypes.IVoxelManager<number>;
-            if (_hasCropGeom && i >= _segZ0 && i < _segZ1) {
+          // Walks the BLOCK's own images: `ai` is a block-array index, `w = ai + _newBlockZ0` the
+          // working index into the full series that the crop geometry and cropBytes are expressed in.
+          // These were the same number only while a block spanned the whole series.
+          for (let ai = 0; _reuseIdx < 0 && ai < derivedImages_new.length; ai++) {
+            const w = ai + _newBlockZ0;
+            if (_hasCropGeom && (w < _segZ0 || w >= _segZ1)) continue;
+            const voxelManager = derivedImages_new[ai].voxelManager as csTypes.IVoxelManager<number>;
+            if (_hasCropGeom) {
               const scalarData = voxelManager.getScalarData();
-              const c = i - _segZ0;
-              const cropSliceBase = c * _cropY * _cropX;
+              const cropSliceBase = (w - _segZ0) * _cropY * _cropX;
               let wrote = false;
               for (let cy = 0; cy < _cropY; cy++) {
                 const srcRow = cropSliceBase + cy * _cropX;
@@ -3513,15 +3570,18 @@ const commandsModule = ({
                   }
                 }
               }
-              if (wrote) z_range.push(flipped ? derivedImages_new.length - i - 1 : i);
-            } else if (!_hasCropGeom && new_arrayBuffer) {
-              // Legacy: full-slice scan
+              // z_range feeds cachedStats.dirtySlices, which is read back as DISPLAY indices into
+              // the full series on the next refine — so convert with the SERIES length.
+              if (wrote) z_range.push(flipIndex(w, _imgLen0, flipped));
+            } else if (new_arrayBuffer) {
+              // Legacy full-slice path. Only reached without crop geometry, where the block spans
+              // the whole series, so ai === w.
               const scalarData = voxelManager.getScalarData();
               const sliceLen = scalarData.length;
-              const sliceData = new_arrayBuffer.slice(i * sliceLen, (i + 1) * sliceLen);
+              const sliceData = new_arrayBuffer.slice(w * sliceLen, (w + 1) * sliceLen);
               if (sliceData.some(v => v === 1)) {
                 voxelManager.setScalarData(sliceData.map(v => v === 1 ? segmentNumber : v));
-                z_range.push(flipped ? derivedImages_new.length - i - 1 : i);
+                z_range.push(flipIndex(w, _imgLen0, flipped));
               }
             }
           }
@@ -3617,9 +3677,22 @@ const commandsModule = ({
               );
           _nextBlockSegments = _nextBlocks.map(b => b.segmentIndex);
           // NEVER evict when reusing: the old block IS derivedImages_new (still live and on screen).
-          // Only a freshly allocated block orphans the previous one.
-          _orphanedImageIds =
-            _isRefine && _reuseIdx < 0 && _prevBlock ? _prevBlock.imageIds.slice() : [];
+          // Only a freshly allocated block orphans the previous one. Images the representation held
+          // but could not attribute to any block (_strandedImageIds) are dropped by the rebuild
+          // below, so they are evicted here too rather than left to leak. Belt-and-braces: never
+          // evict an id the block we just wrote is using.
+          const _keepIds = new Set(flattenBlocks(_nextBlocks));
+          _orphanedImageIds = (
+            _isRefine && _reuseIdx < 0 && _prevBlock
+              ? _prevBlock.imageIds.concat(_strandedImageIds)
+              : _strandedImageIds
+          ).filter(id => !_keepIds.has(id));
+          if (_orphanedImageIds.length) {
+            // A deferred image write queued against the block we are about to evict is dead work:
+            // its blockImageIds no longer resolve, and this refine wrote the new block's images
+            // directly. Newly reachable now that a REFINE (not just a delete) can replace a block.
+            _pendingImageSync.get(segmentationId)?.delete(segmentNumber);
+          }
           merged_derivedImages = flattenBlocks(_nextBlocks).map(id => cache.getImage(id));
         } else {
           if (segImageIds.length == 0){
@@ -3629,6 +3702,9 @@ const commandsModule = ({
             if(flipped){
               derivedImages_new.reverse();
             }
+            // NON-SPARSE branch (SAM2 / single-layer): this block deliberately spans the whole
+            // series, so `i` is simultaneously a block-array index and a working index and the two
+            // never diverge. z_range must still be DISPLAY, converted with the SERIES length.
             for (let i = 0; i < derivedImages_new.length; i++) {
               if (_hasCropGeom && (i < _segZ0 || i >= _segZ1)) continue;
               const voxelManager = derivedImages_new[i]
@@ -3649,7 +3725,7 @@ const commandsModule = ({
                     }
                   }
                 }
-                if (wrote) z_range.push(flipped ? derivedImages_new.length - i - 1 : i);
+                if (wrote) z_range.push(flipIndex(i, imageIds.length, flipped));
               } else if (!_hasCropGeom && new_arrayBuffer) {
                 // Legacy: full-slice scan
                 const scalarData = voxelManager.getScalarData();
@@ -3657,7 +3733,7 @@ const commandsModule = ({
                 const sliceData = new_arrayBuffer.subarray(i * sliceLen, (i + 1) * sliceLen);
                 if (sliceData.some(v => v === 1)){
                   for (let j = 0; j < sliceLen; j++) { if (sliceData[j] === 1) scalarData[j] = segmentNumber; }
-                  z_range.push(flipped ? derivedImages_new.length - i - 1 : i);
+                  z_range.push(flipIndex(i, imageIds.length, flipped));
                 }
               }
             }

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -300,7 +300,12 @@ const commandsModule = ({
         referencedVolumeId: currentDisplaySets.displaySetInstanceUID,
         // The SOURCE image ids for the whole series (not a block's) — releaseSegmentBlock and the
         // legacy describeBlocks path both use this to know the series length.
+        // `referencedImageIds` cannot be trusted by readers: syncLegacyLabelmapData reverts it
+        // (and imageIds) to the PRIMARY LAYER's value on every entry into state, and that value is
+        // deliberately block-scoped via refIdsFor. `allReferencedImageIds` is named so the adapter
+        // leaves it alone — the same reason allImageIds survives alongside the reverted imageIds.
         referencedImageIds: imageIds,
+        allReferencedImageIds: imageIds,
         labelmaps,
         segmentBindings,
         primaryLabelmapId,
@@ -2326,7 +2331,11 @@ const commandsModule = ({
       const seg = csToolsSegmentation.state.getSegmentation(segmentationId);
       const lm = seg?.representationData?.Labelmap as any;
       if (!lm) return;
-      const srcIds: string[] = lm.referencedImageIds ?? [];
+      const srcIds: string[] = lm.allReferencedImageIds ?? lm.referencedImageIds ?? [];
+      // Guard: if srcIds is empty, we cannot reconstruct a valid representation.
+      // describeBlocks ignores sourceCount when lm.blocks is present, so an empty srcIds
+      // would flow into buildMultiBlockLabelmapRepresentation as imageIds: [].
+      if (srcIds.length === 0) return;
       const blocks = describeBlocks(lm, srcIds.length);
       // Keep at least one block: cornerstone needs a primary labelmap to render at all.
       if (blocks.length <= 1) return;

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -325,12 +325,14 @@ const commandsModule = ({
         existingSegments: {} as { [segmentIndex: string]: cstTypes.Segment },
         existing: false,
         blockSegments: null as number[] | null,
+        blocks: [] as LabelmapBlock[],
       };
     }
 
     let existingSegments: { [segmentIndex: string]: cstTypes.Segment } = {};
     let segImageIds: string[] = [];
     let blockSegments: number[] | null = null;
+    let blocks: LabelmapBlock[] = [];
     let existing = false;
     let segmentationId = freshActiveSegmentation.segmentationId;
 
@@ -352,6 +354,10 @@ const commandsModule = ({
         [];
       blockSegments =
         (freshActiveSegmentation.representationData?.Labelmap as any)?.blockSegments ?? null;
+      blocks = describeBlocks(
+        freshActiveSegmentation.representationData?.Labelmap,
+        currentDisplaySets?.imageIds?.length ?? 0
+      );
       existing = true;
     }
 
@@ -362,6 +368,7 @@ const commandsModule = ({
       existingSegments,
       existing,
       blockSegments,
+      blocks,
     };
   }
 
@@ -839,6 +846,7 @@ const commandsModule = ({
     z_range,
     mprInPlaceDone = false,
     blockSegments,
+    blocks,
   }: {
     activeViewportId: string;
     segmentationId: string;
@@ -852,6 +860,7 @@ const commandsModule = ({
     activeSegmentation: any;
     mprInPlaceDone?: boolean;
     blockSegments?: number[] | null;
+    blocks?: LabelmapBlock[] | null;
     currentImageIdIndex?: number;
     z_range: number[];
   }) {
@@ -859,11 +868,10 @@ const commandsModule = ({
     const representations = servicesManager.services.segmentationService.getSegmentationRepresentations(activeViewportId, { segmentationId });
 
     const prevSegmentation = csToolsSegmentation.state.getSegmentation(segmentationId);
-    const prevAllImageIds =
-      prevSegmentation?.representationData?.Labelmap?.allImageIds ??
-      prevSegmentation?.representationData?.Labelmap?.imageIds ??
-      [];
-    const prevBlockCount = imageIds.length > 0 ? Math.floor(prevAllImageIds.length / imageIds.length) : 0;
+    const prevLabelmap = prevSegmentation?.representationData?.Labelmap;
+    // Block count from the block LIST, not allImageIds.length / N — blocks can be shorter than the
+    // series once they are z-cropped, so that division no longer counts them.
+    const prevBlockCount = describeBlocks(prevLabelmap, imageIds.length).length;
 
     const { blockCount, labelmapRepresentation } = buildMultiBlockLabelmapRepresentation({
       segmentationId,
@@ -872,6 +880,7 @@ const commandsModule = ({
       currentDisplaySets,
       segments,
       blockSegments: blockSegments ?? undefined,
+      blocks: blocks ?? undefined,
     });
     const mergedSegments = mergeSegmentsForUpdate(segmentationId, segments);
 
@@ -3759,6 +3768,7 @@ const commandsModule = ({
             z_range,
             mprInPlaceDone: _mprInPlaceDone,
             blockSegments: _nextBlockSegments,
+            blocks: null,
           });
           // Evict the orphaned old block now that the representation swap + volume rebuild are
           // done and nothing references these imageIds. Caps the ~84MB/refine cache growth that

--- a/Viewers/extensions/default/src/utils/labelmapBlocks.ts
+++ b/Viewers/extensions/default/src/utils/labelmapBlocks.ts
@@ -25,6 +25,16 @@ export type LabelmapBlock = {
   z0: number;
   /** Derived labelmap image ids, in working order. */
   imageIds: string[];
+  /**
+   * The block's SOURCE (series) slices, in WORKING order and index-aligned with `imageIds`.
+   *
+   * Cornerstone pairs labelmap image k with referencedImageIds[k] strictly by index, so this is the
+   * ground truth for where the block sits in the series. It is carried on the block because the only
+   * other source — each cached labelmap image's own `referencedImageId` — disappears if those images
+   * are LRU-purged, and the whole-series list is NOT a safe substitute for a z-cropped block (it
+   * would pair block slice 0 with display slice 0 and render the mask at the wrong depth).
+   */
+  referencedImageIds?: string[];
 };
 
 /**
@@ -48,6 +58,9 @@ export function describeBlocks(labelmapData: any, sourceCount: number): Labelmap
       segmentIndex: b.segmentIndex,
       z0: b.z0 ?? 0,
       imageIds: b.imageIds ?? [],
+      // Carried through when the persisted block has it. Left undefined otherwise (a pre-sparse
+      // representation), where the block spans the series and the whole-series list is correct.
+      referencedImageIds: b.referencedImageIds,
     }));
   }
   const all: string[] = labelmapData.allImageIds ?? labelmapData.imageIds ?? [];

--- a/Viewers/extensions/default/src/utils/labelmapBlocks.ts
+++ b/Viewers/extensions/default/src/utils/labelmapBlocks.ts
@@ -55,6 +55,49 @@ export const MIN_BLOCK_SLICES = 2;
 export const BLOCK_GRID_SLICES = 32;
 
 /**
+ * How many times larger than a fresh allocation a block may be before it is worth reallocating.
+ * See shouldShrinkBlock.
+ */
+export const BLOCK_SHRINK_FACTOR = 2;
+
+/**
+ * Should an existing block be reallocated purely because it is far larger than the mask now
+ * needs? Blocks are deliberately sticky -- a mask that grows slightly must keep fitting the
+ * block it already has, or every refine reallocates and remounts. But a single runaway
+ * inference can inflate a block to the whole series, and without this it would stay that way
+ * for the rest of the session.
+ *
+ * The factor is hysteresis: a block may be up to `factor`x the ideal size before it is worth
+ * paying a remount to reclaim. Strict `>` means exactly `factor`x does NOT trigger.
+ *
+ * `snappedLength` is the length a FRESH allocation would take (the grid-snapped range), not the
+ * mask's own extent -- comparing against the mask would shrink a block the grid deliberately
+ * over-reserved. Containment is a SEPARATE question and must still be tested on its own range.
+ */
+export function shouldShrinkBlock(
+  blockLength: number,
+  snappedLength: number,
+  factor: number
+): boolean {
+  // No usable target size: cannot judge oversize, so never shrink.
+  if (!(snappedLength > 0)) {
+    return false;
+  }
+  // An unusable factor degrades to the old "never shrink" rule rather than shrinking on
+  // every refine (factor 0 would make every block grossly oversized).
+  if (!Number.isFinite(factor) || factor <= 0) {
+    return false;
+  }
+  // A block that is not even bigger than the fresh allocation is never "oversized", whatever the
+  // factor says. This only bites for factor < 1, but reallocating a block that is already too
+  // SMALL under the banner of shrinking it would be nonsense; growth is the caller's other test.
+  if (blockLength <= snappedLength) {
+    return false;
+  }
+  return blockLength > snappedLength * factor;
+}
+
+/**
  * Snap a working range outward onto a fixed grid, so a slowly-growing mask keeps fitting the
  * block it already has instead of reallocating (and remounting, and orphaning an MPR volume)
  * on every refine. Lower bound rounds DOWN to a multiple of `grid`, upper bound rounds UP.

--- a/Viewers/extensions/default/src/utils/labelmapBlocks.ts
+++ b/Viewers/extensions/default/src/utils/labelmapBlocks.ts
@@ -45,6 +45,50 @@ export type LabelmapBlock = {
 export const MIN_BLOCK_SLICES = 2;
 
 /**
+ * Grid that fresh block bounds snap to. Allocating a block to the mask's EXACT extent meant an
+ * nnInteractive mask — which grows a little on each refine — outgrew its block every time, and each
+ * reallocation changes imageIds, which forces a remount, which builds a new MPR volume and orphans
+ * the old one. Rounding out to a grid keeps that growth inside the block the segment already has.
+ * 32 slices is a bounded waste (<32 per side) against a typical ~40-slice mask, and it makes block
+ * lengths cluster on a handful of values rather than taking arbitrary ones.
+ */
+export const BLOCK_GRID_SLICES = 32;
+
+/**
+ * Snap a working range outward onto a fixed grid, so a slowly-growing mask keeps fitting the
+ * block it already has instead of reallocating (and remounting, and orphaning an MPR volume)
+ * on every refine. Lower bound rounds DOWN to a multiple of `grid`, upper bound rounds UP.
+ * Result is clamped to [0, sourceCount] and is always a superset of the input range.
+ *
+ * This is for ALLOCATION only. Containment must still be tested against the mask's own range:
+ * an existing block can legitimately cover the mask without covering the whole grid cell, and
+ * testing the snapped range would reallocate in exactly the case this function exists to avoid.
+ */
+export function snapRangeToGrid(
+  w0: number,
+  w1: number,
+  sourceCount: number,
+  grid: number
+): [number, number] {
+  const count = Math.max(0, sourceCount);
+  const a = Math.max(0, Math.min(w0, count));
+  const b = Math.max(a, Math.min(w1, count));
+  // An unusable grid degrades to the clamped input rather than producing NaN bounds — the caller
+  // has already applied MIN_BLOCK_SLICES, so the range is still allocatable.
+  if (!Number.isFinite(grid) || grid <= 0) {
+    return [a, b];
+  }
+  // A series shorter than one cell has nothing to snap to; take the whole thing.
+  if (count <= grid) {
+    return [0, count];
+  }
+  // The extra floor/ceil keep the bounds integral for a non-integer grid, and only ever widen.
+  const lo = Math.max(0, Math.floor(Math.floor(a / grid) * grid));
+  const hi = Math.min(count, Math.ceil(Math.ceil(b / grid) * grid));
+  return [lo, hi];
+}
+
+/**
  * Describe an existing representation as explicit blocks.
  * Falls back to the legacy uniform layout (flat allImageIds in N-sized chunks, optionally with a
  * blockSegments map) so representations built before sparse blocks keep working.

--- a/Viewers/extensions/default/src/utils/labelmapBlocks.ts
+++ b/Viewers/extensions/default/src/utils/labelmapBlocks.ts
@@ -1,0 +1,161 @@
+/**
+ * Pure block-list and index math for the multi-block labelmap scheme.
+ *
+ * Each AI segment owns a BLOCK: a contiguous run of derived labelmap images covering the slices
+ * its mask touches. Blocks used to be uniform — every segment allocated one image per series slice
+ * (~84 MB) though a typical mask covers ~40 of 321 — so block boundaries could be recovered by
+ * arithmetic (`Math.floor(i / N)`). They can be z-cropped now, so the block list is the source of
+ * truth and that arithmetic is gone.
+ *
+ * This module deliberately imports NOTHING: it is the only part of the scheme that is unit-testable
+ * in isolation, and pulling in OHIF or Cornerstone would break that.
+ *
+ * TWO COORDINATE SPACES, never conflated:
+ *   working — index into a block's imageIds array, and the Cornerstone volume's z index. The server's
+ *             crop geometry (segZ0/segZ1) is in working indices INTO THE FULL SERIES.
+ *   display — index into the source series imageIds. z_range and cachedStats.dirtySlices use this.
+ * They differ only for a flipped series, where `w = N - 1 - d`. N is ALWAYS the full series length,
+ * never a block's length.
+ */
+
+export type LabelmapBlock = {
+  /** Segment this block holds the mask for. */
+  segmentIndex: number;
+  /** Working-order index of the block's first slice within the full series. */
+  z0: number;
+  /** Derived labelmap image ids, in working order. */
+  imageIds: string[];
+};
+
+/**
+ * Shortest block we will allocate. calculateSpacingBetweenImageIds cannot derive z-spacing from a
+ * single image and falls back to sliceThickness, which can disagree with the series' real spacing
+ * and mis-size the volume. Two slices let it measure the gap.
+ */
+export const MIN_BLOCK_SLICES = 2;
+
+/**
+ * Describe an existing representation as explicit blocks.
+ * Falls back to the legacy uniform layout (flat allImageIds in N-sized chunks, optionally with a
+ * blockSegments map) so representations built before sparse blocks keep working.
+ */
+export function describeBlocks(labelmapData: any, sourceCount: number): LabelmapBlock[] {
+  if (!labelmapData) {
+    return [];
+  }
+  if (Array.isArray(labelmapData.blocks) && labelmapData.blocks.length) {
+    return labelmapData.blocks.map((b: any) => ({
+      segmentIndex: b.segmentIndex,
+      z0: b.z0 ?? 0,
+      imageIds: b.imageIds ?? [],
+    }));
+  }
+  const all: string[] = labelmapData.allImageIds ?? labelmapData.imageIds ?? [];
+  if (!sourceCount || all.length < sourceCount) {
+    return [];
+  }
+  const count = Math.floor(all.length / sourceCount);
+  const segs: number[] =
+    labelmapData.blockSegments?.length === count
+      ? labelmapData.blockSegments
+      : Array.from({ length: count }, (_, b) => b + 1);
+  return Array.from({ length: count }, (_, b) => ({
+    segmentIndex: segs[b],
+    z0: 0,
+    imageIds: all.slice(b * sourceCount, (b + 1) * sourceCount),
+  }));
+}
+
+/** Index of the block holding `segmentIndex`, or -1. */
+export function blockIndexForSegment(blocks: LabelmapBlock[], segmentIndex: number): number {
+  for (let i = 0; i < blocks.length; i++) {
+    if (blocks[i].segmentIndex === segmentIndex) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+/** The flat image id list Cornerstone consumes. Derived so the two can never disagree. */
+export function flattenBlocks(blocks: LabelmapBlock[]): string[] {
+  const out: string[] = [];
+  for (const b of blocks) {
+    for (const id of b.imageIds) {
+      out.push(id);
+    }
+  }
+  return out;
+}
+
+/**
+ * Convert between display and working order. The mapping is its own inverse, so one function serves
+ * both directions. `count` is the FULL series length.
+ */
+export function flipIndex(i: number, count: number, flipped: boolean): number {
+  return flipped ? count - 1 - i : i;
+}
+
+/** Does this block cover the whole working range [w0, w1)? */
+export function blockContains(block: LabelmapBlock, w0: number, w1: number): boolean {
+  return w0 >= block.z0 && w1 <= block.z0 + block.imageIds.length;
+}
+
+/**
+ * Clamp a working range to the series and widen it to at least `minLength` slices, centred on the
+ * original range. Returns the whole series when it is shorter than `minLength`.
+ */
+export function clampRange(
+  w0: number,
+  w1: number,
+  sourceCount: number,
+  minLength: number
+): [number, number] {
+  if (sourceCount <= minLength) {
+    return [0, sourceCount];
+  }
+  let a = Math.max(0, Math.min(w0, sourceCount));
+  let b = Math.max(a, Math.min(w1, sourceCount));
+  if (b - a < minLength) {
+    const deficit = minLength - (b - a);
+    a = Math.max(0, a - Math.ceil(deficit / 2));
+    b = Math.min(sourceCount, a + minLength);
+    a = Math.max(0, b - minLength);
+  }
+  return [a, b];
+}
+
+/**
+ * Which source imageIds back a working range, and whether they need reversing to land in working
+ * order. Source imageIds are in DISPLAY order; a flipped series mirrors the range.
+ */
+export function sourceRangeForWorking(
+  w0: number,
+  w1: number,
+  sourceCount: number,
+  flipped: boolean
+): { start: number; end: number; reverse: boolean } {
+  return flipped
+    ? { start: sourceCount - w1, end: sourceCount - w0, reverse: true }
+    : { start: w0, end: w1, reverse: false };
+}
+
+/** Replace one block, keeping every other block at its position. */
+export function replaceBlockAt(
+  blocks: LabelmapBlock[],
+  index: number,
+  block: LabelmapBlock
+): LabelmapBlock[] {
+  const next = blocks.slice();
+  next[index] = block;
+  return next;
+}
+
+/** Add a block at the end of the list. */
+export function appendBlock(blocks: LabelmapBlock[], block: LabelmapBlock): LabelmapBlock[] {
+  return [...blocks, block];
+}
+
+/** Drop one block. */
+export function withoutBlockAt(blocks: LabelmapBlock[], index: number): LabelmapBlock[] {
+  return blocks.filter((_, i) => i !== index);
+}


### PR DESCRIPTION
Each AI segment's labelmap block used to span the whole series (~84 MB) even though a typical mask touches ~40 of 321 slices. Blocks are now **z-cropped**, snapped outward onto a 32-slice grid, and reclaimed when grossly oversized.

## Measured

User-verified in the browser across four sessions, not inferred:

| | before | after |
|---|---|---|
| segments held | 6 | 7+ |
| `cacheMB` | 841 | ~450–530 |
| `vols` (volume cache) | climbing to 25, unbounded | flat |
| `parse` (GC proxy) | 494–858 ms | single digits |
| block allocation | 80–99 ms **every** refine | 0 ms on most |
| runaway-mask recovery | stuck at 84 MB for the session | reclaimed on next refine |

Eviction is exact — at ~0.26 MB/slice, a 64-slice block moves `cacheMB` by +17 MB, 96 by +25, 192 by +50, and a same-size reallocation leaves it flat.

## Approach

`LabelmapBlock { segmentIndex, z0, imageIds, referencedImageIds }` becomes the single source of truth, in a new **pure, import-free** module (`utils/labelmapBlocks.ts`, 44 unit tests). Import-freedom is deliberate: every other test in this repo fails on `@ohif/core` module resolution, so it is what keeps these tests runnable.

The first 12 commits are **behaviour-neutral groundwork** — each converts one consumer from uniform-N arithmetic to block-list operations while blocks are still full-length, so each is independently verifiable as "nothing changed". Only then does allocation become sparse. That staging is why the risky commit is small.

Two tunables, one line each: `BLOCK_GRID_SLICES = 32`, `BLOCK_SHRINK_FACTOR = 2`.

## Invariants worth knowing before touching this

- **Two coordinate spaces.** `working` = index into a block's imageIds array *and* the cornerstone volume's z index; `display` = index into the source series. Convert with `flipIndex(i, N, flipped)` where **N is always the full series length, never a block's length**. Pre-sparse code used a block length here and was correct only because blocks were full-length.
- **`_newBlockZ0`** must equal `_prevBlock.z0` on the reuse path and the snapped lower bound on the fresh path. Four sites index the *previous* block through it; wrong value renders a segment at the wrong anatomical depth, silently.
- **Containment tests the mask's range; allocation uses the snapped range.** Conflating them makes every refine reallocate while appearing to work.

## Two bugs found by reading, not by running

**DICOM-SEG export would have silently dropped segments.** It derived its series length from `Labelmap.imageIds` and paired each layer's slices with the primary block's by shared index. Both only worked while every block spanned the series. The failure mode was a valid-looking SEG file with a segment missing — no error.

**`referencedImageIds` cannot be trusted for series geometry.** Cornerstone's `syncLegacyLabelmapData` reverts *four* fields to the primary layer — including `referencedImageIds`, which is deliberately block-scoped. The first fix for the export relocated the bug rather than removing it. Hence `allReferencedImageIds`, which survives because the adapter does not name it (the same reason `allImageIds` survives).

**`undoNninter` was broken by this work and no per-commit review could see it.** It reads the segment's own layer — now cropped and offset — but indexed it with full-series indices. With a block at `z0=96, len=64` and a mask past slice 100 it dereferenced `undefined` and surfaced as "Undo - Failed"; the undo-to-empty path failed *silently*, never clearing the mask. No commit touched that region, so it never appeared in a diff. Caught only by a whole-branch review reading for the invariant.

## Scope

- Only the nnInteractive (`overlap`) path allocates sparsely. SAM2 and the SEG-reload producer still emit full-length blocks — they are the `z0: 0, len: N` special case and flow through unchanged.
- In-plane (XY) cropping is **not** attempted. It would reach ~1.6 MB/segment but needs the MPR volume at an XY origin offset and labelmap images smaller than the CT slices they reference; that needs its own spike.

## Verification

- 44 unit tests on the pure module; `tsc` syntax gate clean on all four touched files
- Four browser sessions covering: new segment · in-place refine · growth reallocation · shrink · delete · reset (stack + MPR) · DICOM-SEG export and reload · **undo**
- `commandsModule.ts` has no unit tests (its `@ohif/core` import chain does not resolve under jest), so careful reading plus those browser gates is the verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)
