### PR TITLE
fix(seg): ghost segment copy and 40MB-per-refine labelmap volume leak

### DIFF
--- a/Viewers/backup/esm/getOrCreateSegmentationVolume.js
+++ b/Viewers/backup/esm/getOrCreateSegmentationVolume.js
@@ -1,0 +1,71 @@
+import { cache, volumeLoader, utilities, ImageVolume, } from '@cornerstonejs/core';
+import { getSegmentation } from '../../stateManagement/segmentation/getSegmentation';
+// PROJECT OVERRIDE. Upstream keys this volume by a CONTENT HASH of the labelmap imageIds
+// (cache.generateVolumeId) and never evicts the volume it supersedes.
+//
+// That is harmless when a segmentation's labelmap images are stable. In this project every
+// nnInteractive/SAM2 refine allocates NEW derived labelmap images for the block, so the hash
+// changes on each refine, a fresh volume is cached under the new key, and the previous one is
+// orphaned in the cache forever. Measured: one 160-slice block leaked 40MB per refine
+// (1 volume/40MB -> 4 volumes/160MB after a handful of refines), unbounded.
+//
+// It is not enough to rely on representationData.Labelmap.volumeId as upstream's fast path:
+// remountSegmentationRepresentations deliberately deletes that key when purging stale MPR
+// volumes, so this function takes the hash path essentially every time.
+//
+// Fix: remember the hash-keyed volume last created for each segmentation and evict it when a
+// new key supersedes it. The eviction is guarded — the old volume is dropped only when NONE of
+// its images are still referenced by the segmentation's current labelmap, so a volume that is
+// still live is never pulled out from under a consumer.
+const lastHashKeyedVolumeIdBySegmentationId = new Map();
+function evictSupersededHashKeyedVolume(segmentationId, nextVolumeId, currentLabelmapImageIds) {
+    const previousVolumeId = lastHashKeyedVolumeIdBySegmentationId.get(segmentationId);
+    lastHashKeyedVolumeIdBySegmentationId.set(segmentationId, nextVolumeId);
+    if (!previousVolumeId || previousVolumeId === nextVolumeId) {
+        return;
+    }
+    const previousVolume = cache.getVolume(previousVolumeId);
+    if (!previousVolume) {
+        return;
+    }
+    const currentImageIdSet = new Set(currentLabelmapImageIds ?? []);
+    const stillReferenced = (previousVolume.imageIds ?? []).some((imageId) => currentImageIdSet.has(imageId));
+    if (stillReferenced) {
+        return;
+    }
+    cache.removeVolumeLoadObject(previousVolumeId);
+}
+function getOrCreateSegmentationVolume(segmentationId) {
+    const { representationData } = getSegmentation(segmentationId);
+    if (!representationData.Labelmap) {
+        return;
+    }
+    let { volumeId } = representationData.Labelmap;
+    let segVolume;
+    if (volumeId) {
+        segVolume = cache.getVolume(volumeId);
+        if (segVolume) {
+            return segVolume;
+        }
+    }
+    const { imageIds: labelmapImageIds } = representationData.Labelmap;
+    volumeId = cache.generateVolumeId(labelmapImageIds);
+    if (!labelmapImageIds || labelmapImageIds.length === 0) {
+        return;
+    }
+    const isValidVolume = utilities.isValidVolume(labelmapImageIds);
+    if (!isValidVolume) {
+        return;
+    }
+    // Reuse before allocating: an unchanged block hashes to the same key, and re-creating the
+    // volume would discard a valid 40MB allocation for an identical one.
+    segVolume = cache.getVolume(volumeId);
+    if (segVolume) {
+        lastHashKeyedVolumeIdBySegmentationId.set(segmentationId, volumeId);
+        return segVolume;
+    }
+    evictSupersededHashKeyedVolume(segmentationId, volumeId, labelmapImageIds);
+    segVolume = volumeLoader.createAndCacheVolumeFromImagesSync(volumeId, labelmapImageIds);
+    return segVolume;
+}
+export default getOrCreateSegmentationVolume;

