### PR TITLE
fix(leak): eliminate per-cycle event-listener leaks and a measurement crash

### DIFF
--- a/Viewers/backup/esm/LabelmapEditWithContour.js
+++ b/Viewers/backup/esm/LabelmapEditWithContour.js
@@ -1,0 +1,129 @@
+import { Events, SegmentationRepresentations } from '../../enums';
+import { eventTarget, utilities, getRenderingEngine, } from '@cornerstonejs/core';
+import PlanarFreehandContourSegmentationTool from '../annotation/PlanarFreehandContourSegmentationTool';
+import BrushTool from './BrushTool';
+import * as segmentation from '../../stateManagement/segmentation';
+import { getSegmentationRepresentationsBySegmentationId } from '../../stateManagement/segmentation/getSegmentationRepresentation';
+class LabelMapEditWithContourTool extends PlanarFreehandContourSegmentationTool {
+    constructor(toolProps = {}) {
+        const initialProps = utilities.deepMerge({
+            configuration: {
+                calculateStats: false,
+                allowOpenContours: false,
+            },
+        }, toolProps);
+        super(initialProps);
+        this.onViewportAddedToToolGroupBinded =
+            this.onViewportAddedToToolGroup.bind(this);
+        this.onSegmentationModifiedBinded = this.onSegmentationModified.bind(this);
+    }
+    initializeListeners() {
+        LabelMapEditWithContourTool.annotationsToViewportMap.clear();
+        LabelMapEditWithContourTool.viewportIdsChecked = [];
+        eventTarget.addEventListener(Events.ANNOTATION_MODIFIED, this.annotationModified);
+        eventTarget.addEventListener(Events.ANNOTATION_COMPLETED, this.annotationCompleted);
+        eventTarget.addEventListener(Events.TOOLGROUP_VIEWPORT_ADDED, this.onViewportAddedToToolGroupBinded);
+        eventTarget.addEventListener(Events.SEGMENTATION_MODIFIED, this.onSegmentationModifiedBinded);
+        eventTarget.addEventListener(Events.SEGMENTATION_REPRESENTATION_MODIFIED, this.onSegmentationModifiedBinded);
+    }
+    cleanUpListeners() {
+        LabelMapEditWithContourTool.annotationsToViewportMap.clear();
+        LabelMapEditWithContourTool.viewportIdsChecked = [];
+        eventTarget.removeEventListener(Events.ANNOTATION_MODIFIED, this.annotationModified);
+        eventTarget.removeEventListener(Events.ANNOTATION_COMPLETED, this.annotationCompleted);
+        // OHIF-AI LEAK FIX (upstream @cornerstonejs/tools bug).
+        // initializeListeners() ADDS the stored bound references (this.onViewportAddedToToolGroupBinded /
+        // this.onSegmentationModifiedBinded), but these three removals used `.bind(this)`, which creates a
+        // BRAND NEW function every call — so removeEventListener could never match what was added and the
+        // listeners accumulated on the global eventTarget forever.
+        // Proof it is exactly this: ANNOTATION_MODIFIED / ANNOTATION_COMPLETED above use the SAME reference
+        // on both sides and were measured perfectly flat, while these two grew +1 per study open/close cycle.
+        eventTarget.removeEventListener(Events.TOOLGROUP_VIEWPORT_ADDED, this.onViewportAddedToToolGroupBinded);
+        eventTarget.removeEventListener(Events.SEGMENTATION_MODIFIED, this.onSegmentationModifiedBinded);
+        eventTarget.removeEventListener(Events.SEGMENTATION_REPRESENTATION_MODIFIED, this.onSegmentationModifiedBinded);
+    }
+    async checkContourSegmentation(viewportId) {
+        if (LabelMapEditWithContourTool.viewportIdsChecked.includes(viewportId)) {
+            return;
+        }
+        const activeSeg = segmentation.getActiveSegmentation(viewportId);
+        if (!activeSeg) {
+            console.log('No active segmentation detected');
+            return false;
+        }
+        const segmentationId = activeSeg.segmentationId;
+        if (!activeSeg.representationData.Contour) {
+            LabelMapEditWithContourTool.viewportIdsChecked.push(viewportId);
+            await segmentation.addContourRepresentationToViewport(viewportId, [
+                {
+                    segmentationId,
+                    type: SegmentationRepresentations.Contour,
+                },
+            ]);
+            segmentation.addRepresentationData({
+                segmentationId,
+                type: SegmentationRepresentations.Contour,
+                data: {},
+            });
+        }
+        else {
+            LabelMapEditWithContourTool.viewportIdsChecked.push(viewportId);
+        }
+        return true;
+    }
+    onViewportAddedToToolGroup(evt) {
+        const { toolGroupId, viewportId } = evt.detail;
+        if (toolGroupId !== this.toolGroupId) {
+            return;
+        }
+        this.checkContourSegmentation(viewportId);
+    }
+    onSegmentationModified(evt) {
+        const { segmentationId } = evt.detail || {};
+        if (!segmentationId) {
+            return;
+        }
+        const representations = getSegmentationRepresentationsBySegmentationId(segmentationId);
+        if (!representations) {
+            return;
+        }
+        representations.forEach(async ({ viewportId }) => await this.checkContourSegmentation(viewportId));
+    }
+    onSetToolEnabled() {
+        this.initializeListeners();
+    }
+    onSetToolActive() {
+        this.initializeListeners();
+    }
+    onSetToolDisabled() {
+        this.cleanUpListeners();
+    }
+    annotationModified(evt) {
+        const { annotation, renderingEngineId, viewportId } = evt.detail;
+        const viewport = getRenderingEngine(renderingEngineId)?.getViewport(viewportId);
+        if (!viewport) {
+            return;
+        }
+        LabelMapEditWithContourTool.annotationsToViewportMap.set(annotation.annotationUID, viewport);
+    }
+    annotationCompleted(evt) {
+        const { annotation } = evt.detail;
+        const { polyline } = annotation.data?.contour || {};
+        if (annotation?.metadata?.toolName !== LabelMapEditWithContourTool.toolName) {
+            return;
+        }
+        if (!polyline) {
+            return;
+        }
+        if (LabelMapEditWithContourTool.annotationsToViewportMap.has(annotation.annotationUID)) {
+            const viewport = LabelMapEditWithContourTool.annotationsToViewportMap.get(annotation.annotationUID);
+            if (polyline.length > 3) {
+                BrushTool.viewportContoursToLabelmap(viewport);
+            }
+        }
+    }
+}
+LabelMapEditWithContourTool.toolName = 'LabelMapEditWithContour';
+LabelMapEditWithContourTool.annotationsToViewportMap = new Map();
+LabelMapEditWithContourTool.viewportIdsChecked = [];
+export default LabelMapEditWithContourTool;

