### PR TITLE
fix(sam2): refuse multi-block segmentations instead of corrupting them

### DIFF
--- a/Viewers/extensions/cornerstone-dicom-seg/src/commandsModule.ts
+++ b/Viewers/extensions/cornerstone-dicom-seg/src/commandsModule.ts
@@ -287,7 +287,6 @@ const commandsModule = ({
           const layerSegments = Array.from(
             new Set(layerLabelmaps2D.filter(Boolean).flatMap((l: any) => l.segmentsOnLabelmap))
           );
-
           if (layerSegments.length === 0) continue;
 
           const layerMetadata: any[] = [];

--- a/Viewers/extensions/cornerstone/src/utils/buildOverlappingSegLayers.ts
+++ b/Viewers/extensions/cornerstone/src/utils/buildOverlappingSegLayers.ts
@@ -400,9 +400,10 @@ export async function buildOverlappingSegLayers({
     if (se && be && be.lo >= 0 && (se.lo < be.lo || se.hi > be.hi)) {
       console.error(
         `SEG reload: segment ${segmentIndex} has voxels in source slices [${se.lo}..${se.hi}] ` +
-        `but the assembled block covers only [${be.lo}..${be.hi}] — slices outside that range ` +
-        `were dropped. Cause: segment appears in multiple layers; only the first layer's voxels ` +
-        `are kept.`
+        `but only [${be.lo}..${be.hi}] was kept — the z-extent of the layer that OWNS this ` +
+        `segment. Slices outside that range were dropped. Cause: segment appears in multiple ` +
+        `layers; only the first layer's voxels are kept. (The allocated block is the grid-snapped ` +
+        `form of the owning extent and so is usually wider; enlarging it would not recover them.)`
       );
     }
   }

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -459,15 +459,25 @@ const commandsModule = ({
   /** Apply (and clear) deferred image writes so the block's images match what MPR already shows. */
   function materializePendingImageSync(segmentationId?: string) {
     const keys = segmentationId ? [segmentationId] : Array.from(_pendingImageSync.keys());
-    // TEMPORARY (diagnostic, strip before merge): a deferred refine write is queued under the
-    // segmentationId that produced it and looked up by the id the caller passes. A mismatch finds
-    // nothing and returns in silence -- the refine stays only in the MPR volume, so it renders
-    // correctly and is then absent from any DICOM-SEG export, which reads the stack images.
+    // PERMANENT guard (one of the three data-loss reports that are deliberately kept -- do not
+    // strip it as leftover diagnostics). A deferred refine write is queued under the segmentationId
+    // that produced it and looked up by the id the caller passes. A mismatch finds nothing and
+    // returns in silence -- the refine stays only in the MPR volume, so it renders correctly and is
+    // then absent from any DICOM-SEG export, which reads the stack images. Nothing else in the
+    // system can observe that, which is why the report has to live here.
+    //
+    // The condition is deliberately loose -- "asked for X, and the queue is not empty" -- because
+    // the queue keys are the only evidence available at this point. It therefore also trips when a
+    // DIFFERENT segmentation legitimately has writes pending, which is not data loss. The MESSAGE
+    // is scoped accordingly: it states what is true (nothing queued for X, and these other ids are
+    // queued) and leaves the conclusion to whoever reads it, rather than asserting loss.
     if (segmentationId && !_pendingImageSync.get(segmentationId)?.size && _pendingImageSync.size) {
       console.error(
-        `Deferred segmentation writes were NOT applied: asked for "${segmentationId}", but the ` +
-        `pending queue holds [${Array.from(_pendingImageSync.keys()).join(', ')}]. ` +
-        `Those refines exist in the rendered volume only and will be missing from an export.`
+        `Deferred segmentation writes: nothing was queued for "${segmentationId}", so nothing was ` +
+        `applied for it. The pending queue holds [${Array.from(_pendingImageSync.keys()).join(', ')}]. ` +
+        `If one of those is the segmentation that was meant to be materialised, its refines exist ` +
+        `in the rendered volume only and will be missing from an export; if they are genuinely ` +
+        `other segmentations still awaiting their own drain, nothing is lost.`
       );
     }
     for (const segId of keys) {

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -1909,16 +1909,23 @@ const commandsModule = ({
             // `existingBlocks` is the describeBlocks result captured when the existing segmentation
             // was matched, reused here so the layout is read exactly once.
             const _srcLen = imageIds.length;
-            const _sparseExisting =
+            const _multiBlockExisting =
               _srcLen > 0 &&
-              (existingBlocks.some(b => b.imageIds.length !== _srcLen) ||
+              // MORE THAN ONE BLOCK is enough on its own. The flat write is only ever well-defined
+              // for a SINGLE full-series block: with two or more, indices past the first block run
+              // into the next segment's images, and the clear pass zeroes this segment's value
+              // across all of them first. Blocks can be full length even after the sparse rework --
+              // when the ordering is unknown, when the series is shorter than one grid cell, or
+              // when a segment genuinely spans everything -- so a length test alone misses this.
+              (existingBlocks.length > 1 ||
+                existingBlocks.some(b => b.imageIds.length !== _srcLen) ||
                 // No block list at all (a legacy representation describeBlocks could not divide):
-                // sparse iff the flat list is not a whole number of full-series layers.
-                (existingBlocks.length === 0 && segImageIds.length % _srcLen !== 0));
-            if (_sparseExisting) {
+                // unusable iff the flat list is not a single full-series layer.
+                (existingBlocks.length === 0 && segImageIds.length !== _srcLen));
+            if (_multiBlockExisting) {
               console.error(
-                `[sam2] refusing to write: segmentation "${segmentationId}" has per-segment ` +
-                `labelmap blocks (${existingBlocks.length} block(s), lengths ` +
+                `[sam2] refusing to write: segmentation "${segmentationId}" stores each segment in ` +
+                `its own labelmap block (${existingBlocks.length} block(s), lengths ` +
                 `[${existingBlocks.map(b => b.imageIds.length).join(', ')}] against a ` +
                 `${_srcLen}-slice series). This handler writes the flat image list using ` +
                 `full-series indices, which would offset the mask and overwrite other segments.`
@@ -1926,9 +1933,10 @@ const commandsModule = ({
               uiNotificationService.show({
                 title: 'SAM2',
                 message:
-                  'SAM2 cannot refine this segmentation: it was loaded from a DICOM-SEG and stores ' +
-                  'each segment in its own labelmap block. Use nnInteractive for this series, or ' +
-                  'start a new segmentation.',
+                  'SAM2 cannot edit this segmentation: it stores each segment in its own labelmap ' +
+                  'block, which SAM2 does not yet understand. Segmentations created by ' +
+                  'nnInteractive or loaded from a DICOM-SEG are stored this way. Start a new ' +
+                  'segmentation to use SAM2.',
                 type: 'error',
                 duration: 6000,
               });

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -1871,6 +1871,59 @@ const commandsModule = ({
             }
             merged_derivedImages = derivedImages_new
           } else {
+            // REFUSE TO WRITE INTO A SPARSE (multi-block, z-cropped) REPRESENTATION.
+            //
+            // The loop below is FLAT: it walks `segImageIds` — the concatenation of EVERY block —
+            // and indexes it with FULL-SERIES slice numbers, because the server's buffer holds one
+            // mask slice per series slice. That is only well defined while every block spans the
+            // whole series, which was true until blocks became z-cropped. It is no longer true for
+            // a reloaded DICOM-SEG, whose blocks cover only the slices their mask touches.
+            //
+            // With a z-cropped block the same loop silently corrupts three ways:
+            //   1. image k of a block starting at z0 is display slice z0 + k, so the mask lands at
+            //      the wrong depth;
+            //   2. once i runs past the first block's length it keeps going into the NEXT segments'
+            //      blocks and stamps `segmentNumber` into them;
+            //   3. the `!getRefineNew()` clear pass below zeroes `segmentNumber` across that same
+            //      flat list first, so the original is destroyed before the bad write.
+            // None of it is visible on screen: generateSegmentation scans raw pixelData for
+            // non-zero values and maps them by referencedImageId, so the strays reach the export.
+            //
+            // Making this handler block-aware is a separate piece of work (nnInteractive's path
+            // already is). Until then it declines rather than corrupts. Falling through to the
+            // fresh full-series allocation above is NOT an option: that path emits a single
+            // full-series block holding only this segment, and buildMultiBlockLabelmapRepresentation
+            // would then bind EVERY segment to it — dropping the other segments' blocks from the
+            // representation entirely. That trades one silent corruption for another.
+            //
+            // `existingBlocks` is the describeBlocks result captured when the existing segmentation
+            // was matched, reused here so the layout is read exactly once.
+            const _srcLen = imageIds.length;
+            const _sparseExisting =
+              _srcLen > 0 &&
+              (existingBlocks.some(b => b.imageIds.length !== _srcLen) ||
+                // No block list at all (a legacy representation describeBlocks could not divide):
+                // sparse iff the flat list is not a whole number of full-series layers.
+                (existingBlocks.length === 0 && segImageIds.length % _srcLen !== 0));
+            if (_sparseExisting) {
+              console.error(
+                `[sam2] refusing to write: segmentation "${segmentationId}" has per-segment ` +
+                `labelmap blocks (${existingBlocks.length} block(s), lengths ` +
+                `[${existingBlocks.map(b => b.imageIds.length).join(', ')}] against a ` +
+                `${_srcLen}-slice series). This handler writes the flat image list using ` +
+                `full-series indices, which would offset the mask and overwrite other segments.`
+              );
+              uiNotificationService.show({
+                title: 'SAM2',
+                message:
+                  'SAM2 cannot refine this segmentation: it was loaded from a DICOM-SEG and stores ' +
+                  'each segment in its own labelmap block. Use nnInteractive for this series, or ' +
+                  'start a new segmentation.',
+                type: 'error',
+                duration: 6000,
+              });
+              return;
+            }
             merged_derivedImages = segImageIds.map(imageId => cache.getImage(imageId));
             if(flipped){
               merged_derivedImages.reverse();


### PR DESCRIPTION
**Hotfix for a silent data-corruption regression currently on `main`.** Introduced by #85 and found by that PR's final whole-branch review, which completed after the merge.

## The bug

`sam2()` runs with `const overlap = false`, so for an existing segmentation the live path writes through a flat loop that indexes the **concatenation of all labelmap blocks** using **full-series** slice indices:

```js
merged_derivedImages = segImageIds.map(cache.getImage)   // = allImageIds, flat, ALL blocks
for (i = 0; i < merged_derivedImages.length; i++)
    sliceData = new_arrayBuffer.slice(i*len, (i+1)*len)  // server buffer is full-series
```

That is well-defined only for a **single full-series block**.

Before #85, a reloaded SEG's blocks were all full-series length, so segment 1's block *was* the first N entries and index `i` landed correctly — refining segment 1 on a non-flipped series worked. With z-cropped blocks, `i` runs off the end of block 1 into blocks 2, 3, 4…

Three consequences, all silent:

1. within block 1, image `k` is display slice `sliceStart + k` → the mask is written **offset**
2. beyond block 1's length, `segmentNumber` is written into **other segments' block images**
3. the preceding clear pass zeroes `segmentNumber` across the whole flat list first, **destroying the original** before the bad write

The stray values **are exported** — `generateSegmentation` scans raw pixel data for non-zero and maps by `referencedImageId` identity.

## The fix

`sam2()` **refuses** a multi-block representation rather than corrupting it. It is not made block-aware here — that is real work with its own regression surface, and this needs to land now.

Refusing was chosen over falling through to a fresh full-series allocation, because that fallthrough is **worse**: it yields `derivedImageIds.length === N`, making `blockCount` 1 and a single synthesised block, and `buildMultiBlockLabelmapRepresentation`'s single-layer case then binds *every* segment to it — dropping all other segments' blocks entirely.

The guard keys on **block count**, not block length:

```js
existingBlocks.length > 1 ||
  existingBlocks.some(b => b.imageIds.length !== _srcLen) ||
  (existingBlocks.length === 0 && segImageIds.length !== _srcLen)
```

A length test alone was insufficient — a representation can have several blocks that are each full-length, reachable when the slice ordering is unknown, when the series is shorter than one 32-slice grid cell, or when a segment spans everything. Review walked all six reachable shapes:

| shape | result |
|---|---|
| one full-series block | **pass** — the only safe case |
| several full-series blocks | refuse |
| any cropped block | refuse |
| legacy flat list, exactly one series | **pass** |
| legacy flat list, 2N | refuse — that is two blocks, and the flat write corrupts it |

**SAM2 still works on its own segmentations.** A SAM2-created representation has exactly one full-series block and passes.

## Also here

- **The notification named the wrong cause.** It blamed DICOM-SEG reload, but nnInteractive allocates per-segment blocks too — so a segment created moments earlier in the same session got an error telling the user to switch to the tool they had just used. Now names both producers and gives a remedy that is actually available.
- **Three comment corrections**, including a `TEMPORARY (strip before merge)` label left on a data-loss guard that is deliberately permanent. A future cleanup would have deleted it on that basis.

## Verification

- First commit is **53 insertions, 0 deletions** — no pre-existing line touched, so a single-full-series-block representation is bit-identical to before.
- The refusal returns *before* any mutation: before the image map, before the clear pass, and inside the existing `try` so the inference lock is still released.
- `tsc` syntax gate clean on all touched files; `TS2304` unchanged (2 pre-existing `cornerstoneTools`); jest `labelmapBlocks` 52/52.
- Two review passes on the fix, both clean; the second walked every representation shape and confirmed the safe case still reaches the write.

## Known and not addressed here

- **Refusal happens after the inference round trip**, not before the POST — costs a wasted GPU inference, not correctness. Moving it earlier is a clean follow-up.
- **A "Run Segmentation - Successful" toast** still appears just before the error toast. Cosmetic.
- **SAM2 is now blocked on any multi-block segmentation**, including for new segments. That path corrupts on `main` today, so refusing is strictly safer — but making `sam2()` block-aware is the real fix and deserves its own branch.
- Unrelated and pre-existing: #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