--- a/Viewers/backup/esm/labelmapImageReferenceResolver.js
+++ b/Viewers/backup/esm/labelmapImageReferenceResolver.js
@@ -1,0 +1,293 @@
+import { cache, getEnabledElementByViewportId, } from '@cornerstonejs/core';
+import getViewportLabelmapRenderMode from '../helpers/getViewportLabelmapRenderMode';
+import { ensureLabelmapState } from './normalizeLabelmapSegmentationData';
+import { getLabelmaps } from './labelmapLayerStore';
+import { getLabelmapForSegment } from './labelmapSegmentBindings';
+import { getReferencedImageIdToCurrentImageIdMap } from './labelmapLegacyAdapter';
+import { getLabelmapImageIdsForReferencedImageId } from './labelmapImageIdMapping';
+// PROJECT OVERRIDE. Upstream resolves a layer's labelmap image for the displayed slice by
+// matching referencedImageId, then falls back to indexing the layer POSITIONALLY with the
+// viewport's slice index. That fallback is only meaningful when the layer covers the series
+// 1:1 -- an assumption that held while labelmaps always spanned the whole stack.
+//
+// This project z-crops labelmap blocks (sparse blocks), so a layer usually holds far fewer
+// images than the viewport has slices (e.g. a 160-slice block over a 694-slice series). The
+// positional fallback then resolves viewport slices 0..159 to unrelated block images, and
+// syncStackLabelmapActors draws them at the CURRENT slice's origin -- rendering a second,
+// ghost copy of the segment at the wrong depth. Observed as one segment appearing both at
+// its true location (source slices 333-453) and at block-local ones (viewport 13-133).
+//
+// Every positional index below is guarded with this helper, so the fallback applies only to
+// full-stack layers. For a cropped layer, resolution relies solely on the referencedImageId
+// match -- correct by construction -- and slices outside the block carry no labelmap.
+function layerSpansViewportStack(layer, viewportImageIdCount) {
+    return (viewportImageIdCount > 0 &&
+        layer?.imageIds?.length === viewportImageIdCount);
+}
+class LabelmapImageReferenceResolver {
+    constructor(getSegmentation) {
+        this.stackLabelmapImageIdReferenceMap = new Map();
+        this.labelmapImageIdReferenceMap = new Map();
+        this.keysBySegmentationId = new Map();
+        this.getSegmentation = getSegmentation;
+    }
+    reset() {
+        this.stackLabelmapImageIdReferenceMap.clear();
+        this.labelmapImageIdReferenceMap.clear();
+        this.keysBySegmentationId.clear();
+    }
+    removeSegmentation(segmentationId) {
+        this.stackLabelmapImageIdReferenceMap.delete(segmentationId);
+        const keys = this.keysBySegmentationId.get(segmentationId);
+        if (keys) {
+            for (const key of keys) {
+                this.labelmapImageIdReferenceMap.delete(key);
+            }
+            this.keysBySegmentationId.delete(segmentationId);
+        }
+    }
+    setLabelmapImageIds(segmentationId, key, labelmapImageIds) {
+        this.labelmapImageIdReferenceMap.set(key, labelmapImageIds);
+        let keys = this.keysBySegmentationId.get(segmentationId);
+        if (!keys) {
+            keys = new Set();
+            this.keysBySegmentationId.set(segmentationId, keys);
+        }
+        keys.add(key);
+    }
+    getLabelmapImageIds(representationData) {
+        const labelmapData = representationData.Labelmap;
+        let labelmapImageIds;
+        if (!labelmapData) {
+            return;
+        }
+        if (labelmapData?.labelmaps) {
+            const imageIds = Object.values(labelmapData.labelmaps).flatMap((layer) => {
+                if (layer.imageIds?.length) {
+                    return layer.imageIds;
+                }
+                if (layer.volumeId) {
+                    return cache.getVolume(layer.volumeId)
+                        ?.imageIds;
+                }
+                return [];
+            });
+            return Array.from(new Set(imageIds.filter(Boolean)));
+        }
+        if (labelmapData.imageIds) {
+            labelmapImageIds = labelmapData
+                .imageIds;
+        }
+        else if (labelmapData.volumeId) {
+            const volumeId = labelmapData
+                .volumeId;
+            const volume = cache.getVolume(volumeId);
+            labelmapImageIds = volume.imageIds;
+        }
+        return labelmapImageIds;
+    }
+    getLabelmapImageIdsForImageId(imageId, segmentationId) {
+        const segmentation = this.getSegmentation(segmentationId);
+        if (!segmentation?.representationData?.Labelmap) {
+            return;
+        }
+        ensureLabelmapState(segmentation);
+        return getReferencedImageIdToCurrentImageIdMap(segmentation).get(imageId);
+    }
+    updateLabelmapSegmentationImageReferences(viewportId, segmentationId) {
+        const segmentation = this.getSegmentation(segmentationId);
+        if (!segmentation) {
+            return;
+        }
+        if (!this.stackLabelmapImageIdReferenceMap.has(segmentationId)) {
+            this.stackLabelmapImageIdReferenceMap.set(segmentationId, new Map());
+        }
+        const { representationData } = segmentation;
+        if (!representationData.Labelmap) {
+            return;
+        }
+        const labelmapImageIds = this.getLabelmapImageIds(representationData);
+        const enabledElement = getEnabledElementByViewportId(viewportId);
+        if (!enabledElement || !labelmapImageIds?.length) {
+            return;
+        }
+        return this.updateLabelmapSegmentationReferences(segmentationId, enabledElement.viewport, labelmapImageIds);
+    }
+    getCurrentLabelmapImageIdsForViewport(viewportId, segmentationId) {
+        const enabledElement = getEnabledElementByViewportId(viewportId);
+        if (!enabledElement) {
+            return;
+        }
+        const { viewport } = enabledElement;
+        const viewportRenderMode = getViewportLabelmapRenderMode(viewport);
+        if (viewportRenderMode !== 'image' ||
+            typeof viewport.getCurrentImageId !== 'function') {
+            return;
+        }
+        const referenceImageId = viewport.getCurrentImageId();
+        const segmentation = this.getSegmentation(segmentationId);
+        if (!segmentation) {
+            return;
+        }
+        ensureLabelmapState(segmentation);
+        const viewportImageIds = viewport.getImageIds();
+        const currentIndex = viewportImageIds.indexOf(referenceImageId);
+        const labelmapImageIds = [];
+        getLabelmaps(segmentation).forEach((layer) => {
+            const referencedLabelmapImageIds = getLabelmapImageIdsForReferencedImageId(layer, referenceImageId);
+            if (referencedLabelmapImageIds.length) {
+                labelmapImageIds.push(...referencedLabelmapImageIds);
+                return;
+            }
+            if (currentIndex !== -1 &&
+                layerSpansViewportStack(layer, viewportImageIds.length) &&
+                layer.imageIds[currentIndex]) {
+                labelmapImageIds.push(layer.imageIds[currentIndex]);
+                return;
+            }
+            layer.imageIds?.some((candidateImageId) => {
+                const viewableImageId = viewport.isReferenceViewable({ referencedImageId: candidateImageId }, { asOverlay: true });
+                if (viewableImageId) {
+                    labelmapImageIds.push(candidateImageId);
+                }
+                return !!viewableImageId;
+            });
+        });
+        const resolvedImageIds = Array.from(new Set(labelmapImageIds));
+        const key = this.generateMapKey({
+            segmentationId,
+            referenceImageId,
+        });
+        this.setLabelmapImageIds(segmentationId, key, resolvedImageIds);
+        if (!this.stackLabelmapImageIdReferenceMap.has(segmentationId)) {
+            this.stackLabelmapImageIdReferenceMap.set(segmentationId, new Map());
+        }
+        const activeSegmentIndex = Object.keys(segmentation.segments).find((segmentIndex) => segmentation.segments[segmentIndex].active);
+        const activeLayer = activeSegmentIndex
+            ? getLabelmapForSegment(segmentation, Number(activeSegmentIndex))
+            : undefined;
+        const activeImageId = layerSpansViewportStack(activeLayer, viewportImageIds.length)
+            ? activeLayer.imageIds[currentIndex]
+            : undefined;
+        this.stackLabelmapImageIdReferenceMap
+            .get(segmentationId)
+            .set(referenceImageId, activeImageId ?? resolvedImageIds[0]);
+        return resolvedImageIds;
+    }
+    getCurrentLabelmapImageIdForViewport(viewportId, segmentationId) {
+        const enabledElement = getEnabledElementByViewportId(viewportId);
+        if (!enabledElement) {
+            return;
+        }
+        const { viewport } = enabledElement;
+        const viewportRenderMode = getViewportLabelmapRenderMode(viewport);
+        if (viewportRenderMode !== 'image' ||
+            typeof viewport.getCurrentImageId !== 'function') {
+            return;
+        }
+        const currentImageId = viewport.getCurrentImageId();
+        const currentImageIds = this.getCurrentLabelmapImageIdsForViewport(viewportId, segmentationId);
+        if (!currentImageIds?.length) {
+            return;
+        }
+        const segmentation = this.getSegmentation(segmentationId);
+        const viewportImageIds = viewport.getImageIds();
+        const currentIndex = viewportImageIds.indexOf(currentImageId);
+        const activeSegmentIndex = segmentation
+            ? Object.keys(segmentation.segments).find((segmentIndex) => segmentation.segments[segmentIndex].active)
+            : undefined;
+        const activeLayer = segmentation && activeSegmentIndex
+            ? getLabelmapForSegment(segmentation, Number(activeSegmentIndex))
+            : undefined;
+        const activeImageId = layerSpansViewportStack(activeLayer, viewportImageIds.length)
+            ? activeLayer.imageIds[currentIndex]
+            : undefined;
+        return activeImageId ?? currentImageIds[0];
+    }
+    getStackSegmentationImageIdsForViewport(viewportId, segmentationId) {
+        const segmentation = this.getSegmentation(segmentationId);
+        if (!segmentation) {
+            return [];
+        }
+        this.updateAllLabelmapSegmentationImageReferences(viewportId, segmentationId);
+        const enabledElement = getEnabledElementByViewportId(viewportId);
+        const imageIds = enabledElement?.viewport.getImageIds?.() ?? [];
+        const imageIdMap = getReferencedImageIdToCurrentImageIdMap(segmentation);
+        return imageIds.flatMap((imageId) => imageIdMap.get(imageId) ?? []);
+    }
+    updateLabelmapSegmentationReferences(segmentationId, viewport, labelmapImageIds, updateCallback) {
+        const referenceImageId = viewport.getCurrentImageId();
+        let viewableLabelmapImageIdFound = false;
+        for (const labelmapImageId of labelmapImageIds) {
+            const viewableImageId = viewport.isReferenceViewable({ referencedImageId: labelmapImageId }, { asOverlay: true });
+            if (viewableImageId) {
+                viewableLabelmapImageIdFound = true;
+                this.stackLabelmapImageIdReferenceMap
+                    .get(segmentationId)
+                    .set(referenceImageId, labelmapImageId);
+                this.updateLabelmapImageIdReferenceMap({
+                    segmentationId,
+                    referenceImageId,
+                    labelmapImageId,
+                });
+            }
+        }
+        updateCallback?.(viewport, segmentationId, labelmapImageIds);
+        return viewableLabelmapImageIdFound
+            ? this.stackLabelmapImageIdReferenceMap
+                .get(segmentationId)
+                .get(referenceImageId)
+            : undefined;
+    }
+    updateAllLabelmapSegmentationImageReferences(viewportId, segmentationId) {
+        const segmentation = this.getSegmentation(segmentationId);
+        if (!segmentation) {
+            return;
+        }
+        if (!this.stackLabelmapImageIdReferenceMap.has(segmentationId)) {
+            this.stackLabelmapImageIdReferenceMap.set(segmentationId, new Map());
+        }
+        const { representationData } = segmentation;
+        if (!representationData.Labelmap) {
+            return;
+        }
+        const labelmapImageIds = this.getLabelmapImageIds(representationData);
+        const enabledElement = getEnabledElementByViewportId(viewportId);
+        if (!enabledElement || !labelmapImageIds?.length) {
+            return;
+        }
+        const stackViewport = enabledElement.viewport;
+        this.updateLabelmapSegmentationReferences(segmentationId, stackViewport, labelmapImageIds, (stackViewport, segmentationId, labelmapImageIds) => {
+            const imageIds = stackViewport.getImageIds();
+            imageIds.forEach((referenceImageId, index) => {
+                for (const labelmapImageId of labelmapImageIds) {
+                    const viewableImageId = stackViewport.isReferenceViewable({ referencedImageId: labelmapImageId, sliceIndex: index }, { asOverlay: true, withNavigation: true });
+                    if (viewableImageId) {
+                        this.stackLabelmapImageIdReferenceMap
+                            .get(segmentationId)
+                            .set(referenceImageId, labelmapImageId);
+                        this.updateLabelmapImageIdReferenceMap({
+                            segmentationId,
+                            referenceImageId,
+                            labelmapImageId,
+                        });
+                    }
+                }
+            });
+        });
+    }
+    updateLabelmapImageIdReferenceMap({ segmentationId, referenceImageId, labelmapImageId, }) {
+        const key = this.generateMapKey({ segmentationId, referenceImageId });
+        if (!this.labelmapImageIdReferenceMap.has(key)) {
+            this.setLabelmapImageIds(segmentationId, key, [labelmapImageId]);
+            return;
+        }
+        const currentValues = this.labelmapImageIdReferenceMap.get(key) ?? [];
+        const newValues = Array.from(new Set([...currentValues, labelmapImageId]));
+        this.setLabelmapImageIds(segmentationId, key, newValues);
+    }
+    generateMapKey({ segmentationId, referenceImageId }) {
+        return `${segmentationId}-${referenceImageId}`;
+    }
+}
+export default LabelmapImageReferenceResolver;