--- a/Viewers/backup/esm/OrientationMarkerTool.js
+++ b/Viewers/backup/esm/OrientationMarkerTool.js
@@ -1,0 +1,307 @@
+import vtkOrientationMarkerWidget from '@kitware/vtk.js/Interaction/Widgets/OrientationMarkerWidget';
+import vtkAnnotatedCubeActor from '@kitware/vtk.js/Rendering/Core/AnnotatedCubeActor';
+import vtkAxesActor from '@kitware/vtk.js/Rendering/Core/AxesActor';
+import vtkActor from '@kitware/vtk.js/Rendering/Core/Actor';
+import vtkMapper from '@kitware/vtk.js/Rendering/Core/Mapper';
+import vtkXMLPolyDataReader from '@kitware/vtk.js/IO/XML/XMLPolyDataReader';
+import vtkPolyData from '@kitware/vtk.js/Common/DataModel/PolyData';
+import { BaseTool } from './base';
+import { Enums, eventTarget, getEnabledElementByIds, getRenderingEngines, } from '@cornerstonejs/core';
+import { filterViewportsWithToolEnabled } from '../utilities/viewportFilters';
+import { getToolGroup } from '../store/ToolGroupManager';
+import { Events } from '../enums';
+var OverlayMarkerType;
+(function (OverlayMarkerType) {
+    OverlayMarkerType[OverlayMarkerType["ANNOTATED_CUBE"] = 1] = "ANNOTATED_CUBE";
+    OverlayMarkerType[OverlayMarkerType["AXES"] = 2] = "AXES";
+    OverlayMarkerType[OverlayMarkerType["CUSTOM"] = 3] = "CUSTOM";
+})(OverlayMarkerType || (OverlayMarkerType = {}));
+class OrientationMarkerTool extends BaseTool {
+    constructor(toolProps = {}, defaultToolProps = {
+        configuration: {
+            orientationWidget: {
+                enabled: true,
+                viewportCorner: vtkOrientationMarkerWidget.Corners.BOTTOM_RIGHT,
+                viewportSize: 0.15,
+                minPixelSize: 100,
+                maxPixelSize: 300,
+            },
+            overlayMarkerType: OrientationMarkerTool.OVERLAY_MARKER_TYPES.ANNOTATED_CUBE,
+            overlayConfiguration: {
+                [OrientationMarkerTool.OVERLAY_MARKER_TYPES.ANNOTATED_CUBE]: {
+                    faceProperties: {
+                        xPlus: { text: 'L', faceColor: '#ffff00', faceRotation: 90 },
+                        xMinus: { text: 'R', faceColor: '#ffff00', faceRotation: 270 },
+                        yPlus: {
+                            text: 'P',
+                            faceColor: '#00ffff',
+                            fontColor: 'white',
+                            faceRotation: 180,
+                        },
+                        yMinus: { text: 'A', faceColor: '#00ffff', fontColor: 'white' },
+                        zPlus: { text: 'S' },
+                        zMinus: { text: 'I' },
+                    },
+                    defaultStyle: {
+                        fontStyle: 'bold',
+                        fontFamily: 'Arial',
+                        fontColor: 'black',
+                        fontSizeScale: (res) => res / 2,
+                        faceColor: '#0000ff',
+                        edgeThickness: 0.1,
+                        edgeColor: 'black',
+                        resolution: 400,
+                    },
+                },
+                [OrientationMarkerTool.OVERLAY_MARKER_TYPES.AXES]: {},
+                [OrientationMarkerTool.OVERLAY_MARKER_TYPES.CUSTOM]: {
+                    polyDataURL: 'https://raw.githubusercontent.com/Slicer/Slicer/80ad0a04dacf134754459557bf2638c63f3d1d1b/Base/Logic/Resources/OrientationMarkers/Human.vtp',
+                },
+            },
+        },
+    }) {
+        super(toolProps, defaultToolProps);
+        this._resizeObservers = new Map();
+        this.onSetToolEnabled = () => {
+            this.initViewports();
+            this._subscribeToViewportEvents();
+        };
+        this.onSetToolActive = () => {
+            this.initViewports();
+            this._subscribeToViewportEvents();
+        };
+        this.onSetToolDisabled = () => {
+            this.cleanUpData();
+            this._unsubscribeToViewportNewVolumeSet();
+        };
+        this._getViewportsInfo = () => {
+            const viewports = getToolGroup(this.toolGroupId).viewportsInfo;
+            return viewports;
+        };
+        this.resize = (viewportId) => {
+            const orientationMarker = this.orientationMarkers[viewportId];
+            if (!orientationMarker) {
+                return;
+            }
+            const { orientationWidget } = orientationMarker;
+            orientationWidget.updateViewport();
+        };
+        this.orientationMarkers = {};
+        this.updatingOrientationMarker = {};
+    }
+    _unsubscribeToViewportNewVolumeSet() {
+        const unsubscribe = () => {
+            const viewportsInfo = this._getViewportsInfo();
+            viewportsInfo.forEach(({ viewportId, renderingEngineId }) => {
+                const { viewport } = getEnabledElementByIds(viewportId, renderingEngineId);
+                const { element } = viewport;
+                element.removeEventListener(Enums.Events.VOLUME_VIEWPORT_NEW_VOLUME, this.initViewports.bind(this));
+                const resizeObserver = this._resizeObservers.get(viewportId);
+                resizeObserver.unobserve(element);
+            });
+        };
+        // OHIF-AI LEAK FIX: this previously passed a FRESH inline arrow to
+        // removeEventListener, which can never match the listener that was added — see the
+        // companion fix in _subscribeToViewportEvents. Remove the stable instance reference.
+        unsubscribe();
+        if (this._toolGroupViewportAddedHandler) {
+            eventTarget.removeEventListener(
+                Events.TOOLGROUP_VIEWPORT_ADDED,
+                this._toolGroupViewportAddedHandler
+            );
+            this._toolGroupViewportAddedHandler = null;
+        }
+    }
+    _subscribeToViewportEvents() {
+        const subscribeToElementResize = () => {
+            const viewportsInfo = this._getViewportsInfo();
+            viewportsInfo.forEach(({ viewportId, renderingEngineId }) => {
+                const { viewport } = getEnabledElementByIds(viewportId, renderingEngineId);
+                const { element } = viewport;
+                this.initViewports();
+                element.addEventListener(Enums.Events.VOLUME_VIEWPORT_NEW_VOLUME, this.initViewports.bind(this));
+                const resizeObserver = new ResizeObserver(() => {
+                    setTimeout(() => {
+                        const element = getEnabledElementByIds(viewportId, renderingEngineId);
+                        if (!element) {
+                            return;
+                        }
+                        const { viewport } = element;
+                        this.resize(viewportId);
+                        viewport.render();
+                    }, 100);
+                });
+                resizeObserver.observe(element);
+                this._resizeObservers.set(viewportId, resizeObserver);
+            });
+        };
+        subscribeToElementResize();
+        // OHIF-AI LEAK FIX (upstream @cornerstonejs/tools bug).
+        // This used to pass a FRESH inline arrow to addEventListener, and the matching
+        // "removal" in _unsubscribeToViewportEvents passed ANOTHER fresh arrow — so nothing
+        // was ever removed and every subscribe added one more TOOLGROUP_VIEWPORT_ADDED
+        // listener to the global eventTarget. MEASURED: +1 per study open/close cycle,
+        // monotonic, each a distinct closure with identical source.
+        // Store a stable reference on the instance so remove can actually match it.
+        if (this._toolGroupViewportAddedHandler) {
+            eventTarget.removeEventListener(
+                Events.TOOLGROUP_VIEWPORT_ADDED,
+                this._toolGroupViewportAddedHandler
+            );
+        }
+        this._toolGroupViewportAddedHandler = evt => {
+            if (evt.detail.toolGroupId !== this.toolGroupId) {
+                return;
+            }
+            subscribeToElementResize();
+            this.initViewports();
+        };
+        eventTarget.addEventListener(
+            Events.TOOLGROUP_VIEWPORT_ADDED,
+            this._toolGroupViewportAddedHandler
+        );
+    }
+    cleanUpData() {
+        const renderingEngines = getRenderingEngines();
+        const renderingEngine = renderingEngines[0];
+        const viewports = renderingEngine.getViewports();
+        viewports.forEach((viewport) => {
+            const orientationMarker = this.orientationMarkers[viewport.id];
+            if (!orientationMarker) {
+                return;
+            }
+            const { actor, orientationWidget } = orientationMarker;
+            orientationWidget?.setEnabled(false);
+            orientationWidget?.delete();
+            actor?.delete();
+            const renderWindow = viewport
+                .getRenderingEngine()
+                .getOffscreenMultiRenderWindow(viewport.id)
+                .getRenderWindow();
+            renderWindow.render();
+            viewport.getRenderingEngine().render();
+            delete this.orientationMarkers[viewport.id];
+        });
+    }
+    initViewports() {
+        const renderingEngines = getRenderingEngines();
+        const renderingEngine = renderingEngines[0];
+        if (!renderingEngine) {
+            return;
+        }
+        let viewports = renderingEngine.getViewports();
+        viewports = filterViewportsWithToolEnabled(viewports, this.getToolName());
+        viewports.forEach((viewport) => {
+            const widget = viewport.getWidget(this.getToolName());
+            if (!widget || widget.isDeleted()) {
+                this.addAxisActorInViewport(viewport);
+            }
+        });
+    }
+    async addAxisActorInViewport(viewport) {
+        const viewportId = viewport.id;
+        if (!this.updatingOrientationMarker[viewportId]) {
+            this.updatingOrientationMarker[viewportId] = true;
+            const type = this.configuration.overlayMarkerType;
+            const overlayConfiguration = this.configuration.overlayConfiguration[type];
+            if (this.orientationMarkers[viewportId]) {
+                const { actor, orientationWidget } = this.orientationMarkers[viewportId];
+                viewport.getRenderer().removeActor(actor);
+                orientationWidget.setEnabled(false);
+            }
+            let actor;
+            if (type === 1) {
+                actor = this.createAnnotationCube(overlayConfiguration);
+            }
+            else if (type === 2) {
+                actor = vtkAxesActor.newInstance();
+            }
+            else if (type === 3) {
+                actor = await this.createCustomActor();
+            }
+            const renderer = viewport.getRenderer();
+            const renderWindow = viewport
+                .getRenderingEngine()
+                .getOffscreenMultiRenderWindow(viewportId)
+                .getRenderWindow();
+            const { enabled, viewportCorner, viewportSize, minPixelSize, maxPixelSize, } = this.configuration.orientationWidget;
+            const orientationWidget = vtkOrientationMarkerWidget.newInstance({
+                actor,
+                interactor: renderWindow.getInteractor(),
+                parentRenderer: renderer,
+            });
+            orientationWidget.setEnabled(enabled);
+            orientationWidget.setViewportCorner(viewportCorner);
+            orientationWidget.setViewportSize(viewportSize);
+            orientationWidget.setMinPixelSize(minPixelSize);
+            orientationWidget.setMaxPixelSize(maxPixelSize);
+            orientationWidget.updateMarkerOrientation();
+            this.orientationMarkers[viewportId] = {
+                orientationWidget,
+                actor,
+            };
+            viewport.addWidget(this.getToolName(), orientationWidget);
+            renderWindow.render();
+            viewport.getRenderingEngine().render();
+            this.updatingOrientationMarker[viewportId] = false;
+        }
+    }
+    async createCustomActor() {
+        const url = this.configuration.overlayConfiguration[OverlayMarkerType.CUSTOM]
+            .polyDataURL;
+        const response = await fetch(url);
+        const arrayBuffer = await response.arrayBuffer();
+        const vtpReader = vtkXMLPolyDataReader.newInstance();
+        vtpReader.parseAsArrayBuffer(arrayBuffer);
+        vtpReader.update();
+        const polyData = vtkPolyData.newInstance();
+        polyData.shallowCopy(vtpReader.getOutputData());
+        polyData.getPointData().setActiveScalars('Color');
+        const mapper = vtkMapper.newInstance();
+        mapper.setInputData(polyData);
+        mapper.setColorModeToDirectScalars();
+        const actor = vtkActor.newInstance();
+        actor.setMapper(mapper);
+        actor.rotateZ(180);
+        return actor;
+    }
+    createAnnotationCube(overlayConfiguration) {
+        const actor = vtkAnnotatedCubeActor.newInstance();
+        actor.setDefaultStyle({ ...overlayConfiguration.defaultStyle });
+        actor.setXPlusFaceProperty({
+            ...overlayConfiguration.faceProperties.xPlus,
+        });
+        actor.setXMinusFaceProperty({
+            ...overlayConfiguration.faceProperties.xMinus,
+        });
+        actor.setYPlusFaceProperty({
+            ...overlayConfiguration.faceProperties.yPlus,
+        });
+        actor.setYMinusFaceProperty({
+            ...overlayConfiguration.faceProperties.yMinus,
+        });
+        actor.setZPlusFaceProperty({
+            ...overlayConfiguration.faceProperties.zPlus,
+        });
+        actor.setZMinusFaceProperty({
+            ...overlayConfiguration.faceProperties.zMinus,
+        });
+        return actor;
+    }
+    async createAnnotatedCubeActor() {
+        const axes = vtkAnnotatedCubeActor.newInstance();
+        const { faceProperties, defaultStyle } = this.configuration.annotatedCube;
+        axes.setDefaultStyle(defaultStyle);
+        Object.keys(faceProperties).forEach((key) => {
+            const methodName = `set${key.charAt(0).toUpperCase() + key.slice(1)}FaceProperty`;
+            axes[methodName](faceProperties[key]);
+        });
+        return axes;
+    }
+}
+OrientationMarkerTool.CUBE = 1;
+OrientationMarkerTool.AXIS = 2;
+OrientationMarkerTool.VTPFILE = 3;
+OrientationMarkerTool.OVERLAY_MARKER_TYPES = OverlayMarkerType;
+OrientationMarkerTool.toolName = 'OrientationMarker';
+export default OrientationMarkerTool;

