### PR TITLE
fix(seg): stop losing slices when reloading an overlapping DICOM-SEG

### DIFF
--- a/Viewers/backup/esm/compactMergeSegData.js
+++ b/Viewers/backup/esm/compactMergeSegData.js
@@ -1,0 +1,75 @@
+const checkHasOverlapping = _ref => {
+  let largerArray = _ref.largerArray,
+    currentTestedArray = _ref.currentTestedArray,
+    newArray = _ref.newArray;
+  return largerArray.some((_, currentImageIndex) => {
+    const originalImagePixelData = currentTestedArray[currentImageIndex];
+    const newImagePixelData = newArray[currentImageIndex];
+    if (!originalImagePixelData || !newImagePixelData) {
+      return false;
+    }
+    return originalImagePixelData.some((originalPixel, currentPixelIndex) => {
+      const newPixel = newImagePixelData[currentPixelIndex];
+      return originalPixel && newPixel;
+    });
+  });
+};
+const compactMergeSegmentDataWithoutInformationLoss = _ref2 => {
+  let arrayOfSegmentData = _ref2.arrayOfSegmentData,
+    newSegmentData = _ref2.newSegmentData;
+  if (arrayOfSegmentData.length === 0) {
+    arrayOfSegmentData.push(newSegmentData);
+    return;
+  }
+  for (let currentTestedIndex = 0; currentTestedIndex < arrayOfSegmentData.length; currentTestedIndex++) {
+    const currentTestedArray = arrayOfSegmentData[currentTestedIndex];
+    const originalArrayIsLarger = currentTestedArray.length > newSegmentData.length;
+    const largerArray = originalArrayIsLarger ? currentTestedArray : newSegmentData;
+    const hasOverlapping = checkHasOverlapping({
+      currentTestedArray,
+      largerArray,
+      newArray: newSegmentData
+    });
+    if (hasOverlapping) {
+      continue;
+    }
+    // OHIF-AI: iterate the index RANGE, not `largerArray`'s populated entries.
+    //
+    // getSegmentData() returns a SPARSE array — segmentData[i] is assigned only for images
+    // that actually hold voxels — and Array.prototype.forEach SKIPS HOLES. So the original
+    // `largerArray.forEach(...)` visited only the indices where largerArray had data. When the
+    // EXISTING layer is the longer one, that is the existing layer's index set, and every
+    // slice where only the NEW segment has data was never visited, and was silently dropped.
+    //
+    // Real case: reloading a DICOM-SEG whose segment 3 spans images [375..525] (length 526)
+    // and segment 4 spans [241..453] (length 454). Segment 4 does not collide in-plane with
+    // segment 3, so it merges into segment 3's layer; largerArray became segment 3, and
+    // segment 4 came back as only [375..453] — 213 slices cut to 79. The survivor was always
+    // seg3.start..seg4.end no matter how far segment 4 extended below it, which is why masks
+    // of different sizes all collapsed to the same 79.
+    //
+    // `checkHasOverlapping` above iterates the same way but is CORRECT: an overlap needs both
+    // arrays populated at the same index, so a hole in either can never be an overlap.
+    const mergeLength = Math.max(currentTestedArray.length, newSegmentData.length);
+    for (let currentImageIndex = 0; currentImageIndex < mergeLength; currentImageIndex++) {
+      const originalImagePixelData = currentTestedArray[currentImageIndex];
+      const newImagePixelData = newSegmentData[currentImageIndex];
+      if (!newImagePixelData) {
+        continue;
+      }
+      if (!originalImagePixelData) {
+        currentTestedArray[currentImageIndex] = newImagePixelData;
+        continue;
+      }
+      const mergedPixelData = originalImagePixelData.map((originalPixel, currentPixelIndex) => {
+        const newPixel = newImagePixelData[currentPixelIndex];
+        return originalPixel || newPixel;
+      });
+      currentTestedArray[currentImageIndex] = mergedPixelData;
+    }
+    return;
+  }
+  arrayOfSegmentData.push(newSegmentData);
+};
+
+export { compactMergeSegmentDataWithoutInformationLoss };

--- a/Viewers/platform/app/.recipes/Nginx-Orthanc/dockerfile
+++ b/Viewers/platform/app/.recipes/Nginx-Orthanc/dockerfile
@@ -56,6 +56,9 @@ RUN rm -rf /usr/src/app/node_modules/@cornerstonejs/tools/dist/esm/utilities/seg
 
 RUN rm -rf /usr/src/app/node_modules/@cornerstonejs/core/dist/esm/utilities/VoxelManager.js
 
+# Sparse-array merge dropped slices when reloading an overlapping DICOM-SEG (see the file's comment)
+RUN rm -rf /usr/src/app/node_modules/@cornerstonejs/adapters/dist/esm/adapters/Cornerstone3D/Segmentation/compactMergeSegData.js
+
 RUN rm -rf /usr/src/app/node_modules/dcmjs/build/dcmjs.es.js
 
 RUN rm -rf /usr/src/app/node_modules/@kitware/vtk.js/Filters/General/ImageMarchingSquares.js