--- a/Viewers/platform/app/.recipes/Nginx-Orthanc/dockerfile
+++ b/Viewers/platform/app/.recipes/Nginx-Orthanc/dockerfile
@@ -95,6 +95,11 @@ COPY ./backup/esm/utilsForWorker.js /usr/src/app/node_modules/@cornerstonejs/too
 COPY ./backup/esm/getStatistics.js /usr/src/app/node_modules/@cornerstonejs/tools/dist/esm/utilities/segmentation/getStatistics.js
 COPY ./backup/esm/VoxelManager.js /usr/src/app/node_modules/@cornerstonejs/core/dist/esm/utilities/VoxelManager.js
 COPY ./backup/esm/compactMergeSegData.js /usr/src/app/node_modules/@cornerstonejs/adapters/dist/esm/adapters/Cornerstone3D/Segmentation/compactMergeSegData.js
+
+# Guard cornerstone's POSITIONAL labelmap fallback: it indexes a layer by the viewport's slice
+# index, which is only valid when the layer spans the series 1:1. Sparse (z-cropped) blocks are
+# shorter than the stack, so it rendered a second, misplaced copy of a segment.
+COPY ./backup/esm/labelmapImageReferenceResolver.js /usr/src/app/node_modules/@cornerstonejs/tools/dist/esm/stateManagement/segmentation/labelmapModel/labelmapImageReferenceResolver.js
 COPY ./backup/dcmjs/dcmjs.es.js /usr/src/app/node_modules/dcmjs/build/dcmjs.es.js
 
 COPY ./backup/vtkjs/ImageMarchingSquares.js /usr/src/app/node_modules/@kitware/vtk.js/Filters/General/ImageMarchingSquares.js