--- a/Viewers/backup/esm/Synchronizer.js
+++ b/Viewers/backup/esm/Synchronizer.js
@@ -62,10 +62,16 @@ class Synchronizer {
             return;
         }
         const eventSource = this._eventSource === 'element' ? viewport.element : eventTarget;
-        eventSource.addEventListener(this._eventName, this._onEvent.bind(this));
+        // OHIF-AI LEAK FIX: `this._onEvent.bind(this)` created a NEW function object on every
+        // call, so removeEventListener could never match it. Worse, removeSource() below removed
+        // `this._eventHandler` — a DIFFERENT function entirely (the synchronizer's callback,
+        // not this internal dispatcher). `_onEvent` is already an instance arrow function
+        // (see constructor), so it is stable and the bind was redundant as well as harmful.
+        // MEASURED: +5 SEGMENTATION_REPRESENTATION_MODIFIED listeners per MPR cycle.
+        eventSource.addEventListener(this._eventName, this._onEvent);
         this._auxiliaryEvents.forEach(({ name, source = 'element' }) => {
             const target = source === 'element' ? viewport.element : eventTarget;
-            target.addEventListener(name, this._onEvent.bind(this));
+            target.addEventListener(name, this._onEvent);
         });
         this._updateDisableHandlers();
         this._sourceViewports.push(viewportInfo);
@@ -98,6 +104,23 @@ class Synchronizer {
             eventTarget.removeEventListener(Enums.Events.ELEMENT_DISABLED, this._disableHandler);
             this._disableHandler = null;
         }
