### PR TITLE
perf(seg): sparse (z-cropped) labelmap blocks for SEG reload — 2.37GB → 394MB

### DIFF
--- a/Viewers/extensions/cornerstone-dicom-seg/src/commandsModule.ts
+++ b/Viewers/extensions/cornerstone-dicom-seg/src/commandsModule.ts
@@ -287,6 +287,29 @@ const commandsModule = ({
           const layerSegments = Array.from(
             new Set(layerLabelmaps2D.filter(Boolean).flatMap((l: any) => l.segmentsOnLabelmap))
           );
+
+          // TEMPORARY (diagnostic, strip before merge): what the EXPORT actually sees per layer.
+          // Established by measurement that the refine updates the block correctly, so if a refined
+          // segment reverts on export the loss is here: either the block's images do not hold the
+          // refined pixels, or they do and the referencedImageId identity mapping drops them.
+          // These two counts separate those cases.
+          {
+            let cached = 0;
+            let unmapped = 0;
+            for (const id of (layer.imageIds ?? [])) {
+              const img = cache.getImage(id);
+              if (!img) continue;
+              cached++;
+              if (sourceIndexById.get((img as any).referencedImageId) === undefined) unmapped++;
+            }
+            console.log(
+              `[export] layer segs=[${layerSegments.join(',')}] ` +
+              `imageIds=${(layer.imageIds ?? []).length} cached=${cached} unmapped=${unmapped} ` +
+              `slicesWithPixels=${layerLabelmaps2D.filter(Boolean).length}` +
+              `${layerSegments.length === 0 ? '  *** LAYER CONTRIBUTES NOTHING -- SKIPPED ***' : ''}`
+            );
+          }
+
           if (layerSegments.length === 0) continue;
 
           const layerMetadata: any[] = [];

--- a/Viewers/extensions/cornerstone-dicom-seg/src/commandsModule.ts
+++ b/Viewers/extensions/cornerstone-dicom-seg/src/commandsModule.ts
@@ -288,28 +288,6 @@ const commandsModule = ({
             new Set(layerLabelmaps2D.filter(Boolean).flatMap((l: any) => l.segmentsOnLabelmap))
           );
 
-          // TEMPORARY (diagnostic, strip before merge): what the EXPORT actually sees per layer.
-          // Established by measurement that the refine updates the block correctly, so if a refined
-          // segment reverts on export the loss is here: either the block's images do not hold the
-          // refined pixels, or they do and the referencedImageId identity mapping drops them.
-          // These two counts separate those cases.
-          {
-            let cached = 0;
-            let unmapped = 0;
-            for (const id of (layer.imageIds ?? [])) {
-              const img = cache.getImage(id);
-              if (!img) continue;
-              cached++;
-              if (sourceIndexById.get((img as any).referencedImageId) === undefined) unmapped++;
-            }
-            console.log(
-              `[export] layer segs=[${layerSegments.join(',')}] ` +
-              `imageIds=${(layer.imageIds ?? []).length} cached=${cached} unmapped=${unmapped} ` +
-              `slicesWithPixels=${layerLabelmaps2D.filter(Boolean).length}` +
-              `${layerSegments.length === 0 ? '  *** LAYER CONTRIBUTES NOTHING -- SKIPPED ***' : ''}`
-            );
-          }
-
           if (layerSegments.length === 0) continue;
 
           const layerMetadata: any[] = [];

--- a/Viewers/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
+++ b/Viewers/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
@@ -455,7 +455,10 @@ class SegmentationService extends PubSubService {
     //   2. it then sorts DESCENDING by that value.
     // Descending in (ref - pos)·axis is ASCENDING in pos·axis. So cornerstone's sorted (working)
     // order always runs from lowest to highest projection onto the scan axis, whatever the source
-    // series order was. Display order therefore matches sorted order exactly when the
+    // series order was. (Exact for the full sort; the wadouri branch only reverses on a
+    // first-vs-middle probe, so it lands ascending for any MONOTONIC series -- which is also the
+    // assumption `_d` itself makes by sampling only the first and last slice.)
+    // Display order therefore matches sorted order exactly when the
     // display-ordered series is itself ASCENDING in pos·axis, i.e. when the last slice projects
     // FURTHER ALONG the axis than the first: (p_last - p_first)·axis > 0.
     //

--- a/Viewers/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
+++ b/Viewers/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
@@ -446,11 +446,12 @@ class SegmentationService extends PubSubService {
     // refine flow's block-index assumptions hold for reloaded SEGs. Covers both
     // multi-layer (overlapping) SEGs and a single layer packing multiple segments;
     // only a single layer holding exactly segment 1 keeps the legacy path.
-    // TEMPORARY (diagnostic, strip before merge): does cornerstone's SORTED volume order match the
-    // source series' display order? That is the fact deciding whether a SEG block's array index
-    // equals its volume z index. sortImageIdsAndGetSpacing orders by DESCENDING distance along the
-    // scan axis, so display order matches iff the series' own positions already descend. Measured
-    // here rather than taken from the server's `flipped` flag, whose semantics we'd be guessing at.
+    // Does cornerstone's SORTED volume order match the source series' display order? This decides
+    // whether a SEG block's array index equals its volume z index. sortImageIdsAndGetSpacing orders
+    // by DESCENDING distance along the scan axis, so display order matches iff the series' own
+    // positions already descend. Measured here rather than taken from the server's `flipped` flag,
+    // whose semantics differ. null (metadata unavailable) means "unknown" and forces the
+    // full-length, unreversed fallback in segmentBlockRange.
     let _sortedMatchesDisplay: boolean | null = null;
     try {
       const _ids = imageIds as string[];
@@ -582,6 +583,7 @@ class SegmentationService extends PubSubService {
               labelmaps: overlappingLayers.labelmaps,
               segmentBindings: overlappingLayers.segmentBindings,
               primaryLabelmapId: overlappingLayers.primaryLabelmapId,
+              blocks: overlappingLayers.blocks,
               sourceRepresentationName: 'binaryLabelmap',
             } as unknown as cstTypes.LabelmapSegmentationData)
           : {

--- a/Viewers/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
+++ b/Viewers/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
@@ -447,11 +447,21 @@ class SegmentationService extends PubSubService {
     // multi-layer (overlapping) SEGs and a single layer packing multiple segments;
     // only a single layer holding exactly segment 1 keeps the legacy path.
     // Does cornerstone's SORTED volume order match the source series' display order? This decides
-    // whether a SEG block's array index equals its volume z index. sortImageIdsAndGetSpacing orders
-    // by DESCENDING distance along the scan axis, so display order matches iff the series' own
-    // positions already descend. Measured here rather than taken from the server's `flipped` flag,
-    // whose semantics differ. null (metadata unavailable) means "unknown" and forces the
-    // full-length, unreversed fallback in segmentBlockRange.
+    // whether a SEG block's array index equals its volume z index.
+    //
+    // Derivation, from sortImageIdsAndGetSpacing (two negations that cancel):
+    //   1. its distance metric is an INVERTED subtraction — getDistance(id) = (ref - pos)·axis,
+    //      where `ref` is the position of imageIds[0], NOT (pos - ref)·axis;
+    //   2. it then sorts DESCENDING by that value.
+    // Descending in (ref - pos)·axis is ASCENDING in pos·axis. So cornerstone's sorted (working)
+    // order always runs from lowest to highest projection onto the scan axis, whatever the source
+    // series order was. Display order therefore matches sorted order exactly when the
+    // display-ordered series is itself ASCENDING in pos·axis, i.e. when the last slice projects
+    // FURTHER ALONG the axis than the first: (p_last - p_first)·axis > 0.
+    //
+    // Measured here rather than taken from the server's `flipped` flag, whose semantics differ.
+    // null (metadata unavailable) means "unknown" and forces the full-length, unreversed fallback
+    // in segmentBlockRange.
     let _sortedMatchesDisplay: boolean | null = null;
     try {
       const _ids = imageIds as string[];
@@ -469,8 +479,9 @@ class SegmentationService extends PubSubService {
         const _pN = _pmN.imagePositionPatient;
         const _d =
           (_pN[0] - _p0[0]) * _axis[0] + (_pN[1] - _p0[1]) * _axis[1] + (_pN[2] - _p0[2]) * _axis[2];
-        // Sort is descending, so display order already matches when the last slice sits BEHIND the first.
-        _sortedMatchesDisplay = _d < 0;
+        // Sorted order is ascending in pos·axis (see derivation above), so display order already
+        // matches it when the series' own last slice sits FURTHER ALONG the axis than its first.
+        _sortedMatchesDisplay = _d > 0;
       }
     } catch {
       /* diagnostic only */

--- a/Viewers/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
+++ b/Viewers/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
@@ -446,10 +446,40 @@ class SegmentationService extends PubSubService {
     // refine flow's block-index assumptions hold for reloaded SEGs. Covers both
     // multi-layer (overlapping) SEGs and a single layer packing multiple segments;
     // only a single layer holding exactly segment 1 keeps the legacy path.
+    // TEMPORARY (diagnostic, strip before merge): does cornerstone's SORTED volume order match the
+    // source series' display order? That is the fact deciding whether a SEG block's array index
+    // equals its volume z index. sortImageIdsAndGetSpacing orders by DESCENDING distance along the
+    // scan axis, so display order matches iff the series' own positions already descend. Measured
+    // here rather than taken from the server's `flipped` flag, whose semantics we'd be guessing at.
+    let _sortedMatchesDisplay: boolean | null = null;
+    try {
+      const _ids = imageIds as string[];
+      const _pm0 = metaData.get('imagePlaneModule', _ids[0]);
+      const _pmN = metaData.get('imagePlaneModule', _ids[_ids.length - 1]);
+      const _row = _pm0?.rowCosines;
+      const _col = _pm0?.columnCosines;
+      if (_row && _col && _pm0?.imagePositionPatient && _pmN?.imagePositionPatient) {
+        const _axis = [
+          _row[1] * _col[2] - _row[2] * _col[1],
+          _row[2] * _col[0] - _row[0] * _col[2],
+          _row[0] * _col[1] - _row[1] * _col[0],
+        ];
+        const _p0 = _pm0.imagePositionPatient;
+        const _pN = _pmN.imagePositionPatient;
+        const _d =
+          (_pN[0] - _p0[0]) * _axis[0] + (_pN[1] - _p0[1]) * _axis[1] + (_pN[2] - _p0[2]) * _axis[2];
+        // Sort is descending, so display order already matches when the last slice sits BEHIND the first.
+        _sortedMatchesDisplay = _d < 0;
+      }
+    } catch {
+      /* diagnostic only */
+    }
+
     const overlappingLayers = await buildOverlappingSegLayers({
       segmentationId,
       labelMapImages,
       sourceImageIds: imageIds as string[],
+      sortedMatchesDisplay: _sortedMatchesDisplay,
       segmentIndices: (segDisplaySet.segMetadata?.data ?? [])
         .map(data => Number(data?.SegmentNumber))
         .filter(index => Number.isFinite(index) && index > 0),

--- a/Viewers/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
+++ b/Viewers/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
@@ -589,6 +589,11 @@ class SegmentationService extends PubSubService {
               // AI multi-block scheme, where allImageIds.length > imageIds.length).
               imageIds: overlappingLayers.primaryImageIds,
               allImageIds: overlappingLayers.allImageIds,
+              // DEAD as written: syncLegacyLabelmapData overwrites both this and `imageIds` above
+              // with the PRIMARY LAYER's own values on every entry into state, so no reader ever
+              // sees the whole-series list here. Kept only to mirror the AI producer's shape
+              // (commandsModule, buildMultiBlockLabelmapRepresentation) — `allReferencedImageIds`
+              // is the field readers must use, and it is named so the adapter leaves it alone.
               referencedImageIds: imageIds as string[],
               allReferencedImageIds: imageIds as string[],
               labelmaps: overlappingLayers.labelmaps,

--- a/Viewers/extensions/cornerstone/src/utils/buildOverlappingSegLayers.ts
+++ b/Viewers/extensions/cornerstone/src/utils/buildOverlappingSegLayers.ts
@@ -103,6 +103,30 @@ export async function buildOverlappingSegLayers({
     layerSliceHasSegment.push(sliceHasSegmentFlags);
   }
 
+  // Per-segment display-space extent, inclusive. lo = -1 means the segment has no voxels at all.
+  // Derived from scans that already happen: a single-segment layer's slice flags ARE that segment's
+  // extent, and packed layers get theirs from the voxel loop that is already running.
+  const segmentExtents = new Map<number, { lo: number; hi: number }>();
+  const noteSlice = (segmentIndex: number, z: number) => {
+    const e = segmentExtents.get(segmentIndex);
+    if (!e) {
+      segmentExtents.set(segmentIndex, { lo: z, hi: z });
+      return;
+    }
+    if (z < e.lo) e.lo = z;
+    if (z > e.hi) e.hi = z;
+  };
+
+  for (let layerIndex = 0; layerIndex < labelMapImages.length; layerIndex++) {
+    const layerSegments = layerSegmentSets[layerIndex];
+    if (layerSegments.size !== 1) continue;
+    const [only] = layerSegments;
+    const flags = layerSliceHasSegment[layerIndex];
+    for (let z = 0; z < flags.length; z++) {
+      if (flags[z]) noteSlice(only, z);
+    }
+  }
+
   const maxSegmentIndex = Math.max(
     0,
     ...segmentIndices.filter(index => Number.isFinite(index) && index > 0),
@@ -165,6 +189,7 @@ export async function buildOverlappingSegLayers({
             const target = targetByValue[value];
             if (target) {
               (target as number[])[i] = value;
+              noteSlice(value, z);
             }
           }
         }
@@ -174,6 +199,14 @@ export async function buildOverlappingSegLayers({
           }
         }
       }
+    }
+  }
+
+  // Segments declared in metadata but absent from pixels get an explicit empty extent, so the
+  // block-assembly loop below has one uniform source of truth to consult.
+  for (let segmentIndex = 1; segmentIndex <= maxSegmentIndex; segmentIndex++) {
+    if (!segmentExtents.has(segmentIndex)) {
+      segmentExtents.set(segmentIndex, { lo: -1, hi: -1 });
     }
   }
 
@@ -256,6 +289,8 @@ export async function buildOverlappingSegLayers({
         `seg=${segmentIndex} len=${blockImages.length}/${sliceCount} ` +
         `srcIdx first=${firstSrc} last=${lastSrc} order=${order} ` +
         `extent=[${lo}..${hi}] (${lo < 0 ? 0 : hi - lo + 1} slices) ` +
+        `cheap=[${segmentExtents.get(segmentIndex)?.lo}..${segmentExtents.get(segmentIndex)?.hi}]` +
+        `${segmentExtents.get(segmentIndex)?.lo === lo && segmentExtents.get(segmentIndex)?.hi === hi ? '' : ' *** EXTENT MISMATCH ***'} ` +
         `source=${blocksBySegment.has(segmentIndex) ? 'layer-or-split' : 'empty-fabricated'}`
       );
     }

--- a/Viewers/extensions/cornerstone/src/utils/buildOverlappingSegLayers.ts
+++ b/Viewers/extensions/cornerstone/src/utils/buildOverlappingSegLayers.ts
@@ -44,12 +44,15 @@ export async function buildOverlappingSegLayers({
   segmentationId,
   labelMapImages,
   sourceImageIds,
+  sortedMatchesDisplay = null,
   segmentIndices = [],
   createDerivedImages,
 }: {
   segmentationId: string;
   labelMapImages: SegLayerImage[][];
   sourceImageIds: string[];
+  /** TEMPORARY (diagnostic): whether cornerstone's sorted volume order matches display order. */
+  sortedMatchesDisplay?: boolean | null;
   segmentIndices?: number[];
   createDerivedImages: (sourceImageIds: string[]) => Promise<SegLayerImage[]> | SegLayerImage[];
 }): Promise<OverlappingSegLayerResult | null> {
@@ -249,7 +252,8 @@ export async function buildOverlappingSegLayers({
         }
       }
       console.log(
-        `[seg-reload] seg=${segmentIndex} len=${blockImages.length}/${sliceCount} ` +
+        `[seg-reload] sortedMatchesDisplay=${sortedMatchesDisplay} ` +
+        `seg=${segmentIndex} len=${blockImages.length}/${sliceCount} ` +
         `srcIdx first=${firstSrc} last=${lastSrc} order=${order} ` +
         `extent=[${lo}..${hi}] (${lo < 0 ? 0 : hi - lo + 1} slices) ` +
         `source=${blocksBySegment.has(segmentIndex) ? 'layer-or-split' : 'empty-fabricated'}`

--- a/Viewers/extensions/cornerstone/src/utils/buildOverlappingSegLayers.ts
+++ b/Viewers/extensions/cornerstone/src/utils/buildOverlappingSegLayers.ts
@@ -4,8 +4,10 @@ import { segmentBlockRange } from '../../../default/src/utils/labelmapBlocks';
 /**
  * Normalizes a DICOM-SEG display set into the canonical per-segment multi-block
  * labelmap representation used by AI segmentations: block b holds only segment
- * b+1's voxels (N images per block, pixel value = segment index), blocks ordered
- * by segment. Applies to multi-layer SEGs (overlapping segments) and to
+ * b+1's voxels (pixel value = segment index), blocks ordered by segment. Blocks are
+ * z-cropped to the segment's own extent, so a block is generally SHORTER than the
+ * series and its length varies per segment; `LabelmapBlock.referencedImageIds` is
+ * what says where it sits. Applies to multi-layer SEGs (overlapping segments) and to
  * single-layer SEGs whose one layer packs multiple segments (or a segment
  * numbered != 1); only a single layer holding exactly segment 1 keeps the
  * legacy flat representation.
@@ -19,10 +21,12 @@ import { segmentBlockRange } from '../../../default/src/utils/labelmapBlocks';
  * volume per block, and refine/undo/export see the exact structure
  * buildMultiBlockLabelmapRepresentation produces.
  *
- * Layers that already hold a single segment are reused as that segment's block;
- * only packed layers allocate new derived images (via createDerivedImages). Segments
- * declared in metadata but empty in pixels get an empty block so block indices stay
- * aligned with segment indices.
+ * Layers that already hold a single segment supply that segment's block, but as a SLICED
+ * copy — the decoded layer is full length, so it is cut down to the segment's z-range
+ * (the layer's own images are left untouched; segDisplaySet.images is built from them).
+ * Only packed layers allocate new derived images (via createDerivedImages). Segments
+ * declared in metadata but empty in pixels get a minimum-size empty block so block
+ * indices stay aligned with segment indices.
  */
 
 interface SegLayerImage {
@@ -124,7 +128,21 @@ export async function buildOverlappingSegLayers({
     layerSliceHasSegment.push(sliceHasSegmentFlags);
   }
 
-  // Per-segment display-space extent, inclusive. lo = -1 means the segment has no voxels at all.
+  // OWNERSHIP: the FIRST layer (in layer order) that contains a segment is the one whose voxels are
+  // kept — the assembly loop below claims a segment into blocksBySegment on first sight and every
+  // later layer skips it, whether it is single-segment or packed. Extent recording must follow the
+  // same rule, or segmentExtents describes a layer whose voxels were never written to any block.
+  const ownerLayerForSegment = new Map<number, number>();
+  for (let layerIndex = 0; layerIndex < layerSegmentSets.length; layerIndex++) {
+    for (const segmentIndex of layerSegmentSets[layerIndex]) {
+      if (!ownerLayerForSegment.has(segmentIndex)) {
+        ownerLayerForSegment.set(segmentIndex, layerIndex);
+      }
+    }
+  }
+
+  // Per-segment display-space extent, inclusive, of the OWNING layer only — i.e. the extent of the
+  // voxels that are actually kept. lo = -1 means the segment has no voxels at all.
   // Derived from scans that already happen: a single-segment layer's slice flags ARE that segment's
   // extent, and packed layers get theirs from the voxel loop that is already running.
   const segmentExtents = new Map<number, { lo: number; hi: number }>();
@@ -142,6 +160,11 @@ export async function buildOverlappingSegLayers({
     const layerSegments = layerSegmentSets[layerIndex];
     if (layerSegments.size !== 1) continue;
     const [only] = layerSegments;
+    // Same ownership rule Pass A applies to packed layers: an earlier layer already owns this
+    // segment, so this layer's voxels go to no block and must not widen its extent. Without this,
+    // a segment split across two layers had segmentExtents silently cover BOTH — which both
+    // over-sized the owning block and made the data-loss check below unable to see the loss.
+    if (ownerLayerForSegment.get(only) !== layerIndex) continue;
     const flags = layerSliceHasSegment[layerIndex];
     for (let z = 0; z < flags.length; z++) {
       if (flags[z]) noteSlice(only, z);
@@ -209,7 +232,9 @@ export async function buildOverlappingSegLayers({
         for (let i = 0; i < sourceData.length; i++) {
           const value = sourceData[i] as number;
           // The `has` guard mirrors Pass B's skip: a segment already owned by an earlier layer
-          // keeps that layer's block, so this layer's voxels must not widen its extent.
+          // keeps that layer's block, so this layer's voxels must not widen its extent. Equivalent
+          // to the pre-pass's ownerLayerForSegment test — blocksBySegment holds exactly the
+          // segments claimed by layers before this one.
           if (value !== 0 && !blocksBySegment.has(value)) {
             noteSlice(value, z);
           }
@@ -313,7 +338,12 @@ export async function buildOverlappingSegLayers({
     // the reference list from each block image's own referencedImageId (order-safe); fall back to
     // the block's OWN display slice range if any is missing. The whole-series list is not a legal
     // substitute for a cropped block — it would pair block slice 0 with display slice 0 and render
-    // the mask at the wrong depth. Both the length test and the fallback are therefore per-block.
+    // the mask at the wrong depth, so the fallback is per-block.
+    //
+    // Only `refIds.every(Boolean)` does any work here: `refIds` is `blockImages.map(...)` on the
+    // line above, so the length comparison against `blockImages` is a tautology. It is kept purely
+    // to mirror `refIdsFor` in the AI path (commandsModule), where the two arrays have independent
+    // origins and the length test is real — do not read it as a per-block length check.
     const refIds = blockImages.map(image => image.referencedImageId);
     const referencedImageIds =
       refIds.length === blockImages.length && refIds.every(Boolean)
@@ -352,10 +382,15 @@ export async function buildOverlappingSegLayers({
 
     // Permanent data-loss check: kept while everything around it was removed because it is the only
     // check that can detect dropped voxels. Any check that measures the assembled block agrees with
-    // it even when the block is missing data — sourceExtents is recorded before the blocksBySegment
-    // ownership guard, so it captures what the source contained, not what was kept.
-    // A segment present in multiple layers has its voxels from the second layer written to no block
-    // (the ownership guard skips them), so its mask renders cut off in z.
+    // it even when the block is missing data — sourceExtents is recorded before ANY ownership
+    // guard, so it captures what the source contained, while segmentExtents records only the
+    // OWNING layer, i.e. what was kept. The two diverge exactly when voxels are lost.
+    // A segment present in multiple layers has its voxels from every layer after the first written
+    // to no block, so its mask renders cut off in z.
+    // This fires for all three orderings — single+single, packed-then-single, single-then-packed —
+    // because both the packed Pass A guard and the single-segment pre-pass now apply the same
+    // first-layer ownership rule. (It still cannot see voxels lost INSIDE the owning layer's
+    // z-range, which no extent comparison can; nothing in the assembly drops those.)
     const se = sourceExtents.get(segmentIndex);
     const be = segmentExtents.get(segmentIndex);
     if (se && be && be.lo >= 0 && (se.lo < be.lo || se.hi > be.hi)) {

--- a/Viewers/extensions/cornerstone/src/utils/buildOverlappingSegLayers.ts
+++ b/Viewers/extensions/cornerstone/src/utils/buildOverlappingSegLayers.ts
@@ -393,6 +393,19 @@ export async function buildOverlappingSegLayers({
     }
   }
 
+  // TEMPORARY (diagnostic, strip before merge): the actual saving, computed from the blocks we built.
+  // Pure arithmetic -- this file takes no cornerstone dependency, so it cannot read the image cache.
+  {
+    const allocated = blocks.reduce((n, b) => n + b.imageIds.length, 0);
+    const wouldHaveBeen = blocks.length * sliceCount;
+    const mb = (n: number) => ((n * 512 * 512) / 1e6).toFixed(0);
+    console.log(
+      `[seg-reload] TOTAL: ${blocks.length} blocks, ${allocated}/${wouldHaveBeen} slices ` +
+      `(~${mb(allocated)}MB vs ~${mb(wouldHaveBeen)}MB, ` +
+      `${(100 * (1 - allocated / wouldHaveBeen)).toFixed(0)}% saved)`
+    );
+  }
+
   return {
     labelmaps,
     segmentBindings,

--- a/Viewers/extensions/cornerstone/src/utils/buildOverlappingSegLayers.ts
+++ b/Viewers/extensions/cornerstone/src/utils/buildOverlappingSegLayers.ts
@@ -75,6 +75,21 @@ export async function buildOverlappingSegLayers({
 
   // Scan each layer once: which segments it holds, and the first segmented slice
   // in adapter (layer-major) order — parity with the legacy hydration loop.
+  // TEMPORARY (diagnostic, strip before merge): each segment's TRUE extent across ALL layers,
+  // recorded before any blocksBySegment ownership guard. Comparing this against the assembled
+  // block's extent detects DROPPED VOXELS -- which the extent/cheap check cannot, because both of
+  // those measure the block we built, so they agree even when the block is missing data.
+  const sourceExtents = new Map<number, { lo: number; hi: number }>();
+  const noteSourceSlice = (segmentIndex: number, z: number) => {
+    const e = sourceExtents.get(segmentIndex);
+    if (!e) {
+      sourceExtents.set(segmentIndex, { lo: z, hi: z });
+      return;
+    }
+    if (z < e.lo) e.lo = z;
+    if (z > e.hi) e.hi = z;
+  };
+
   const layerSegmentSets: Set<number>[] = [];
   let firstSegmentedSliceImageId: string | null = null;
   // Per layer, per slice: whether the slice holds any segment voxels. Lets the
@@ -98,6 +113,7 @@ export async function buildOverlappingSegLayers({
         if (value !== 0) {
           layerSegments.add(value);
           sliceHasSegment = true;
+          noteSourceSlice(value, z);
         }
       }
       sliceHasSegmentFlags[z] = sliceHasSegment;
@@ -386,6 +402,13 @@ export async function buildOverlappingSegLayers({
         `seg=${segmentIndex} len=${blockImages.length}/${sliceCount} z0=${range.z0} ` +
         `srcIdx first=${firstSrc} last=${lastSrc} order=${order} ` +
         `extent=[${dLo}..${dHi}] (${lo < 0 ? 0 : hi - lo + 1} slices) ` +
+        `src=[${sourceExtents.get(segmentIndex)?.lo ?? -1}..${sourceExtents.get(segmentIndex)?.hi ?? -1}]` +
+        `${(() => {
+          const se = sourceExtents.get(segmentIndex);
+          const be = segmentExtents.get(segmentIndex);
+          if (!se || !be || be.lo < 0) return '';
+          return se.lo < be.lo || se.hi > be.hi ? ' *** VOXELS DROPPED ***' : '';
+        })()} ` +
         `cheap=[${segmentExtents.get(segmentIndex)?.lo}..${segmentExtents.get(segmentIndex)?.hi}]` +
         `${segmentExtents.get(segmentIndex)?.lo === dLo && segmentExtents.get(segmentIndex)?.hi === dHi ? '' : ' *** EXTENT MISMATCH ***'} ` +
         `source=${blocksBySegment.has(segmentIndex) ? 'layer-or-split' : 'empty-fabricated'}`

--- a/Viewers/extensions/cornerstone/src/utils/buildOverlappingSegLayers.ts
+++ b/Viewers/extensions/cornerstone/src/utils/buildOverlappingSegLayers.ts
@@ -57,6 +57,7 @@ export async function buildOverlappingSegLayers({
   createDerivedImages: (sourceImageIds: string[]) => Promise<SegLayerImage[]> | SegLayerImage[];
 }): Promise<OverlappingSegLayerResult | null> {
   if (!labelMapImages?.length) {
+    console.log('[seg-reload] SKIPPED: no labelMapImages (legacy flat path)');
     return null;
   }
 
@@ -64,6 +65,7 @@ export async function buildOverlappingSegLayers({
   if (labelMapImages.some(layerImages => layerImages.length !== sliceCount)) {
     // Unexpected adapter output — fall back to the legacy flat path rather than
     // build blocks with a broken image->slice mapping.
+    console.log('[seg-reload] SKIPPED: a layer length != sliceCount (legacy flat path)');
     return null;
   }
 
@@ -133,6 +135,7 @@ export async function buildOverlappingSegLayers({
     ...layerSegmentSets.flatMap(set => Array.from(set))
   );
   if (maxSegmentIndex === 0) {
+    console.log('[seg-reload] SKIPPED: maxSegmentIndex === 0 (legacy flat path)');
     return null;
   }
 
@@ -143,6 +146,12 @@ export async function buildOverlappingSegLayers({
   // shared block makes refines stack on top of the old mask (segment >= 2) or
   // wipe the other segments (segment 1).
   if (labelMapImages.length === 1 && maxSegmentIndex <= 1) {
+    // NOTE: a single-segment SEG never reaches the block-building code below, so it gets NO
+    // sparse blocks from this work — it uses the legacy full-length flat representation.
+    console.log(
+      `[seg-reload] SKIPPED: single layer holding only segment 1 (legacy flat path, ` +
+      `${sliceCount} slices, NOT cropped)`
+    );
     return null;
   }
 

--- a/Viewers/extensions/cornerstone/src/utils/buildOverlappingSegLayers.ts
+++ b/Viewers/extensions/cornerstone/src/utils/buildOverlappingSegLayers.ts
@@ -1,3 +1,6 @@
+import type { LabelmapBlock } from '../../../default/src/utils/labelmapBlocks';
+import { segmentBlockRange } from '../../../default/src/utils/labelmapBlocks';
+
 /**
  * Normalizes a DICOM-SEG display set into the canonical per-segment multi-block
  * labelmap representation used by AI segmentations: block b holds only segment
@@ -38,6 +41,7 @@ interface OverlappingSegLayerResult {
   primaryImageIds: string[];
   allImageIds: string[];
   firstSegmentedSliceImageId: string | null;
+  blocks: LabelmapBlock[];
 }
 
 export async function buildOverlappingSegLayers({
@@ -51,7 +55,7 @@ export async function buildOverlappingSegLayers({
   segmentationId: string;
   labelMapImages: SegLayerImage[][];
   sourceImageIds: string[];
-  /** TEMPORARY (diagnostic): whether cornerstone's sorted volume order matches display order. */
+  /** Whether cornerstone's sorted volume order matches display order; null means unknown. */
   sortedMatchesDisplay?: boolean | null;
   segmentIndices?: number[];
   createDerivedImages: (sourceImageIds: string[]) => Promise<SegLayerImage[]> | SegLayerImage[];
@@ -222,6 +226,7 @@ export async function buildOverlappingSegLayers({
   const labelmaps: Record<string, object> = {};
   const segmentBindings: Record<number, { labelmapId: string; labelValue: number }> = {};
   const allImageIds: string[] = [];
+  const blocks: LabelmapBlock[] = [];
   const primaryLabelmapId = `${segmentationId}-storage-0`;
   let primaryImageIds: string[] = [];
 
@@ -241,21 +246,44 @@ export async function buildOverlappingSegLayers({
         ? (refIds as string[])
         : sourceImageIds;
 
+    // Ordering only, for now: take the whole series but normalise to WORKING order, so the array
+    // index of a block equals its cornerstone volume z index. Cropping comes next; keeping the two
+    // changes apart means a rendering regression points at one or the other, not both.
+    //
+    // Only `range.reverse` is consumed here. `range.sliceStart`/`sliceEnd` describe the CROPPED
+    // range and are deliberately ignored until Task 4 — the blocks below stay full length.
+    const ext = segmentExtents.get(segmentIndex) ?? { lo: -1, hi: -1 };
+    const range = segmentBlockRange(ext.lo, ext.hi, sliceCount, sortedMatchesDisplay);
+    const orderedImageIds = range.reverse ? blockImageIds.slice().reverse() : blockImageIds;
+    const orderedRefIds = range.reverse
+      ? (referencedImageIds as string[]).slice().reverse()
+      : (referencedImageIds as string[]);
+
     const labelmapId =
       segmentIndex === 1 ? primaryLabelmapId : `${segmentationId}-private-${segmentIndex}`;
     labelmaps[labelmapId] = {
       labelmapId,
       type: 'stack',
-      imageIds: blockImageIds,
-      referencedImageIds,
+      imageIds: orderedImageIds,
+      referencedImageIds: orderedRefIds,
       labelToSegmentIndex: {},
     };
     segmentBindings[segmentIndex] = { labelmapId, labelValue: segmentIndex };
 
+    blocks.push({
+      segmentIndex,
+      // A full-length block starts at working 0 whichever way it is ordered: segmentBlockRange
+      // would give z0 = sourceCount - sourceCount = 0 when reversed, and 0 when not. Task 4 crops
+      // the block and takes z0 from `range` directly.
+      z0: 0,
+      imageIds: orderedImageIds,
+      referencedImageIds: orderedRefIds,
+    });
+
     if (segmentIndex === 1) {
-      primaryImageIds = blockImageIds;
+      primaryImageIds = orderedImageIds;
     }
-    allImageIds.push(...blockImageIds);
+    allImageIds.push(...orderedImageIds);
 
     // TEMPORARY (diagnostic, strip before merge): settles whether a SEG block's images are stored
     // in DISPLAY order (index-aligned with sourceImageIds) or WORKING order (reversed for a
@@ -311,6 +339,7 @@ export async function buildOverlappingSegLayers({
     primaryLabelmapId,
     primaryImageIds,
     allImageIds,
+    blocks,
     firstSegmentedSliceImageId,
   };
 }

--- a/Viewers/extensions/cornerstone/src/utils/buildOverlappingSegLayers.ts
+++ b/Viewers/extensions/cornerstone/src/utils/buildOverlappingSegLayers.ts
@@ -61,7 +61,6 @@ export async function buildOverlappingSegLayers({
   createDerivedImages: (sourceImageIds: string[]) => Promise<SegLayerImage[]> | SegLayerImage[];
 }): Promise<OverlappingSegLayerResult | null> {
   if (!labelMapImages?.length) {
-    console.log('[seg-reload] SKIPPED: no labelMapImages (legacy flat path)');
     return null;
   }
 
@@ -69,16 +68,16 @@ export async function buildOverlappingSegLayers({
   if (labelMapImages.some(layerImages => layerImages.length !== sliceCount)) {
     // Unexpected adapter output — fall back to the legacy flat path rather than
     // build blocks with a broken image->slice mapping.
-    console.log('[seg-reload] SKIPPED: a layer length != sliceCount (legacy flat path)');
     return null;
   }
 
   // Scan each layer once: which segments it holds, and the first segmented slice
   // in adapter (layer-major) order — parity with the legacy hydration loop.
-  // TEMPORARY (diagnostic, strip before merge): each segment's TRUE extent across ALL layers,
-  // recorded before any blocksBySegment ownership guard. Comparing this against the assembled
-  // block's extent detects DROPPED VOXELS -- which the extent/cheap check cannot, because both of
-  // those measure the block we built, so they agree even when the block is missing data.
+  //
+  // sourceExtents records each segment's TRUE extent across ALL layers, before any
+  // blocksBySegment ownership guard. This is kept permanently: it is the only way to
+  // detect DROPPED VOXELS — any check that measures the assembled block agrees with it
+  // even when the block is missing data, because the block is what was built.
   const sourceExtents = new Map<number, { lo: number; hi: number }>();
   const noteSourceSlice = (segmentIndex: number, z: number) => {
     const e = sourceExtents.get(segmentIndex);
@@ -155,7 +154,6 @@ export async function buildOverlappingSegLayers({
     ...layerSegmentSets.flatMap(set => Array.from(set))
   );
   if (maxSegmentIndex === 0) {
-    console.log('[seg-reload] SKIPPED: maxSegmentIndex === 0 (legacy flat path)');
     return null;
   }
 
@@ -168,10 +166,6 @@ export async function buildOverlappingSegLayers({
   if (labelMapImages.length === 1 && maxSegmentIndex <= 1) {
     // NOTE: a single-segment SEG never reaches the block-building code below, so it gets NO
     // sparse blocks from this work — it uses the legacy full-length flat representation.
-    console.log(
-      `[seg-reload] SKIPPED: single layer holding only segment 1 (legacy flat path, ` +
-      `${sliceCount} slices, NOT cropped)`
-    );
     return null;
   }
 
@@ -356,77 +350,22 @@ export async function buildOverlappingSegLayers({
     }
     allImageIds.push(...orderedImageIds);
 
-    // TEMPORARY (diagnostic, strip before merge): settles whether a SEG block's images are stored
-    // in DISPLAY order (index-aligned with sourceImageIds) or WORKING order (reversed for a
-    // z-descending series). LabelmapBlock.z0 is defined as a WORKING offset, so emitting a real z0
-    // for reloaded SEGs is only safe once we know which of the two this producer actually produces.
-    // `order` is measured, not assumed: it is the direction of the block's own referencedImageIds
-    // through the source series.
-    {
-      const srcIndexById = new Map<string, number>();
-      sourceImageIds.forEach((id, i) => srcIndexById.set(id, i));
-      const firstSrc = srcIndexById.get(String(refIds[0]));
-      const lastSrc = srcIndexById.get(String(refIds[refIds.length - 1]));
-      const order =
-        firstSrc == null || lastSrc == null
-          ? 'unknown'
-          : firstSrc < lastSrc
-            ? 'ascending(display)'
-            : 'descending(working-if-flipped)';
-      // Measured extent, scanned in the block's own index space. `blockImages` is always in DISPLAY
-      // order here (only the ordered* arrays above are reversed), and the block starts at display
-      // index range.sliceStart, so adding that offset puts it back in the same space as `cheap`
-      // below — which is what makes the mismatch check meaningful now that blocks are cropped.
-      let lo = -1;
-      let hi = -1;
-      for (let z = 0; z < blockImages.length; z++) {
-        const sd = blockImages[z]?.voxelManager?.getScalarData?.();
-        if (sd && (sd as ArrayLike<number>).length) {
-          let hit = false;
-          for (let i = 0; i < (sd as ArrayLike<number>).length; i++) {
-            if ((sd as ArrayLike<number>)[i] === segmentIndex) {
-              hit = true;
-              break;
-            }
-          }
-          if (hit) {
-            if (lo < 0) lo = z;
-            hi = z;
-          }
-        }
-      }
-      const dLo = lo < 0 ? -1 : lo + range.sliceStart;
-      const dHi = hi < 0 ? -1 : hi + range.sliceStart;
-      console.log(
-        `[seg-reload] sortedMatchesDisplay=${sortedMatchesDisplay} ` +
-        `seg=${segmentIndex} len=${blockImages.length}/${sliceCount} z0=${range.z0} ` +
-        `srcIdx first=${firstSrc} last=${lastSrc} order=${order} ` +
-        `extent=[${dLo}..${dHi}] (${lo < 0 ? 0 : hi - lo + 1} slices) ` +
-        `src=[${sourceExtents.get(segmentIndex)?.lo ?? -1}..${sourceExtents.get(segmentIndex)?.hi ?? -1}]` +
-        `${(() => {
-          const se = sourceExtents.get(segmentIndex);
-          const be = segmentExtents.get(segmentIndex);
-          if (!se || !be || be.lo < 0) return '';
-          return se.lo < be.lo || se.hi > be.hi ? ' *** VOXELS DROPPED ***' : '';
-        })()} ` +
-        `cheap=[${segmentExtents.get(segmentIndex)?.lo}..${segmentExtents.get(segmentIndex)?.hi}]` +
-        `${segmentExtents.get(segmentIndex)?.lo === dLo && segmentExtents.get(segmentIndex)?.hi === dHi ? '' : ' *** EXTENT MISMATCH ***'} ` +
-        `source=${blocksBySegment.has(segmentIndex) ? 'layer-or-split' : 'empty-fabricated'}`
+    // Permanent data-loss check: kept while everything around it was removed because it is the only
+    // check that can detect dropped voxels. Any check that measures the assembled block agrees with
+    // it even when the block is missing data — sourceExtents is recorded before the blocksBySegment
+    // ownership guard, so it captures what the source contained, not what was kept.
+    // A segment present in multiple layers has its voxels from the second layer written to no block
+    // (the ownership guard skips them), so its mask renders cut off in z.
+    const se = sourceExtents.get(segmentIndex);
+    const be = segmentExtents.get(segmentIndex);
+    if (se && be && be.lo >= 0 && (se.lo < be.lo || se.hi > be.hi)) {
+      console.error(
+        `SEG reload: segment ${segmentIndex} has voxels in source slices [${se.lo}..${se.hi}] ` +
+        `but the assembled block covers only [${be.lo}..${be.hi}] — slices outside that range ` +
+        `were dropped. Cause: segment appears in multiple layers; only the first layer's voxels ` +
+        `are kept.`
       );
     }
-  }
-
-  // TEMPORARY (diagnostic, strip before merge): the actual saving, computed from the blocks we built.
-  // Pure arithmetic -- this file takes no cornerstone dependency, so it cannot read the image cache.
-  {
-    const allocated = blocks.reduce((n, b) => n + b.imageIds.length, 0);
-    const wouldHaveBeen = blocks.length * sliceCount;
-    const mb = (n: number) => ((n * 512 * 512) / 1e6).toFixed(0);
-    console.log(
-      `[seg-reload] TOTAL: ${blocks.length} blocks, ${allocated}/${wouldHaveBeen} slices ` +
-      `(~${mb(allocated)}MB vs ~${mb(wouldHaveBeen)}MB, ` +
-      `${(100 * (1 - allocated / wouldHaveBeen)).toFixed(0)}% saved)`
-    );
   }
 
   return {

--- a/Viewers/extensions/cornerstone/src/utils/buildOverlappingSegLayers.ts
+++ b/Viewers/extensions/cornerstone/src/utils/buildOverlappingSegLayers.ts
@@ -211,6 +211,50 @@ export async function buildOverlappingSegLayers({
       primaryImageIds = blockImageIds;
     }
     allImageIds.push(...blockImageIds);
+
+    // TEMPORARY (diagnostic, strip before merge): settles whether a SEG block's images are stored
+    // in DISPLAY order (index-aligned with sourceImageIds) or WORKING order (reversed for a
+    // z-descending series). LabelmapBlock.z0 is defined as a WORKING offset, so emitting a real z0
+    // for reloaded SEGs is only safe once we know which of the two this producer actually produces.
+    // `order` is measured, not assumed: it is the direction of the block's own referencedImageIds
+    // through the source series.
+    {
+      const srcIndexById = new Map<string, number>();
+      sourceImageIds.forEach((id, i) => srcIndexById.set(id, i));
+      const firstSrc = srcIndexById.get(String(refIds[0]));
+      const lastSrc = srcIndexById.get(String(refIds[refIds.length - 1]));
+      const order =
+        firstSrc == null || lastSrc == null
+          ? 'unknown'
+          : firstSrc < lastSrc
+            ? 'ascending(display)'
+            : 'descending(working-if-flipped)';
+      // Extent this segment WOULD get if cropped, in the block's own index space.
+      let lo = -1;
+      let hi = -1;
+      for (let z = 0; z < blockImages.length; z++) {
+        const sd = blockImages[z]?.voxelManager?.getScalarData?.();
+        if (sd && (sd as ArrayLike<number>).length) {
+          let hit = false;
+          for (let i = 0; i < (sd as ArrayLike<number>).length; i++) {
+            if ((sd as ArrayLike<number>)[i] === segmentIndex) {
+              hit = true;
+              break;
+            }
+          }
+          if (hit) {
+            if (lo < 0) lo = z;
+            hi = z;
+          }
+        }
+      }
+      console.log(
+        `[seg-reload] seg=${segmentIndex} len=${blockImages.length}/${sliceCount} ` +
+        `srcIdx first=${firstSrc} last=${lastSrc} order=${order} ` +
+        `extent=[${lo}..${hi}] (${lo < 0 ? 0 : hi - lo + 1} slices) ` +
+        `source=${blocksBySegment.has(segmentIndex) ? 'layer-or-split' : 'empty-fabricated'}`
+      );
+    }
   }
 
   return {

--- a/Viewers/extensions/cornerstone/src/utils/buildOverlappingSegLayers.ts
+++ b/Viewers/extensions/cornerstone/src/utils/buildOverlappingSegLayers.ts
@@ -163,6 +163,11 @@ export async function buildOverlappingSegLayers({
   // packed layers are split into fresh per-segment blocks; declared-but-empty
   // segments get an empty block to preserve block index === segmentIndex - 1.
   const blocksBySegment = new Map<number, SegLayerImage[]>();
+  // Display-space slice offset of each split block, i.e. the block's own `sliceStart`. The split
+  // pass writes by ABSOLUTE slice index z, so it needs this to translate z into a block index.
+  // Presence in this map also marks a block as "already allocated cropped", which the assembly
+  // loop below uses to tell it apart from a full-length reused layer that still needs slicing.
+  const splitBlockOffsets = new Map<number, number>();
   for (let layerIndex = 0; layerIndex < labelMapImages.length; layerIndex++) {
     const layerSegments = layerSegmentSets[layerIndex];
     if (layerSegments.size === 1) {
@@ -173,15 +178,51 @@ export async function buildOverlappingSegLayers({
       continue;
     }
     if (layerSegments.size > 1) {
-      const splitBlocks = new Map<number, SegLayerImage[]>();
-      for (const segmentIndex of layerSegments) {
-        if (!blocksBySegment.has(segmentIndex)) {
-          const blockImages = await createDerivedImages(sourceImageIds);
-          splitBlocks.set(segmentIndex, blockImages);
-          blocksBySegment.set(segmentIndex, blockImages);
+      const sliceHasSegment = layerSliceHasSegment[layerIndex];
+
+      // A packed layer's per-segment extents are not known before this point: a single-segment
+      // layer's slice flags ARE its segment's extent, but a packed layer's flags say only that
+      // SOME segment is present. So the voxels must be read twice — once to size the blocks, once
+      // to fill them. Merging the two would allocate against an empty extent map, silently giving
+      // every packed segment a MIN_BLOCK_SLICES block and dropping most of its mask.
+      // Packed layers are the minority of SEG reloads; correctness beats the saved scan.
+
+      // PASS A — extents only. Must complete before allocation: block size depends on it.
+      for (let z = 0; z < sliceCount; z++) {
+        if (!sliceHasSegment[z]) {
+          continue;
+        }
+        const sourceData = labelMapImages[layerIndex][z].voxelManager?.getScalarData();
+        if (!sourceData) {
+          continue;
+        }
+        for (let i = 0; i < sourceData.length; i++) {
+          const value = sourceData[i] as number;
+          // The `has` guard mirrors Pass B's skip: a segment already owned by an earlier layer
+          // keeps that layer's block, so this layer's voxels must not widen its extent.
+          if (value !== 0 && !blocksBySegment.has(value)) {
+            noteSlice(value, z);
+          }
         }
       }
-      const sliceHasSegment = layerSliceHasSegment[layerIndex];
+
+      // PASS B — allocate each segment's block over its own cropped range.
+      const splitBlocks = new Map<number, SegLayerImage[]>();
+      for (const segmentIndex of layerSegments) {
+        if (blocksBySegment.has(segmentIndex)) {
+          continue;
+        }
+        const sExt = segmentExtents.get(segmentIndex) ?? { lo: -1, hi: -1 };
+        const sRange = segmentBlockRange(sExt.lo, sExt.hi, sliceCount, sortedMatchesDisplay);
+        const blockImages = await createDerivedImages(
+          sourceImageIds.slice(sRange.sliceStart, sRange.sliceEnd)
+        );
+        splitBlocks.set(segmentIndex, blockImages);
+        blocksBySegment.set(segmentIndex, blockImages);
+        splitBlockOffsets.set(segmentIndex, sRange.sliceStart);
+      }
+
+      // PASS C — copy voxels, indexing each block through its own offset.
       for (let z = 0; z < sliceCount; z++) {
         // All-zero source slice: nothing to copy, target blocks stay zeroed.
         if (!sliceHasSegment[z]) {
@@ -191,10 +232,15 @@ export async function buildOverlappingSegLayers({
         if (!sourceData) {
           continue;
         }
-        // Dense value-indexed lookup — cheaper than a Map.get per nonzero voxel.
+        // Dense value-indexed lookup — cheaper than a Map.get per nonzero voxel. A segment whose
+        // block does not cover this slice is left undefined, so its voxels here are skipped.
         const targetByValue: (ArrayLike<number> | undefined)[] = new Array(maxSegmentIndex + 1);
         for (const [segmentIndex, blockImages] of splitBlocks) {
-          targetByValue[segmentIndex] = blockImages[z].voxelManager?.getScalarData();
+          const ai = z - (splitBlockOffsets.get(segmentIndex) ?? 0);
+          targetByValue[segmentIndex] =
+            ai >= 0 && ai < blockImages.length
+              ? blockImages[ai].voxelManager?.getScalarData()
+              : undefined;
         }
         for (let i = 0; i < sourceData.length; i++) {
           const value = sourceData[i] as number;
@@ -202,13 +248,13 @@ export async function buildOverlappingSegLayers({
             const target = targetByValue[value];
             if (target) {
               (target as number[])[i] = value;
-              noteSlice(value, z);
             }
           }
         }
         for (const [segmentIndex, blockImages] of splitBlocks) {
-          if (targetByValue[segmentIndex]) {
-            blockImages[z].voxelManager?.setScalarData?.(targetByValue[segmentIndex]);
+          const ai = z - (splitBlockOffsets.get(segmentIndex) ?? 0);
+          if (ai >= 0 && ai < blockImages.length && targetByValue[segmentIndex]) {
+            blockImages[ai].voxelManager?.setScalarData?.(targetByValue[segmentIndex]);
           }
         }
       }
@@ -231,29 +277,41 @@ export async function buildOverlappingSegLayers({
   let primaryImageIds: string[] = [];
 
   for (let segmentIndex = 1; segmentIndex <= maxSegmentIndex; segmentIndex++) {
+    // The block's z-crop. Computed from the same inputs the split pass used, so a split block's
+    // range here is by construction the one it was allocated at.
+    const ext = segmentExtents.get(segmentIndex) ?? { lo: -1, hi: -1 };
+    const range = segmentBlockRange(ext.lo, ext.hi, sliceCount, sortedMatchesDisplay);
+
     let blockImages = blocksBySegment.get(segmentIndex);
     if (!blockImages) {
-      blockImages = await createDerivedImages(sourceImageIds);
+      // Declared-but-empty segment: the smallest legal block, not a full-series slab of zeros.
+      blockImages = await createDerivedImages(
+        sourceImageIds.slice(range.sliceStart, range.sliceEnd)
+      );
+    } else if (splitBlockOffsets.has(segmentIndex)) {
+      // Already allocated at the cropped size by the split loop — take as-is.
+    } else {
+      // Reused decoded layer: it is full length, so slice it down. Never reallocate or reverse in
+      // place — these images belong to the display set (segDisplaySet.images is built from them).
+      // The out-of-range images stay in cache for that reason, so this frees no image memory; the
+      // win is the per-block MPR volume, which is built from exactly these ids.
+      blockImages = blockImages.slice(range.sliceStart, range.sliceEnd);
     }
     const blockImageIds = blockImages.map(image => image.imageId);
 
     // Cornerstone maps labelmap image k -> referencedImageIds[k] by index, so derive
-    // the reference list from each block image's own referencedImageId (order-safe);
-    // fall back to the source ordering if any is missing.
+    // the reference list from each block image's own referencedImageId (order-safe); fall back to
+    // the block's OWN display slice range if any is missing. The whole-series list is not a legal
+    // substitute for a cropped block — it would pair block slice 0 with display slice 0 and render
+    // the mask at the wrong depth. Both the length test and the fallback are therefore per-block.
     const refIds = blockImages.map(image => image.referencedImageId);
     const referencedImageIds =
-      refIds.length === sliceCount && refIds.every(Boolean)
+      refIds.length === blockImages.length && refIds.every(Boolean)
         ? (refIds as string[])
-        : sourceImageIds;
+        : sourceImageIds.slice(range.sliceStart, range.sliceEnd);
 
-    // Ordering only, for now: take the whole series but normalise to WORKING order, so the array
-    // index of a block equals its cornerstone volume z index. Cropping comes next; keeping the two
-    // changes apart means a rendering regression points at one or the other, not both.
-    //
-    // Only `range.reverse` is consumed here. `range.sliceStart`/`sliceEnd` describe the CROPPED
-    // range and are deliberately ignored until Task 4 — the blocks below stay full length.
-    const ext = segmentExtents.get(segmentIndex) ?? { lo: -1, hi: -1 };
-    const range = segmentBlockRange(ext.lo, ext.hi, sliceCount, sortedMatchesDisplay);
+    // Normalise the cropped block to WORKING order, so its array index equals the cornerstone
+    // volume z index. imageIds and referencedImageIds reverse together to stay index-aligned.
     const orderedImageIds = range.reverse ? blockImageIds.slice().reverse() : blockImageIds;
     const orderedRefIds = range.reverse
       ? (referencedImageIds as string[]).slice().reverse()
@@ -272,10 +330,7 @@ export async function buildOverlappingSegLayers({
 
     blocks.push({
       segmentIndex,
-      // A full-length block starts at working 0 whichever way it is ordered: segmentBlockRange
-      // would give z0 = sourceCount - sourceCount = 0 when reversed, and 0 when not. Task 4 crops
-      // the block and takes z0 from `range` directly.
-      z0: 0,
+      z0: range.z0,
       imageIds: orderedImageIds,
       referencedImageIds: orderedRefIds,
     });
@@ -302,7 +357,10 @@ export async function buildOverlappingSegLayers({
           : firstSrc < lastSrc
             ? 'ascending(display)'
             : 'descending(working-if-flipped)';
-      // Extent this segment WOULD get if cropped, in the block's own index space.
+      // Measured extent, scanned in the block's own index space. `blockImages` is always in DISPLAY
+      // order here (only the ordered* arrays above are reversed), and the block starts at display
+      // index range.sliceStart, so adding that offset puts it back in the same space as `cheap`
+      // below — which is what makes the mismatch check meaningful now that blocks are cropped.
       let lo = -1;
       let hi = -1;
       for (let z = 0; z < blockImages.length; z++) {
@@ -321,13 +379,15 @@ export async function buildOverlappingSegLayers({
           }
         }
       }
+      const dLo = lo < 0 ? -1 : lo + range.sliceStart;
+      const dHi = hi < 0 ? -1 : hi + range.sliceStart;
       console.log(
         `[seg-reload] sortedMatchesDisplay=${sortedMatchesDisplay} ` +
-        `seg=${segmentIndex} len=${blockImages.length}/${sliceCount} ` +
+        `seg=${segmentIndex} len=${blockImages.length}/${sliceCount} z0=${range.z0} ` +
         `srcIdx first=${firstSrc} last=${lastSrc} order=${order} ` +
-        `extent=[${lo}..${hi}] (${lo < 0 ? 0 : hi - lo + 1} slices) ` +
+        `extent=[${dLo}..${dHi}] (${lo < 0 ? 0 : hi - lo + 1} slices) ` +
         `cheap=[${segmentExtents.get(segmentIndex)?.lo}..${segmentExtents.get(segmentIndex)?.hi}]` +
-        `${segmentExtents.get(segmentIndex)?.lo === lo && segmentExtents.get(segmentIndex)?.hi === hi ? '' : ' *** EXTENT MISMATCH ***'} ` +
+        `${segmentExtents.get(segmentIndex)?.lo === dLo && segmentExtents.get(segmentIndex)?.hi === dHi ? '' : ' *** EXTENT MISMATCH ***'} ` +
         `source=${blocksBySegment.has(segmentIndex) ? 'layer-or-split' : 'empty-fabricated'}`
       );
     }

--- a/Viewers/extensions/cornerstone/src/utils/buildOverlappingSegLayers.ts
+++ b/Viewers/extensions/cornerstone/src/utils/buildOverlappingSegLayers.ts
@@ -389,8 +389,12 @@ export async function buildOverlappingSegLayers({
     // to no block, so its mask renders cut off in z.
     // This fires for all three orderings — single+single, packed-then-single, single-then-packed —
     // because both the packed Pass A guard and the single-segment pre-pass now apply the same
-    // first-layer ownership rule. (It still cannot see voxels lost INSIDE the owning layer's
-    // z-range, which no extent comparison can; nothing in the assembly drops those.)
+    // first-layer ownership rule.
+    //
+    // LIMIT worth knowing: an extent comparison can only see loss that CHANGES the z-range. If a
+    // later layer's copy of the segment falls entirely INSIDE the owner's z-range, its voxels are
+    // dropped by the same ownership rule and this check stays silent. So a clean run means no
+    // segment lost slices at its ends -- not that no voxels were lost at all.
     const se = sourceExtents.get(segmentIndex);
     const be = segmentExtents.get(segmentIndex);
     if (se && be && be.lo >= 0 && (se.lo < be.lo || se.hi > be.hi)) {

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -471,11 +471,18 @@ const commandsModule = ({
           const sd = vm.getScalarData();
           for (let j = 0; j < sd.length; j++) if (sd[j] === p.segmentNumber) sd[j] = 0;
         }
+        // A deferred refine write that lands outside its block, or on an image no longer cached,
+        // used to be dropped by a bare `continue`. That is invisible on screen -- the MPR volume is
+        // written separately and immediately -- but the stack images are what DICOM-SEG export
+        // reads, so the refine silently fails to persist and the segment exports cut off at the
+        // block boundary. Count both and report, so the failure is attributable instead of mute.
+        let _skippedOutOfRange = 0;
+        let _skippedUncached = 0;
         for (let z = p.segZ0; z < p.segZ1; z++) {
           const arrIdx = z - p.z0;
-          if (arrIdx < 0 || arrIdx >= p.blockImageIds.length) continue;
+          if (arrIdx < 0 || arrIdx >= p.blockImageIds.length) { _skippedOutOfRange++; continue; }
           const vm = cache.getImage(p.blockImageIds[arrIdx])?.voxelManager as csTypes.IVoxelManager<number>;
-          if (!vm) continue;
+          if (!vm) { _skippedUncached++; continue; }
           const sd = vm.getScalarData();
           const cropSliceBase = (z - p.segZ0) * p.cropY * p.cropX;
           for (let cy = 0; cy < p.cropY; cy++) {
@@ -485,6 +492,16 @@ const commandsModule = ({
               if (p.cropBytes[srcRow + cx] === 1) sd[dstRow + cx] = p.segmentNumber;
             }
           }
+        }
+        if (_skippedOutOfRange || _skippedUncached) {
+          console.error(
+            `Segmentation write lost for segment ${p.segmentNumber}: ` +
+            `${_skippedOutOfRange} slice(s) fell outside its block ` +
+            `(write range [${p.segZ0}..${p.segZ1}), block z0=${p.z0} len=${p.blockImageIds.length}), ` +
+            `${_skippedUncached} slice(s) had no cached image. ` +
+            `Those pixels are in the rendered volume but NOT in the stack images, so they will be ` +
+            `missing from a DICOM-SEG export and the segment will appear cut off.`
+          );
         }
       }
       _pendingImageSync.delete(segId);

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -1717,6 +1717,10 @@ const commandsModule = ({
           let existingSegments: { [segmentIndex: string]: cstTypes.Segment } = {};
             
           let segImageIds = [];
+          // The existing representation's block list, so it can be handed back to
+          // postSegmentationProcessing rather than re-derived by length division. See the
+          // `_sam2Blocks` note at the call site.
+          let existingBlocks: LabelmapBlock[] = [];
 
           let existing = false;
           // Find existing segmentation with matching seriesInstanceUid
@@ -1739,6 +1743,10 @@ const commandsModule = ({
               // allImageIds preserves all blocks; imageIds is reverted to block1 by syncLegacyLabelmapData
               segImageIds = activeSegmentation.representationData.Labelmap.allImageIds
                 ?? activeSegmentation.representationData.Labelmap.imageIds;
+              existingBlocks = describeBlocks(
+                activeSegmentation.representationData.Labelmap,
+                imageIds.length
+              );
               existing = true;
             }
           }
@@ -1885,6 +1893,29 @@ const commandsModule = ({
             }
           };
 
+          // Hand the EXISTING block list back rather than letting buildMultiBlockLabelmapRepresentation
+          // re-derive it as `derivedImageIds.length / imageIds.length`. That division is only exact
+          // when every block spans the whole series. Blocks are z-cropped now (a reloaded SEG's
+          // 9022 slices become ~1504), so the division would cut the flat list into a couple of
+          // bogus full-length layers straddling segment boundaries, drop the real segmentIndex ->
+          // labelmapId mapping, and leave most segments unbound.
+          //
+          // This does NOT make sam2() sparse — its write loop still treats the flat list as one
+          // series, which is a separate pre-existing limitation. It only stops it from DESTROYING a
+          // block list that already exists.
+          //
+          // Guard: only pass blocks that flatten back to exactly the images being submitted. The
+          // two are the same array by construction (merged_derivedImages comes from segImageIds,
+          // and any `flipped` reverse is undone before this point), so a mismatch means something
+          // upstream reshaped the list — in which case fall back to today's length-division
+          // behaviour rather than register a representation whose blocks disagree with its images.
+          const _flatExisting = flattenBlocks(existingBlocks);
+          const _sam2Blocks =
+            _flatExisting.length === derivedImageIds.length &&
+            _flatExisting.every((id, i) => id === derivedImageIds[i])
+              ? existingBlocks
+              : undefined;
+
           // Post-segmentation processing: update representations, handle viewports, trigger events
           await postSegmentationProcessing({
             activeViewportId,
@@ -1899,6 +1930,7 @@ const commandsModule = ({
             activeSegmentation,
             currentImageIdIndex,
             z_range,
+            blocks: _sam2Blocks,
           });
           const end = Date.now();
           console.log(`Time taken: ${(end - start)/1000} Seconds`);

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -515,10 +515,6 @@ const commandsModule = ({
           );
         }
       }
-      console.log(
-        `[refine] materialized deferred writes for "${segId}" ` +
-        `(segments ${Array.from(bySegment.keys()).join(',')})`
-      );
       _pendingImageSync.delete(segId);
     }
   }
@@ -3651,22 +3647,6 @@ const commandsModule = ({
             shouldShrinkBlock(_prevBlock.imageIds.length, _aw1 - _aw0, BLOCK_SHRINK_FACTOR);
           const _reuseIdx = (_hasCropGeom && !toolboxState.getRefineNew() && _nMpr > 0 && _nStack === 0
             && _fitsBlock && !_blockOversized) ? _blockIdxForSeg : -1;
-
-          // TEMPORARY (diagnostic, strip before merge): which block this refine chose, and why.
-          // The [nninter-client] probes were stripped when the sparse-block work merged, leaving
-          // this decision unobservable -- and a refine that silently targets the wrong block, or is
-          // treated as a NEW segment because its index is not in the block list, looks identical
-          // from outside to a refine that did nothing.
-          console.log(
-            `[refine] seg=${segmentNumber} blockIdx=${_blockIdxForSeg} ` +
-            `prevBlock=${_prevBlock ? `${_prevBlock.imageIds.length}@${_prevBlock.z0}` : 'NONE'} ` +
-            `blocks=[${_prevBlocks.map(b => b.segmentIndex).join(',')}] ` +
-            `mask=[${_segZ0}..${_segZ1}) clamped=[${_bw0}..${_bw1}) snapped=[${_aw0}..${_aw1}) ` +
-            `hasCrop=${_hasCropGeom} refineNew=${toolboxState.getRefineNew()} ` +
-            `mpr=${_nMpr} stack=${_nStack} fits=${_fitsBlock} oversized=${_blockOversized} ` +
-            `=> reuse=${_reuseIdx}` +
-            `${_blockIdxForSeg < 0 ? '  *** SEGMENT HAS NO BLOCK -- WILL BE TREATED AS NEW ***' : ''}`
-          );
 
           // Working-order offset of the block being written.
           // INVARIANT: on the REUSE path this MUST equal _prevBlock.z0, because _clearIdxs, the

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -3637,6 +3637,22 @@ const commandsModule = ({
           const _reuseIdx = (_hasCropGeom && !toolboxState.getRefineNew() && _nMpr > 0 && _nStack === 0
             && _fitsBlock && !_blockOversized) ? _blockIdxForSeg : -1;
 
+          // TEMPORARY (diagnostic, strip before merge): which block this refine chose, and why.
+          // The [nninter-client] probes were stripped when the sparse-block work merged, leaving
+          // this decision unobservable -- and a refine that silently targets the wrong block, or is
+          // treated as a NEW segment because its index is not in the block list, looks identical
+          // from outside to a refine that did nothing.
+          console.log(
+            `[refine] seg=${segmentNumber} blockIdx=${_blockIdxForSeg} ` +
+            `prevBlock=${_prevBlock ? `${_prevBlock.imageIds.length}@${_prevBlock.z0}` : 'NONE'} ` +
+            `blocks=[${_prevBlocks.map(b => b.segmentIndex).join(',')}] ` +
+            `mask=[${_segZ0}..${_segZ1}) clamped=[${_bw0}..${_bw1}) snapped=[${_aw0}..${_aw1}) ` +
+            `hasCrop=${_hasCropGeom} refineNew=${toolboxState.getRefineNew()} ` +
+            `mpr=${_nMpr} stack=${_nStack} fits=${_fitsBlock} oversized=${_blockOversized} ` +
+            `=> reuse=${_reuseIdx}` +
+            `${_blockIdxForSeg < 0 ? '  *** SEGMENT HAS NO BLOCK -- WILL BE TREATED AS NEW ***' : ''}`
+          );
+
           // Working-order offset of the block being written.
           // INVARIANT: on the REUSE path this MUST equal _prevBlock.z0, because _clearIdxs, the
           // blockZ0 argument, the _pendingImageSync payload and the fallback write loop all index

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -459,6 +459,17 @@ const commandsModule = ({
   /** Apply (and clear) deferred image writes so the block's images match what MPR already shows. */
   function materializePendingImageSync(segmentationId?: string) {
     const keys = segmentationId ? [segmentationId] : Array.from(_pendingImageSync.keys());
+    // TEMPORARY (diagnostic, strip before merge): a deferred refine write is queued under the
+    // segmentationId that produced it and looked up by the id the caller passes. A mismatch finds
+    // nothing and returns in silence -- the refine stays only in the MPR volume, so it renders
+    // correctly and is then absent from any DICOM-SEG export, which reads the stack images.
+    if (segmentationId && !_pendingImageSync.get(segmentationId)?.size && _pendingImageSync.size) {
+      console.error(
+        `Deferred segmentation writes were NOT applied: asked for "${segmentationId}", but the ` +
+        `pending queue holds [${Array.from(_pendingImageSync.keys()).join(', ')}]. ` +
+        `Those refines exist in the rendered volume only and will be missing from an export.`
+      );
+    }
     for (const segId of keys) {
       const bySegment = _pendingImageSync.get(segId);
       if (!bySegment?.size) continue;
@@ -504,6 +515,10 @@ const commandsModule = ({
           );
         }
       }
+      console.log(
+        `[refine] materialized deferred writes for "${segId}" ` +
+        `(segments ${Array.from(bySegment.keys()).join(',')})`
+      );
       _pendingImageSync.delete(segId);
     }
   }

--- a/Viewers/extensions/default/src/utils/labelmapBlocks.ts
+++ b/Viewers/extensions/default/src/utils/labelmapBlocks.ts
@@ -259,3 +259,50 @@ export function appendBlock(blocks: LabelmapBlock[], block: LabelmapBlock): Labe
 export function withoutBlockAt(blocks: LabelmapBlock[], index: number): LabelmapBlock[] {
   return blocks.filter((_, i) => i !== index);
 }
+
+/**
+ * Where a SEG-reload segment's block should sit, given the segment's extent in DISPLAY space.
+ *
+ * The SEG producer builds blocks indexed by source-series position (display order) and never
+ * reverses. `LabelmapBlock.z0` is a WORKING offset — the cornerstone volume's z index — and those
+ * two spaces diverge exactly when cornerstone's sort is the reverse of display order. This function
+ * is the single place that reconciles them, so no caller has to reason about it.
+ *
+ * `lo`/`hi` are inclusive display indices, or `lo < 0` for a segment with no voxels at all (which
+ * still needs a small block, because block index must stay aligned with segment index).
+ *
+ * Returns a half-open DISPLAY slice range to take from the source, whether to reverse those slices,
+ * and the resulting WORKING offset.
+ */
+export function segmentBlockRange(
+  lo: number,
+  hi: number,
+  sourceCount: number,
+  sortedMatchesDisplay: boolean | null
+): { z0: number; sliceStart: number; sliceEnd: number; reverse: boolean } {
+  // Ordering unknown (metadata unavailable): fall back to today's behaviour — a full-length,
+  // unreversed block. Cropping without knowing the ordering could place the mask at the wrong depth.
+  if (sortedMatchesDisplay === null || sortedMatchesDisplay === undefined) {
+    return { z0: 0, sliceStart: 0, sliceEnd: sourceCount, reverse: false };
+  }
+
+  // An empty segment still needs a block so block index stays aligned with segment index, but it
+  // needs the smallest legal one rather than a full-series slab of zeros. On the measured data this
+  // single case is the dominant waste: four such blocks cost ~728MB on one 694-slice study.
+  const hasExtent = lo >= 0 && hi >= lo;
+  const [c0, c1] = hasExtent
+    ? clampRange(lo, hi + 1, sourceCount, MIN_BLOCK_SLICES)
+    : clampRange(0, MIN_BLOCK_SLICES, sourceCount, MIN_BLOCK_SLICES);
+
+  const [sliceStart, sliceEnd] = hasExtent
+    ? snapRangeToGrid(c0, c1, sourceCount, BLOCK_GRID_SLICES)
+    : [c0, c1];
+
+  // Display -> working. When the sorted volume order is the reverse of display order, the block's
+  // array index 0 must be the slice with the LOWEST volume z, which is the one at display index
+  // sliceEnd - 1. Hence reverse the taken slices, and mirror the offset.
+  const reverse = sortedMatchesDisplay === false;
+  const z0 = reverse ? sourceCount - sliceEnd : sliceStart;
+
+  return { z0, sliceStart, sliceEnd, reverse };
+}


### PR DESCRIPTION
A reloaded DICOM-SEG allocated one **full-series** labelmap block per segment, regardless of how few slices the segment actually touched. PR #83 made the nnInteractive path sparse; the SEG-reload producer was left out of scope, so reloading a saved SEG put memory straight back where it had been.

## Measured

Browser-verified across four studies. On a 13-segment SEG over a 694-slice series:

| | slices | memory |
|---|---|---|
| before | 13 × 694 = 9,022 | **~2.37 GB** |
| after | 1,504 (grid-snapped) | **~394 MB** |

**83% reduction.** Per-segment extents run 15–45% of the series, and one segment in that study has a **1-slice** extent — it now gets a 32-slice block instead of 694.

Declared-but-empty segments were the single largest waste: one study declares five segments and populates one, spending ~728 MB on four blocks of pure zeros. Those now get the minimum block size.

## Approach

The index math lives in `labelmapBlocks.ts` — pure, import-free, 52 unit tests — and the producer calls it. `segmentBlockRange` is the single place reconciling the two coordinate spaces:

- `display` — index into the source series
- `working` — index into a block's `imageIds` array, and the cornerstone volume's z index

They diverge exactly when cornerstone's sort runs opposite to display order, which **occurs in real data**. Extents come free from scans the producer already performs; ranges are grid-snapped so a reloaded segment later refined by nnInteractive fits its block instead of reallocating on the first click.

Ordering shipped **before** cropping, deliberately: both a wrong reversal and a wrong crop produce the same symptom — a mask at the wrong depth — so landing them together would have made any regression un-attributable.

## What the reviews caught

**A Critical of my own making.** `sortedMatchesDisplay` was computed with the wrong sign. `sortImageIdsAndGetSpacing` uses an *inverted* subtraction — `(reference − position) · axis` — and then sorts descending by it, which is **ascending in `position · axis`**. I read "sorts descending" and stopped there.

It survived four browser gates because `reverse` is invisible to rendering: MPR rebuilds by geometric sort regardless of array order, and the stack path keeps `imageIds[k]` ↔ `referencedImageIds[k]` paired either way. Its only consumer is `z0`, read by refine and undo.

There was a tell I misread: every study reported `sortedMatchesDisplay=false`. I treated that as a fact about the data rather than about an expression that returns a constant.

**`sam2()` was invalidated but never touched** — the same shape of defect a whole-branch review caught on the previous branch. It passed no `blocks`, so the builder fell back to `floor(derivedImageIds.length / N)`. Exact when blocks were full length (`9022/694 = 13`); with cropped blocks `1504/694 = 2`, rebuilding the representation as two bogus layers and dropping most segment bindings. Now threads the block list through, guarded so it falls back to today's behaviour if the lists disagree.

## Three `console.error` guards are intentional, not leftovers

Each reports **silent data loss** and is meant to stay:

- **`SEG reload: segment N …`** — voxels dropped on decode when a segment spans multiple layers and only the first layer's are kept
- **`Segmentation write lost …`** — deferred refine writes that never reach the stack images
- **`Deferred writes NOT applied …`** — a `segmentationId` mismatch when draining the write queue

They were added while chasing a bug during testing. Nothing else in the codebase can see these conditions — every other extent check measures the block that was built, so they all agree even when it is missing data.

## A pre-existing bug found during testing — NOT fixed here, NOT caused here

Refining a reloaded segment and exporting **discards the refinement entirely**. Verified on a throwaway branch containing main plus one probe:

| | export 1 | after reload, export 2 |
|---|---|---|
| untouched segments | — | identical |
| the refined segment | `slicesWithPixels=213` | **`79`** |

Both main and this branch converge on `79`, the original extent from the source file. Narrowed to dcmjs encoding: the refine is correct (the block updates), and the export *read* is correct (all images cached, all identity-mapped). The loss is between that read and the bytes on disk. Its own branch.

## Scope

Only the SEG-reload producer. SAM2 stays single-layer with no crop geometry from the server; the nnInteractive non-overlap branch is unreachable (`const overlap = true`); XY cropping needs an offset MPR volume and undersized stack images.

## Verification

52/52 unit tests on the pure module; `tsc` syntax gate clean on all four files; four browser sessions covering reload on both ordering cases, an empty-segment SEG, refine-after-reload, export, delete and reset.

`buildOverlappingSegLayers.ts` and `SegmentationService.ts` have no unit tests — their `@ohif/core` import chain does not resolve under jest — so careful reading plus those browser gates is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