--- a/Viewers/platform/app/.recipes/Nginx-Orthanc/dockerfile
+++ b/Viewers/platform/app/.recipes/Nginx-Orthanc/dockerfile
@@ -100,6 +100,10 @@ COPY ./backup/esm/compactMergeSegData.js /usr/src/app/node_modules/@cornerstonej
 # index, which is only valid when the layer spans the series 1:1. Sparse (z-cropped) blocks are
 # shorter than the stack, so it rendered a second, misplaced copy of a segment.
 COPY ./backup/esm/labelmapImageReferenceResolver.js /usr/src/app/node_modules/@cornerstonejs/tools/dist/esm/stateManagement/segmentation/labelmapModel/labelmapImageReferenceResolver.js
+
+# Evict the superseded hash-keyed labelmap volume. Upstream keys it by a content hash of the
+# labelmap imageIds and never drops the old one, leaking ~40MB per refine.
+COPY ./backup/esm/getOrCreateSegmentationVolume.js /usr/src/app/node_modules/@cornerstonejs/tools/dist/esm/utilities/segmentation/getOrCreateSegmentationVolume.js
 COPY ./backup/dcmjs/dcmjs.es.js /usr/src/app/node_modules/dcmjs/build/dcmjs.es.js
 
 COPY ./backup/vtkjs/ImageMarchingSquares.js /usr/src/app/node_modules/@kitware/vtk.js/Filters/General/ImageMarchingSquares.js