+        // OHIF-AI LEAK FIX (part 2). removeSource() only unregisters this._eventHandler when it
+        // can still find the viewport in _sourceViewports AND getEventSource() resolves — at
+        // teardown either can fail (viewport already spliced, rendering engine gone), leaving the
+        // handler attached to the GLOBAL eventTarget. Measured: SynchronizerManager.destroy() was
+        // confirmed to RUN on mode exit (onModeExit fired, destroy called) yet
+        // SEGMENTATION_REPRESENTATION_MODIFIED listeners did not drop — +5 per MPR cycle,
+        // registration site confirmed as Synchronizer.addSource via captured stack traces.
+        // Remove unconditionally; removeEventListener is a no-op if it was already taken off.
+        try {
+            eventTarget.removeEventListener(this._eventName, this._onEvent);
+            (this._auxiliaryEvents || []).forEach(({ name }) => {
+                eventTarget.removeEventListener(name, this._onEvent);
+            });
+        }
+        catch (error) {
+            /* nothing attached */
+        }
     }
     remove(viewportInfo) {
         this.removeTarget(viewportInfo);
@@ -112,12 +135,15 @@ class Synchronizer {
             ? this.getViewportElement(viewportInfo)
             : eventTarget;
         this._sourceViewports.splice(index, 1);
-        eventSource.removeEventListener(this._eventName, this._eventHandler);
+        // OHIF-AI LEAK FIX: was removing `this._eventHandler`, which is NOT what addSource
+        // registered — addSource attaches `this._onEvent`. Removing the wrong function is a
+        // silent no-op, so every source added here leaked its listener.
+        eventSource?.removeEventListener(this._eventName, this._onEvent);
         this._auxiliaryEvents.forEach(({ name, source }) => {
             const target = source === 'element'
                 ? this.getViewportElement(viewportInfo)
                 : eventTarget;
-            target.removeEventListener(name, this._eventHandler);
+            target?.removeEventListener(name, this._onEvent);
         });
         this._updateDisableHandlers();
     }

--- a/Viewers/backup/esm/Synchronizer.js
+++ b/Viewers/backup/esm/Synchronizer.js
@@ -1,0 +1,246 @@
+import { getRenderingEngine, getEnabledElement, eventTarget, Enums, getEnabledElementByViewportId, } from '@cornerstonejs/core';
+class Synchronizer {
+    constructor(synchronizerId, eventName, eventHandler, options) {
+        this._viewportOptions = {};
+        this._onEvent = (evt) => {
+            if (this._ignoreFiredEvents === true) {
+                return;
+            }
+            if (!this._targetViewports.length) {
+                return;
+            }
+            const enabledElement = this._eventSource === 'element'
+                ? getEnabledElement(evt.currentTarget)
+                : getEnabledElementByViewportId(evt.detail?.viewportId);
+            if (!enabledElement) {
+                return;
+            }
+            const { renderingEngineId, viewportId } = enabledElement;
+            if (!this._sourceViewports.find((s) => s.viewportId === viewportId)) {
+                return;
+            }
+            this.fireEvent({
+                renderingEngineId,
+                viewportId,
+            }, evt);
+        };
+        this._enabled = true;
+        this._eventName = eventName;
+        this._eventHandler = eventHandler;
+        this._ignoreFiredEvents = false;
+        this._sourceViewports = [];
+        this._targetViewports = [];
+        this._options = options || {};
+        this._eventSource = this._options.eventSource || 'element';
+        this._auxiliaryEvents = this._options.auxiliaryEvents || [];
+        this.id = synchronizerId;
+    }
+    isDisabled() {
+        return !this._enabled || !this._hasSourceElements();
+    }
+    setOptions(viewportId, options = {}) {
+        this._viewportOptions[viewportId] = options;
+    }
+    setEnabled(enabled) {
+        this._enabled = enabled;
+    }
+    getOptions(viewportId) {
+        return this._viewportOptions[viewportId];
+    }
+    add(viewportInfo) {
+        this.addTarget(viewportInfo);
+        this.addSource(viewportInfo);
+    }
+    addSource(viewportInfo) {
+        if (_containsViewport(this._sourceViewports, viewportInfo)) {
+            return;
+        }
+        const { renderingEngineId, viewportId } = viewportInfo;
+        const viewport = getRenderingEngine(renderingEngineId).getViewport(viewportId);
+        if (!viewport) {
+            console.warn(`Synchronizer.addSource: No viewport for ${renderingEngineId} ${viewportId}`);
+            return;
+        }
+        const eventSource = this._eventSource === 'element' ? viewport.element : eventTarget;
+        eventSource.addEventListener(this._eventName, this._onEvent.bind(this));
+        this._auxiliaryEvents.forEach(({ name, source = 'element' }) => {
+            const target = source === 'element' ? viewport.element : eventTarget;
+            target.addEventListener(name, this._onEvent.bind(this));
+        });
+        this._updateDisableHandlers();
+        this._sourceViewports.push(viewportInfo);
+    }
+    addTarget(viewportInfo) {
+        if (_containsViewport(this._targetViewports, viewportInfo)) {
+            return;
+        }
+        this._targetViewports.push(viewportInfo);
+        this._updateDisableHandlers();
+    }
+    getSourceViewports() {
+        return this._sourceViewports;
+    }
+    getTargetViewports() {
+        return this._targetViewports;
+    }
+    destroy() {
+        // Iterate over COPIES: removeSource/removeTarget splice the very arrays being
+        // iterated, so forEach over the live arrays skips elements (upstream bug — it
+        // meant destroy() left viewports attached).
+        [...this._sourceViewports].forEach((s) => this.removeSource(s));
+        [...this._targetViewports].forEach((t) => this.removeTarget(t));
+        // OHIF-AI LEAK FIX: with the stable handler above, remove+add is idempotent while
+        // the synchronizer is alive — but on teardown the viewport lists are emptied FIRST,
+        // so _updateDisableHandlers iterates nothing and the last-added global listener is
+        // orphaned. Element-scoped listeners die with their element; the global eventTarget
+        // one must be removed explicitly or every destroyed synchronizer leaks exactly one.
+        if (this._disableHandler) {
+            eventTarget.removeEventListener(Enums.Events.ELEMENT_DISABLED, this._disableHandler);
+            this._disableHandler = null;
+        }
+    }
+    remove(viewportInfo) {
+        this.removeTarget(viewportInfo);
+        this.removeSource(viewportInfo);
+    }
+    removeSource(viewportInfo) {
+        const index = _getViewportIndex(this._sourceViewports, viewportInfo);
+        if (index === -1) {
+            return;
+        }
+        const eventSource = this._eventSource === 'element'
+            ? this.getViewportElement(viewportInfo)
+            : eventTarget;
+        this._sourceViewports.splice(index, 1);
+        eventSource.removeEventListener(this._eventName, this._eventHandler);
+        this._auxiliaryEvents.forEach(({ name, source }) => {
+            const target = source === 'element'
+                ? this.getViewportElement(viewportInfo)
+                : eventTarget;
+            target.removeEventListener(name, this._eventHandler);
+        });
+        this._updateDisableHandlers();
+    }
+    removeTarget(viewportInfo) {
+        const index = _getViewportIndex(this._targetViewports, viewportInfo);
+        if (index === -1) {
+            return;
+        }
+        this._targetViewports.splice(index, 1);
+        this._updateDisableHandlers();
+    }
+    hasSourceViewport(renderingEngineId, viewportId) {
+        return _containsViewport(this._sourceViewports, {
+            renderingEngineId,
+            viewportId,
+        });
+    }
+    hasTargetViewport(renderingEngineId, viewportId) {
+        return _containsViewport(this._targetViewports, {
+            renderingEngineId,
+            viewportId,
+        });
+    }
+    fireEvent(sourceViewport, sourceEvent) {
+        if (this.isDisabled() || this._ignoreFiredEvents) {
+            return;
+        }
+        this._ignoreFiredEvents = true;
+        const promises = [];
+        try {
+            for (let i = 0; i < this._targetViewports.length; i++) {
+                const targetViewport = this._targetViewports[i];
+                const targetIsSource = sourceViewport.viewportId === targetViewport.viewportId;
+                if (targetIsSource) {
+                    continue;
+                }
+                const result = this._eventHandler(this, sourceViewport, targetViewport, sourceEvent, this._options);
+                if (result instanceof Promise) {
+                    promises.push(result);
+                }
+            }
+        }
+        catch (ex) {
+            console.warn(`Synchronizer, for: ${this._eventName}`, ex);
+        }
+        finally {
+            if (promises.length) {
+                Promise.allSettled(promises).then(() => {
+                    this._ignoreFiredEvents = false;
+                });
+            }
+            else {
+                this._ignoreFiredEvents = false;
+            }
+        }
+    }
+    _hasSourceElements() {
+        return this._sourceViewports.length !== 0;
+    }
+    _updateDisableHandlers() {
+        const viewports = _getUniqueViewports(this._sourceViewports, this._targetViewports);
+        // OHIF-AI LEAK FIX (upstream @cornerstonejs/tools bug).
+        // `disableHandler` used to be a FRESH closure created on every call, so the
+        // removeEventListener below could never match a previously-added listener — the
+        // remove-then-add idiom only works with a STABLE reference. Every call therefore
+        // added one more ELEMENT_DISABLED listener to the (global) eventTarget and removed
+        // none. _updateDisableHandlers is called from add/removeSource/removeTarget/destroy,
+        // so even tearing a synchronizer down leaked more listeners.
+        // MEASURED before this fix: +3 ELEMENT_DISABLED listeners per study open/close
+        // cycle, monotonic (6 -> 9 -> 12 -> 15 -> 18 over 4 cycles), never reclaimed.
+        // Caching the handler on the instance makes remove+add idempotent.
+        if (!this._disableHandler) {
+            const _remove = this.remove.bind(this);
+            this._disableHandler = (elementDisabledEvent) => {
+                _remove(elementDisabledEvent.detail.element);
+            };
+        }
+        const disableHandler = this._disableHandler;
+        viewports.forEach((vp) => {
+            const eventSource = this.getEventSource(vp);
+            if (!eventSource) {
+                return;
+            }
+            eventSource.removeEventListener(Enums.Events.ELEMENT_DISABLED, disableHandler);
+            eventSource.addEventListener(Enums.Events.ELEMENT_DISABLED, disableHandler);
+        });
+    }
+    getEventSource(viewportInfo) {
+        return this._eventSource === 'element'
+            ? this.getViewportElement(viewportInfo)
+            : eventTarget;
+    }
+    getViewportElement(viewportInfo) {
+        const { renderingEngineId, viewportId } = viewportInfo;
+        const renderingEngine = getRenderingEngine(renderingEngineId);
+        if (!renderingEngine) {
+            return null;
+        }
+        const viewport = renderingEngine.getViewport(viewportId);
+        if (!viewport) {
+            return null;
+        }
+        return viewport.element;
+    }
+}
+function _getUniqueViewports(vp1, vp2) {
+    const unique = [];
+    const vps = vp1.concat(vp2);
+    for (let i = 0; i < vps.length; i++) {
+        const vp = vps[i];
+        if (!unique.some((u) => vp.renderingEngineId === u.renderingEngineId &&
+            vp.viewportId === u.viewportId)) {
+            unique.push(vp);
+        }
+    }
+    return unique;
+}
+function _getViewportIndex(arr, vp) {
+    return arr.findIndex((ar) => vp.renderingEngineId === ar.renderingEngineId &&
+        vp.viewportId === ar.viewportId);
+}
+function _containsViewport(arr, vp) {
+    return arr.some((ar) => ar.renderingEngineId === vp.renderingEngineId &&
+        ar.viewportId === vp.viewportId);
+}
+export default Synchronizer;

--- a/Viewers/backup/esm/destroyToolGroup.js
+++ b/Viewers/backup/esm/destroyToolGroup.js
@@ -1,0 +1,33 @@
+import { state } from '../state';
+function destroyToolGroup(toolGroupId) {
+    const toolGroupIndex = state.toolGroups.findIndex((tg) => tg.id === toolGroupId);
+    if (toolGroupIndex > -1) {
+        // OHIF-AI LEAK FIX (upstream @cornerstonejs/tools bug).
+        // This function used to ONLY splice the tool group out of an array. No tool's
+        // disable hook was ever invoked, so tools that registered handlers on the GLOBAL
+        // cornerstone eventTarget in onSetToolEnabled/onSetToolActive never ran their
+        // onSetToolDisabled cleanup. Those listeners survived every mode exit — and because
+        // a listener references the tool instance, the tool objects leaked with them.
+        // MEASURED: +1 TOOLGROUP_VIEWPORT_ADDED and +1 SEGMENTATION_REPRESENTATION_MODIFIED
+        // listener per study open/close cycle, monotonic, each a distinct closure.
+        //
+        // We invoke onSetToolDisabled() DIRECTLY rather than calling toolGroup.setToolDisabled(),
+        // because the latter also calls _renderViewports() and fires tool-mode-changed events —
+        // side effects we do not want while the viewports are being torn down.
+        const toolGroup = state.toolGroups[toolGroupIndex];
+        const toolInstances = (toolGroup && toolGroup._toolInstances) || {};
+        for (const toolName of Object.keys(toolInstances)) {
+            const toolInstance = toolInstances[toolName];
+            try {
+                if (toolInstance && typeof toolInstance.onSetToolDisabled === 'function') {
+                    toolInstance.onSetToolDisabled();
+                }
+            } catch (error) {
+                // teardown hygiene must never break tool-group disposal
+                console.debug(`destroyToolGroup: ${toolName}.onSetToolDisabled() failed`, error);
+            }
+        }
+        state.toolGroups.splice(toolGroupIndex, 1);
+    }
+}
+export default destroyToolGroup;

--- a/Viewers/backup/esm/stackContextPrefetch.js
+++ b/Viewers/backup/esm/stackContextPrefetch.js
@@ -20,6 +20,34 @@ function _stablePromiseRemovedHandler(element) {
     }
     return handler;
 }