@@ -91,6 +94,7 @@ COPY ./backup/esm/getOrCreateImageVolume.js /usr/src/app/node_modules/@cornersto
 COPY ./backup/esm/utilsForWorker.js /usr/src/app/node_modules/@cornerstonejs/tools/dist/esm/utilities/segmentation/utilsForWorker.js
 COPY ./backup/esm/getStatistics.js /usr/src/app/node_modules/@cornerstonejs/tools/dist/esm/utilities/segmentation/getStatistics.js
 COPY ./backup/esm/VoxelManager.js /usr/src/app/node_modules/@cornerstonejs/core/dist/esm/utilities/VoxelManager.js
+COPY ./backup/esm/compactMergeSegData.js /usr/src/app/node_modules/@cornerstonejs/adapters/dist/esm/adapters/Cornerstone3D/Segmentation/compactMergeSegData.js
 COPY ./backup/dcmjs/dcmjs.es.js /usr/src/app/node_modules/dcmjs/build/dcmjs.es.js
 
 COPY ./backup/vtkjs/ImageMarchingSquares.js /usr/src/app/node_modules/@kitware/vtk.js/Filters/General/ImageMarchingSquares.js


### PR DESCRIPTION
Fixes #86.

## The bug

Reloading a saved DICOM-SEG silently truncated a segment. Re-exporting then wrote the truncated mask back, so the loss compounded on every save/reload cycle. Nothing logged an error.

Measured on real stored files, two independent reproductions. Identical segment labels before/after prove it is the same segment reloaded, not a different SEG series:

| time | series | seg-4 frames | seg-4 extent | seg-4 label |
|---|---|---|---|---|
| 20:33 | `exportfixed5` | **134** | 240..373 | `nninter_pred_20260804203242` |
| 20:57 | `justreex` | **79** | 240..318 | `nninter_pred_20260804203242` (same) |
| 21:31 | `shouldfixed6` | **213** | 240..452 | `nninter_pred_20260804212937` |
| 21:33 | `reexportofshouldfixed6` | **79** | 240..318 | `nninter_pred_20260804212937` (same) |

All 12 other segments were byte-identical across both pairs.

## Root cause — upstream, in `@cornerstonejs/adapters`

`compactMergeSegData.js:36`

```js
largerArray.forEach((_, currentImageIndex) => { ...merge... });
```

`getSegmentData()` returns a **sparse** array — `segmentData[i]` is assigned only for images that hold voxels — and `Array.prototype.forEach` **skips holes**. So the merge visited only the indices where `largerArray` had data. When the *existing layer* is the longer one, `largerArray` **is** that layer, and every slice where only the *incoming* segment had data was never visited, and was dropped.

Concretely: segment 3 spans images `[375..525]` (length 526), segment 4 spans `[241..453]` (length 454). They do not collide in-plane, so segment 4 merges into segment 3's layer; `largerArray` became segment 3, and segment 4 survived only as `[375..453]`.

This is why **79 was a fixed point**: the survivor is always `seg3.start..seg4.end`, regardless of how far segment 4 extends below it — so masks of 134 and 213 slices both collapsed to exactly 79. That constant was the thing that made the bug look bizarre from the outside.

## The fix

Iterate the index **range** instead of one array's populated entries. Applied with the repo's standard vendored-file override pair (`rm` + `COPY` in the dockerfile), matching the ~20 other `@cornerstonejs` overrides.

`checkHasOverlapping` iterates the same way but is **correct** and is deliberately left alone: an overlap needs both arrays populated at the same index, so a hole can never be one.

## Verification

Reload of the affected SEG then re-export is now **byte-identical** to the original:

```
A frames=1428  B frames=1428
frames only in A: 0
frames only in B: 0
frames present in both but with DIFFERENT pixels: 0
=> BYTE-IDENTICAL round trip (per segment label + source instance)
```

13/13 segments, 1428/1428 frames, zero differing pixels. Segment 4: 213 → 213. Confirmed in-browser too, via temporary probes (since removed): `[segreload] seg=4 src=[241..453] kept=[241..453] written=213` and `[export] segs=[4] slices=213 perSeg={"4":213}`, with matching image ids at both points.

## ⚠️ Known open issue — not fixed by this PR

On **one** run with this fix in place, the export reported segment 4's layer as empty:

```
[export] segs=[] imageIds=256 cached=256 unmapped=0 slices=0  *** LAYER CONTRIBUTES NOTHING ***
```

while `[segreload]` in the same session reported `written=213` and the mask rendered correctly. Same layer shape — 256 imageIds, all cached, none unmapped — only the pixel content was empty. The very next run of the same build exported 213 correctly.

So it is timing- or interaction-dependent, not deterministic, and **it is not explained**. It is unrelated to the sparse-merge bug fixed here (that one was perfectly deterministic), but it can also silently drop a whole segment, so it should not be forgotten.

Candidates, none verified:
- cornerstone image-cache **eviction**, with `cache.getImage` returning a re-created zeroed derived image — would explain `cached=256` alongside empty pixels, and would be sensitive to how much else had been loaded in the session;
- the two probe blocks coming from two **different hydrations** (several SEGs had been loaded that session).

If it recurs: capture `[segreload]` and `[export]` from a single uninterrupted load → export and compare the `ids=` fields. Matching ids with empty pixels ⇒ eviction/zeroing. Differing ids ⇒ re-hydration. That splits it in one run.

## Upstream

Reported as cornerstonejs/cornerstone3D#2846, with a dependency-free reproduction and a source-level patch. The bug is present verbatim in upstream `main` @ `28a786f`. This override can be dropped once a fixed `@cornerstonejs/adapters` is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