### PR DESCRIPTION
Two independent bugs in stock cornerstone code, both **already present on `main`** and both exposed by the sparse (z-cropped) labelmap blocks from #83. Neither is a regression from any in-flight branch.

Each is one guarded override plus its `COPY` line. Each commit is self-contained and builds on its own.

## 1. A segment rendered twice, the second copy at the wrong depth (`b96b879`)

A single segment appeared both at its true location (source slices 333-453 of a 694-slice series) and as a ghost at viewport slices 13-133. It survived MPR round-trips and viewport reloads.

The labelmap data was innocent throughout: one block, one layer, one contiguous mask, no unresolved references.

`labelmapImageReferenceResolver` resolves a layer's labelmap image for the displayed slice by matching `referencedImageId`, then falls back to indexing the layer **positionally** with the viewport's slice index:

```js
if (currentIndex !== -1 && layer.imageIds?.[currentIndex]) {
    labelmapImageIds.push(layer.imageIds[currentIndex]);
```

That only holds when a layer covers the series 1:1 — true while labelmaps always spanned the whole stack. With z-cropped blocks a layer holds 160 images against 694 viewport slices, so slices 0-159 resolved to unrelated block images, and `syncStackLabelmapActors` drew them at the **current** slice's origin.

Evidence gathered at runtime before any code changed:

| observation | explained by |
|---|---|
| current image not in the layer's refs, yet an actor was mounted | the fallback fires exactly when the correct lookup misses |
| ghost actor foreground: 5881 px @ slice 76, 5830 @ slice 86 — exact and unique | `layer.imageIds[viewportIndex]` |
| actor origin = the CT slice (z 15.07), not the block's geometry (z 290.87) | `imageData.setOrigin(currentOrigin)` |
| ghost confined to 13-133 | the mask's block-local extent |

Fix guards all three positional sites — the main fallback and two `activeImageId` lookups sharing the assumption — so the fallback applies only to full-stack layers. Cropped layers rely solely on the `referencedImageId` match, correct by construction. Full-stack layers keep upstream behaviour, so ordinary segmentations are unaffected.

## 2. ~40MB leaked per refine (`efa4362`)

`getOrCreateSegmentationVolume` keys its cached volume by a **content hash** of the labelmap `imageIds` and never evicts the volume a new key supersedes. Every nnInteractive/SAM2 refine allocates new derived images, so the hash changes each time and the previous 40MB volume is orphaned forever.

It compounds with our own code: `remountSegmentationRepresentations` deletes `representationData.Labelmap.volumeId` when purging stale MPR volumes, disabling upstream's fast path and forcing the hash path on essentially every refine.

Measured on a 160-slice block: **1 volume / 40MB grew to 4 volumes / 160MB** across a handful of refines, unbounded. The sibling volumes (the uuid one from `legacyVolumePlan`, the `-geometry` one from `labelmapLayerStore`) were already purged correctly — only the hash-keyed one leaked.

Fix remembers the hash-keyed volume per segmentation and evicts it when superseded, **guarded**: dropped only when none of its images are still referenced by the current labelmap, so a live volume is never pulled from under a consumer. Also checks the cache before allocating.

After: steady state 1 volume / 40MB, briefly 2 mid-refine while the superseded one is dropped (the transient entry carries no scalar data).

## Verification

- Both bugs **reproduced on unpatched `origin/main`** in a side-by-side build before fixing — this is not a theoretical fix.
- Both fixes **user-verified in the browser**: ghost gone, real segment unchanged; volume count flat instead of climbing.
- Built bundle confirmed to carry **both guards**; `main`'s existing 22 overrides intact.
- Cornerstone is 5.0.13 with no lockfile drift, so these full-file copies don't silently revert upstream changes.
- Commit 1 was **built in isolation** to confirm it stands alone for `git bisect`.

## Risk

The eviction is the only behavioural risk: if a consumer still held a superseded volume, statistics or the overlay could blank after a refine. The reference guard exists for that, and refine/stats were exercised without issue. Worth watching in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