+
+// OHIF-AI LEAK FIX (part 2). Making the handler stable is not enough on its own, because
+// nothing ever calls disable(): OHIF tears viewports down wholesale and never invokes
+// per-viewport teardown, so each new viewport element left its listener behind forever
+// (measured +1 per study open/close cycle even after the stable-handler fix).
+// Self-clean instead of depending on a caller: register ONE global ELEMENT_DISABLED listener
+// (once per module, not per element) and drop the element's prefetch registration when
+// cornerstone disables it. Bounded: exactly one extra listener for the app's lifetime.
+let _elementDisabledCleanupRegistered = false;
+function _ensureElementDisabledCleanup() {
+    if (_elementDisabledCleanupRegistered) {
+        return;
+    }
+    _elementDisabledCleanupRegistered = true;
+    eventTarget.addEventListener(Enums.Events.ELEMENT_DISABLED, (evt) => {
+        const element = evt?.detail?.element;
+        if (!element || !_promiseRemovedHandlers.has(element)) {
+            return;
+        }
+        try {
+            disable(element);
+        }
+        catch (error) {
+            // teardown hygiene must never break element disposal
+            console.debug('stackContextPrefetch self-cleanup failed', error);
+        }
+    });
+}
 let configuration = {
     maxImagesToPrefetch: Infinity,
     minBefore: 2,
@@ -44,6 +72,7 @@ const enable = (element, priority = 0) => {
     prefetch(element, priority);
     element.removeEventListener(Enums.Events.STACK_NEW_IMAGE, onImageUpdated);
     element.addEventListener(Enums.Events.STACK_NEW_IMAGE, onImageUpdated);
+    _ensureElementDisabledCleanup();
     const promiseRemovedHandler = _stablePromiseRemovedHandler(element);
     eventTarget.removeEventListener(Enums.Events.IMAGE_CACHE_IMAGE_REMOVED, promiseRemovedHandler);
     eventTarget.addEventListener(Enums.Events.IMAGE_CACHE_IMAGE_REMOVED, promiseRemovedHandler);

--- a/Viewers/backup/esm/stackContextPrefetch.js
+++ b/Viewers/backup/esm/stackContextPrefetch.js
@@ -1,0 +1,257 @@
+import { imageLoader, Enums, eventTarget, imageLoadPoolManager, cache, metaData, utilities, triggerEvent, } from '@cornerstonejs/core';
+import { addToolState, getToolState } from './state';
+import { getStackData, requestType, clearFromImageIds, getPromiseRemovedHandler, } from './stackPrefetchUtils';
+import { Events } from '../../enums';
+const { imageRetrieveMetadataProvider } = utilities;
+
+// OHIF-AI LEAK FIX (upstream @cornerstonejs/tools bug).
+// getPromiseRemovedHandler(element) returns a NEW function on every call, but both the
+// enable path and disable() called it and then passed the result to removeEventListener —
+// which can never match a previously-added listener. So enabling added one more
+// IMAGE_CACHE_IMAGE_REMOVED listener to the global eventTarget and disabling removed none.
+// MEASURED: +1 per study open/close cycle, monotonic, each a distinct closure.
+// Cache one stable handler per element (WeakMap so detached elements are still collectable).
+const _promiseRemovedHandlers = new WeakMap();
+function _stablePromiseRemovedHandler(element) {
+    let handler = _promiseRemovedHandlers.get(element);
+    if (!handler) {
+        handler = getPromiseRemovedHandler(element);
+        _promiseRemovedHandlers.set(element, handler);
+    }
+    return handler;
+}
+let configuration = {
+    maxImagesToPrefetch: Infinity,
+    minBefore: 2,
+    maxAfter: 2,
+    directionExtraImages: 10,
+    preserveExistingPool: false,
+};
+let resetPrefetchTimeout;
+const resetPrefetchDelay = 5;
+const priorities = {};
+const enable = (element, priority = 0) => {
+    const stack = getStackData(element);
+    if (!stack) {
+        return;
+    }
+    if (!stack.imageIds?.length) {
+        console.warn('CornerstoneTools.stackPrefetch: No images in stack.');
+        return;
+    }
+    updateToolState(element);
+    priorities[element] = priority;
+    prefetch(element, priority);
+    element.removeEventListener(Enums.Events.STACK_NEW_IMAGE, onImageUpdated);
+    element.addEventListener(Enums.Events.STACK_NEW_IMAGE, onImageUpdated);
+    const promiseRemovedHandler = _stablePromiseRemovedHandler(element);
+    eventTarget.removeEventListener(Enums.Events.IMAGE_CACHE_IMAGE_REMOVED, promiseRemovedHandler);
+    eventTarget.addEventListener(Enums.Events.IMAGE_CACHE_IMAGE_REMOVED, promiseRemovedHandler);
+};
+function prefetch(element, priority = 0) {
+    const stack = getStackData(element);
+    if (!stack) {
+        return;
+    }
+    if (!stack?.imageIds?.length) {
+        console.warn('CornerstoneTools.stackPrefetch: No images in stack.');
+        return;
+    }
+    const stackPrefetchData = getToolState(element);
+    if (!stackPrefetchData) {
+        return;
+    }
+    const stackPrefetch = (stackPrefetchData || {});
+    stackPrefetch.enabled =
+        stackPrefetch.enabled && (stackPrefetch.indicesToRequest?.length ?? 0) > 0;
+    if (stackPrefetch.enabled === false) {
+        return;
+    }
+    function removeFromList(imageIdIndex) {
+        const index = stackPrefetch.indicesToRequest.indexOf(imageIdIndex);
+        if (index > -1) {
+            stackPrefetch.indicesToRequest.splice(index, 1);
+        }
+    }
+    const indicesToRequestCopy = stackPrefetch.indicesToRequest.slice();
+    const { currentImageIdIndex } = stack;
+    indicesToRequestCopy.forEach((imageIdIndex) => {
+        const imageId = stack.imageIds[imageIdIndex];
+        if (!imageId) {
+            return;
+        }
+        const distance = Math.abs(currentImageIdIndex - imageIdIndex);
+        const imageCached = distance < 6
+            ? cache.getImageLoadObject(imageId)
+            : cache.isLoaded(imageId);
+        if (imageCached) {
+            removeFromList(imageIdIndex);
+        }
+    });
+    if (!stackPrefetch.indicesToRequest.length) {
+        return;
+    }
+    if (!configuration.preserveExistingPool) {
+        imageLoadPoolManager.filterRequests(clearFromImageIds(stack));
+    }
+    function doneCallback(imageId) {
+        const imageIdIndex = stack.imageIds.indexOf(imageId);
+        removeFromList(imageIdIndex);
+        const image = cache.getCachedImageBasedOnImageURI(imageId);
+        const { stats } = stackPrefetch;
+        const decodeTimeInMS = image?.image?.decodeTimeInMS || 0;
+        if (decodeTimeInMS) {
+            stats.imageIds.set(imageId, decodeTimeInMS);
+            stats.decodeTimeInMS += decodeTimeInMS;
+            const loadTimeInMS = image?.image?.loadTimeInMS || 0;
+            stats.loadTimeInMS += loadTimeInMS;
+        }
+        if (!stackPrefetch.indicesToRequest.length) {
+            if (image?.sizeInBytes) {
+                const { sizeInBytes } = image;
+                const usage = cache.getMaxCacheSize() / 4 / sizeInBytes;
+                if (!stackPrefetch.cacheFill) {
+                    stats.initialTime = Date.now() - stats.start;
+                    stats.initialSize = stats.imageIds.size;
+                    updateToolState(element, usage);
+                    prefetch(element, priority);
+                }
+                else if (stats.imageIds.size) {
+                    stats.fillTime = Date.now() - stats.start;
+                    const { size } = stats.imageIds;
+                    stats.fillSize = size;
+                }
+            }
+        }
+        if (stackPrefetch.indicesToRequest.length === 0) {
+            const eventDetail = {
+                element: element,
+                lastPrefetchedImageId: imageId,
+            };
+            triggerEvent(eventTarget, Events.STACK_PREFETCH_COMPLETE, eventDetail);
+        }
+    }
+    const requestFn = (imageId, options) => {
+        const { retrieveOptions = {} } = metaData.get(imageRetrieveMetadataProvider.IMAGE_RETRIEVE_CONFIGURATION, imageId, 'stack') || {};
+        options.retrieveOptions = {
+            ...options.retrieveOptions,
+            ...(retrieveOptions.default || Object.values(retrieveOptions)?.[0] || {}),
+        };
+        return imageLoader
+            .loadAndCacheImage(imageId, options)
+            .then(() => doneCallback(imageId));
+    };
+    stackPrefetch.indicesToRequest.forEach((imageIdIndex) => {
+        const imageId = stack.imageIds[imageIdIndex];
+        const options = {
+            requestType,
+        };
+        imageLoadPoolManager.addRequest(requestFn.bind(null, imageId, options), requestType, {
+            imageId,
+        }, priority);
+    });
+}
+function onImageUpdated(e) {
+    clearTimeout(resetPrefetchTimeout);
+    resetPrefetchTimeout = setTimeout(function () {
+        const element = e.target;
+        try {
+            updateToolState(element);
+            prefetch(element, priorities[element]);
+        }
+        catch (error) {
+            return;
+        }
+    }, resetPrefetchDelay);
+}
+const signum = (x) => (x < 0 ? -1 : 1);
+const updateToolState = (element, usage) => {
+    const stack = getStackData(element);
+    if (!stack) {
+        return;
+    }
+    if (!stack.imageIds?.length) {
+        console.warn('CornerstoneTools.stackPrefetch: No images in stack.');
+        return;
+    }
+    const { currentImageIdIndex } = stack;
+    let { maxAfter = 2, minBefore = 2 } = configuration;
+    const { directionExtraImages = 10 } = configuration;
+    const stackPrefetchData = getToolState(element) ||
+        {
+            indicesToRequest: [],
+            currentImageIdIndex,
+            stackCount: 0,
+            enabled: true,
+            direction: 1,
+            stats: {
+                start: Date.now(),
+                imageIds: new Map(),
+                decodeTimeInMS: 0,
+                loadTimeInMS: 0,
+                totalBytes: 0,
+            },
+        };
+    const delta = currentImageIdIndex - stackPrefetchData.currentImageIdIndex;
+    stackPrefetchData.direction = signum(delta);
+    stackPrefetchData.currentImageIdIndex = currentImageIdIndex;
+    stackPrefetchData.enabled = true;
+    if (stackPrefetchData.stackCount < 100) {
+        stackPrefetchData.stackCount += directionExtraImages;
+    }
+    if (Math.abs(delta) > maxAfter || !delta) {
+        stackPrefetchData.stackCount = 0;
+        if (usage) {
+            const positionFraction = currentImageIdIndex / stack.imageIds.length;
+            minBefore = Math.ceil(usage * positionFraction);
+            maxAfter = Math.ceil(usage * (1 - positionFraction));
+            stackPrefetchData.cacheFill = true;
+        }
+        else {
+            stackPrefetchData.cacheFill = false;
+        }
+    }
+    else if (delta < 0) {
+        minBefore += stackPrefetchData.stackCount;
+        maxAfter = 0;
+    }
+    else {
+        maxAfter += stackPrefetchData.stackCount;
+        minBefore = 0;
+    }
+    const minIndex = Math.max(0, currentImageIdIndex - minBefore);
+    const maxIndex = Math.min(stack.imageIds.length - 1, currentImageIdIndex + maxAfter);
+    const indicesToRequest = [];
+    for (let i = currentImageIdIndex + 1; i <= maxIndex; i++) {
+        indicesToRequest.push(i);
+    }
+    for (let i = currentImageIdIndex - 1; i >= minIndex; i--) {
+        indicesToRequest.push(i);
+    }
+    stackPrefetchData.indicesToRequest = indicesToRequest;
+    addToolState(element, stackPrefetchData);
+};
+function disable(element) {
+    clearTimeout(resetPrefetchTimeout);
+    element.removeEventListener(Enums.Events.STACK_NEW_IMAGE, onImageUpdated);
+    const promiseRemovedHandler = _stablePromiseRemovedHandler(element);
+    eventTarget.removeEventListener(Enums.Events.IMAGE_CACHE_IMAGE_REMOVED, promiseRemovedHandler);
+    _promiseRemovedHandlers.delete(element);
+    const stackPrefetchData = getToolState(element);
+    if (stackPrefetchData) {
+        stackPrefetchData.enabled = false;
+    }
+}
+function getConfiguration() {
+    return configuration;
+}
+function setConfiguration(config) {
+    configuration = config;
+}
+const stackContextPrefetch = {
+    enable,
+    disable,
+    getConfiguration,
+    setConfiguration,
+};
+export default stackContextPrefetch;

--- a/Viewers/extensions/cornerstone/src/index.tsx
+++ b/Viewers/extensions/cornerstone/src/index.tsx
@@ -135,6 +135,25 @@ const cornerstoneExtension: Types.Extensions.Extension = {
 
     cineService.setIsCineEnabled(false);
 
+    // LEAK FIX: stackContextPrefetch.enable(element) registers an IMAGE_CACHE_IMAGE_REMOVED
+    // listener on the GLOBAL cornerstone eventTarget, one per viewport element, and nothing in
+    // OHIF ever called its disable(). Mode exit tears down wholesale (enabledElementReset below
+    // drops the elements) without invoking any per-viewport teardown, so every study open left
+    // another listener behind — measured +1 per open/close cycle, monotonic, never reclaimed.
+    // Must run BEFORE enabledElementReset(), which is what makes the elements unreachable.
+    try {
+      const { cornerstoneViewportService } = servicesManager.services;
+      const renderingEngine = cornerstoneViewportService?.getRenderingEngine?.();
+      renderingEngine?.getViewports?.().forEach(viewport => {
+        if (viewport?.element) {
+          cornerstoneTools.utilities.stackContextPrefetch.disable(viewport.element);
+        }
+      });
+    } catch (error) {
+      // teardown hygiene must never break mode exit
+      console.debug('stackContextPrefetch.disable on mode exit skipped', error);
+    }
+
     enabledElementReset();
 
     useLutPresentationStore.getState().clearLutPresentationStore();

--- a/Viewers/extensions/cornerstone/src/services/SyncGroupService/SyncGroupService.ts
+++ b/Viewers/extensions/cornerstone/src/services/SyncGroupService/SyncGroupService.ts
@@ -167,6 +167,24 @@ export default class SyncGroupService {
     });
   }
 
+  /**
+   * LEAK FIX: this service had a destroy() but no onModeExit, so it was never invoked —
+   * unlike the sibling ToolGroupService, which does `onModeExit() { this.destroy(); }`.
+   * Synchronizers therefore survived every mode exit, and each Synchronizer.addSource()
+   * registers `this._eventHandler` for its configured event on the GLOBAL cornerstone
+   * eventTarget. Only removeSource() takes it back off, and that is reached solely via
+   * destroy(). onModeExit's `clearSynchronizersStore()` clears a zustand store, NOT
+   * cornerstone's SynchronizerManager, so nothing ever unregistered them.
+   *
+   * MEASURED: +5 SEGMENTATION_REPRESENTATION_MODIFIED listeners per study open/close cycle
+   * when MPR is toggled (one per synchronizer source), monotonic and never reclaimed.
+   * Registration site confirmed by capturing stack traces at addEventListener:
+   *   [5x] Synchronizer.addSource <- Synchronizer.add
+   */
+  public onModeExit(): void {
+    this.destroy();
+  }
+
   public destroy(): void {
     SynchronizerManager.destroy();
   }

--- a/Viewers/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
+++ b/Viewers/extensions/cornerstone/src/services/ViewportService/CornerstoneViewportService.ts
@@ -189,6 +189,22 @@ class CornerstoneViewportService extends PubSubService implements IViewportServi
    * @param viewportId - The viewportId to disable
    */
   public disableElement(viewportId: string): void {
+    // LEAK FIX: stackContextPrefetch.enable(element) is called when a stack viewport's
+    // images load (see _setStackViewport), and it registers an IMAGE_CACHE_IMAGE_REMOVED
+    // listener on the GLOBAL cornerstone eventTarget keyed to that element. Nothing in OHIF
+    // ever called the matching disable(), so every viewport teardown left its listener
+    // behind — measured +1 per study open/close cycle, monotonic, never reclaimed.
+    // Must run BEFORE renderingEngine.disableElement(), which destroys the element we need.
+    try {
+      const element = this.renderingEngine?.getViewport(viewportId)?.element;
+      if (element) {
+        csToolsUtils.stackContextPrefetch.disable(element);
+      }
+    } catch (e) {
+      // never let telemetry/teardown hygiene break viewport disposal
+      console.debug('stackContextPrefetch.disable skipped', e);
+    }
+
     this.renderingEngine?.disableElement(viewportId);
 
     // clean up

--- a/Viewers/extensions/cornerstone/src/utils/measurementServiceMappings/utils/getSOPInstanceAttributes.js
+++ b/Viewers/extensions/cornerstone/src/utils/measurementServiceMappings/utils/getSOPInstanceAttributes.js
@@ -38,6 +38,24 @@ export default function getSOPInstanceAttributes(imageId, displaySetService, ann
 function _getUIDFromImageID(imageId) {
   const instance = cornerstone.metaData.get('instance', imageId);
 
+  // `metaData.get` returns undefined when the referenced image's metadata is no longer
+  // registered — e.g. an annotation event fires for a study whose metadata has already been
+  // torn down. Reading through it threw
+  //   "Cannot read properties of undefined (reading 'SOPInstanceUID')"
+  // which MeasurementService catches, logs as "Failed to map", and then RETHROWS from inside
+  // an event dispatch — aborting the remaining listeners for that annotation event.
+  // Returning undefined UIDs is the contract this function already uses for its other
+  // unresolvable case (the no-volumeId branch above), and the caller in SegmentBidirectional
+  // already guards with `if (SOPInstanceUID)`.
+  if (!instance) {
+    return {
+      SOPInstanceUID: undefined,
+      SeriesInstanceUID: undefined,
+      StudyInstanceUID: undefined,
+      frameNumber: 1,
+    };
+  }
+
   return {
     SOPInstanceUID: instance.SOPInstanceUID,
     SeriesInstanceUID: instance.SeriesInstanceUID,

--- a/Viewers/platform/app/.recipes/Nginx-Orthanc/dockerfile
+++ b/Viewers/platform/app/.recipes/Nginx-Orthanc/dockerfile
@@ -82,6 +82,11 @@ COPY ./backup/esm/OrientationMarkerTool.js /usr/src/app/node_modules/@cornerston
 # listeners could never be removed. ANNOTATION_* used the same ref on both sides and did not leak.
 COPY ./backup/esm/LabelmapEditWithContour.js /usr/src/app/node_modules/@cornerstonejs/tools/dist/esm/tools/segmentation/
 
+# THE ARCHITECTURAL ONE: destroyToolGroup only spliced the group out of an array and never
+# invoked any tool's onSetToolDisabled, so tools that registered on the global eventTarget
+# never cleaned up — and the listeners kept the tool instances alive.
+COPY ./backup/esm/destroyToolGroup.js /usr/src/app/node_modules/@cornerstonejs/tools/dist/esm/store/ToolGroupManager/
+
 # Add annotation from the given indices plus the detail rendering setup for each prompt type
 COPY ./backup/esm/ProbeTool.js /usr/src/app/node_modules/@cornerstonejs/tools/dist/esm/tools/annotation/
 COPY ./backup/esm/RectangleROITool.js /usr/src/app/node_modules/@cornerstonejs/tools/dist/esm/tools/annotation/

--- a/Viewers/platform/app/.recipes/Nginx-Orthanc/dockerfile
+++ b/Viewers/platform/app/.recipes/Nginx-Orthanc/dockerfile
@@ -72,6 +72,16 @@ COPY ./backup/esm/AnnotationTool.js /usr/src/app/node_modules/@cornerstonejs/too
 # cycle, monotonic, never reclaimed). Also fixes destroy() iterating arrays it splices.
 COPY ./backup/esm/Synchronizer.js /usr/src/app/node_modules/@cornerstonejs/tools/dist/esm/store/SynchronizerManager/
 
+# Same listener-leak family: both passed a FRESH function to removeEventListener, which can
+# never match, so every enable/subscribe added another global eventTarget listener.
+COPY ./backup/esm/stackContextPrefetch.js /usr/src/app/node_modules/@cornerstonejs/tools/dist/esm/utilities/stackPrefetch/
+COPY ./backup/esm/OrientationMarkerTool.js /usr/src/app/node_modules/@cornerstonejs/tools/dist/esm/tools/
+
+# cleanUpListeners removed with `.bind(this)` (a NEW function) while initializeListeners added
+# the stored *Binded refs — so TOOLGROUP_VIEWPORT_ADDED and SEGMENTATION_REPRESENTATION_MODIFIED
+# listeners could never be removed. ANNOTATION_* used the same ref on both sides and did not leak.
+COPY ./backup/esm/LabelmapEditWithContour.js /usr/src/app/node_modules/@cornerstonejs/tools/dist/esm/tools/segmentation/
+
 # Add annotation from the given indices plus the detail rendering setup for each prompt type
 COPY ./backup/esm/ProbeTool.js /usr/src/app/node_modules/@cornerstonejs/tools/dist/esm/tools/annotation/
 COPY ./backup/esm/RectangleROITool.js /usr/src/app/node_modules/@cornerstonejs/tools/dist/esm/tools/annotation/

--- a/Viewers/platform/app/.recipes/Nginx-Orthanc/dockerfile
+++ b/Viewers/platform/app/.recipes/Nginx-Orthanc/dockerfile
@@ -66,6 +66,12 @@ RUN rm -rf /usr/src/app/node_modules/@kitware/vtk.js/Filters/General/ImageMarchi
 # To change color of negative prompts
 COPY ./backup/esm/AnnotationTool.js /usr/src/app/node_modules/@cornerstonejs/tools/dist/esm/tools/base/
 
+# Listener-leak fix: _updateDisableHandlers built a FRESH closure each call, so its
+# removeEventListener never matched and every synchronizer lifecycle event added another
+# ELEMENT_DISABLED listener to the global eventTarget (measured +3 per study open/close
+# cycle, monotonic, never reclaimed). Also fixes destroy() iterating arrays it splices.
+COPY ./backup/esm/Synchronizer.js /usr/src/app/node_modules/@cornerstonejs/tools/dist/esm/store/SynchronizerManager/
+
 # Add annotation from the given indices plus the detail rendering setup for each prompt type
 COPY ./backup/esm/ProbeTool.js /usr/src/app/node_modules/@cornerstonejs/tools/dist/esm/tools/annotation/
 COPY ./backup/esm/RectangleROITool.js /usr/src/app/node_modules/@cornerstonejs/tools/dist/esm/tools/annotation/

--- a/Viewers/platform/core/src/services/ToolBarService/ToolbarService.ts
+++ b/Viewers/platform/core/src/services/ToolBarService/ToolbarService.ts
@@ -67,12 +67,33 @@ export default class ToolbarService extends PubSubService {
   }
 
   public reset(): void {
-    // this.unsubscriptions.forEach(unsub => unsub());
+    // LEAK FIX: this cleanup used to be commented out, and `_serviceSubscriptions` was a
+    // write-only array (pushed in registerEventForToolbarUpdate, never drained). reset() runs
+    // on every mode enter, and onModeEnter re-registers TOOL_ACTIVATED on the GLOBAL cornerstone
+    // eventTarget — so every study open added another listener that nothing ever removed.
+    // MEASURED: +1 CORNERSTONE_TOOLS_TOOL_ACTIVATED listener per open/close cycle, monotonic,
+    // each a distinct closure. Now safe to run because the addEventListener branch above
+    // returns a real unsubscribe instead of undefined (calling those undefined entries is what
+    // broke this originally).
+    const drain = list => {
+      list.forEach(unsub => {
+        if (typeof unsub === 'function') {
+          try {
+            unsub();
+          } catch (e) {
+            console.warn('ToolbarService: unsubscribe failed', e);
+          }
+        }
+      });
+    };
+    drain(this.unsubscriptions);
+    drain(this._serviceSubscriptions);
     this.state = {
       buttons: {},
       buttonSections: {},
     };
     this.unsubscriptions = [];
+    this._serviceSubscriptions = [];
   }
 
   public onModeEnter(): void {
@@ -105,7 +126,13 @@ export default class ToolbarService extends PubSubService {
       if (service.subscribe) {
         return service.subscribe(event, callback);
       } else if (service.addEventListener) {
-        return service.addEventListener(event, callback);
+        // LEAK FIX: addEventListener returns undefined, unlike subscribe() which returns an
+        // unsubscribe handle. Returning it directly stored `undefined` as the "unsubscription",
+        // so the listener could never be removed — and calling those undefined entries is what
+        // made the cleanup in reset() throw (hence it being commented out). Return a real
+        // closure over the SAME callback reference so removeEventListener can match it.
+        service.addEventListener(event, callback);
+        return () => service.removeEventListener(event, callback);
       }
     });
 


### PR DESCRIPTION
Six fixes for event-listener leaks and one measurement crash, extracted from the perf/telemetry work. **No telemetry or test tooling is included** — this branch is product code only.

The client leaked **27.5 listeners per study open/close cycle**, monotonic over a 30-cycle soak measured at rest after forced GC, with heap growing ~16 MB/cycle. After these six fixes: **~0.2 per cycle**.

Every one is the same defect class — a listener that could never be removed.

## The fixes

**`039c98f` — Synchronizer add/remove referenced different functions.** The root cause, and the hardest to find:

```js
addSource:    eventSource.addEventListener(this._eventName, this._onEvent.bind(this)); // fresh bind
removeSource: eventSource.removeEventListener(this._eventName, this._eventHandler);    // DIFFERENT function
```

`.bind()` returns a new function object every call, so removal never matched and no synchronizer source was ever detached. Both now use the stable instance arrow. Also adds the missing `onModeExit` to `SyncGroupService`.

**`0caa5be` — ToolbarService.** Its `addEventListener` branch returned a no-op unsubscribe, and `reset()` drained neither `unsubscriptions` nor `_serviceSubscriptions`.

**`231718b` — three more unremovable listeners.** `LabelmapEditWithContour` (cleanup used freshly-bound refs instead of the stored `*Binded` ones), `OrientationMarkerTool`, and `stackContextPrefetch` (WeakMap-stable handler).

**`170b9ff` — destroyToolGroup.** Spliced the array but never invoked each tool's `onSetToolDisabled()`, so no tool cleanup hook ever ran on tool-group destroy.

**`f37ecda` — stackContextPrefetch** self-cleans on `ELEMENT_DISABLED`.

**`26dcf3d` — measurement crash guard.** Fixes the user-reported `TypeError: Cannot read properties of undefined (reading 'SOPInstanceUID')` when referenced image metadata is gone. This one is a defensive guard with no teardown semantics — lowest risk in the set.

## How the root causes were found

Grepping produced only decoys. What worked: dumping `eventTarget.listeners` **per event type** at rest and checking same-ref vs distinct-ref, then **wrapping `addEventListener` at runtime to capture stack traces**. A useful elimination trick — when a subscriber registers the same handler for two events, compare their growth; a stable sibling exonerates it.

## Verification

- Listener counts re-measured after each fix; 27.5 → ~0.2 per cycle.
- All five `backup/esm` overrides confirmed **byte-identical in the shipped bundle** (compared against `sourcesContent` in the built source maps), not merely present in the build context.
- Cherry-picked cleanly onto current `main`; PR #90's two overrides remain wired.
- Verified independent of the telemetry branch: no fix file references `perfTrace`/`__ohifPerf`/`isPerfEnabled`, and no telemetry commit touches a fix file.

## Risk — please read before merging

**These change teardown behaviour that has never actually executed before.** Synchronizer source removal, in particular, now genuinely happens for the first time. Listener counts prove listeners are *removed*; they say nothing about whether the app still behaves correctly when they are.

Not yet clinically verified. The highest-risk paths to exercise:

1. **Linked scrolling / viewport sync** — enable sync, scroll, switch hanging protocol, return.
2. **MPR + hanging-protocol switching** — default → MPR → default, repeatedly; check tools and crosshairs.
3. **Study open → close → reopen** several times; behaviour on the 5th open should match the 1st.

`26dcf3d` alone could be split out if the teardown changes need to wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
