### PR TITLE
feat(perf): opt-in client, server and host telemetry with a scripted soak

### DIFF
--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -37,7 +37,8 @@ import {
 import { parseMultipart } from './utils/multipart';
 import { callInputDialog } from './utils/callInputDialog';
 import { getNninterToken, clearNninterToken } from './utils/nninterSession';
-import { describeBlocks, blockIndexForSegment, replaceBlockAt, appendBlock, flattenBlocks, flipIndex, withoutBlockAt, blockContains, clampRange, snapRangeToGrid, shouldShrinkBlock, sourceRangeForWorking, MIN_BLOCK_SLICES, BLOCK_GRID_SLICES, BLOCK_SHRINK_FACTOR } from './utils/labelmapBlocks';
+import { perf, installPerfHandle, setBlockStatsProvider, leakRetain } from './utils';
+import { summarizeBlocks, describeBlocks, blockIndexForSegment, replaceBlockAt, appendBlock, flattenBlocks, flipIndex, withoutBlockAt, blockContains, clampRange, snapRangeToGrid, shouldShrinkBlock, sourceRangeForWorking, MIN_BLOCK_SLICES, BLOCK_GRID_SLICES, BLOCK_SHRINK_FACTOR } from './utils/labelmapBlocks';
 // Separate: LabelmapBlock is a type, and isolatedModules requires type-only imports be marked so
 // the transpiler can erase them without resolving the module.
 import type { LabelmapBlock } from './utils/labelmapBlocks';
@@ -115,6 +116,37 @@ const commandsModule = ({
       setTimeout(() => runAiSegmentationCommand(), 0);
     }
   }
+
+  // Perf telemetry: no-ops unless ?perf=1 / localStorage.ohifPerf=1.
+  // Pass a navigate wrapper that always reads the live history.navigate reference
+  // (React Router wires it in Mode.tsx; passing the wrapper rather than the value
+  // avoids capturing a stale null if installPerfHandle runs before the first render).
+  installPerfHandle(commandsManager, servicesManager, (path: string) => history.navigate?.(path), toolboxState);
+
+  // Block stats come from describeBlocks(), which needs the live labelmap data + series
+  // length that only the segmentation paths hold. We cache the segmentationId and series
+  // length, then read LIVE state at snapshot time so we never report stale block counts.
+  // (cornerstone's SegmentationStateManager.updateState() deep-clones state on every
+  // mutation, so any object captured beforehand is permanently orphaned.)
+  let _lastLabelmapCtx: { segmentationId: string; sourceCount: number } | null = null;
+  setBlockStatsProvider(() => {
+    if (!_lastLabelmapCtx) return { segCount: -1, blockCount: -1, blockSlices: -1 };
+    const liveSeg = csToolsSegmentation.state.getSegmentation(_lastLabelmapCtx.segmentationId);
+    const lm = liveSeg?.representationData?.Labelmap;
+    if (!lm) return { segCount: -1, blockCount: -1, blockSlices: -1 };
+    const blockSummary = summarizeBlocks(describeBlocks(lm, _lastLabelmapCtx.sourceCount));
+    // segCount is the number of segments in live state — distinct from blockCount, which counts
+    // blocks. For a single-layer labelmap (SAM2 overlap=false), multiple segments share one block
+    // so blockCount < segCount. For a multi-block labelmap each segment has its own block so they
+    // may agree, but they are independently derived and can legitimately differ.
+    const segCount = liveSeg?.segments
+      ? Object.keys(liveSeg.segments).filter(k => {
+          const idx = Number(k);
+          return Number.isFinite(idx) && idx > 0;
+        }).length
+      : -1;
+    return { ...blockSummary, segCount };
+  });
 
   // Loop guard for session-expired auto-recovery: if a second recovery is
   // needed within 5s the pool is thrashing (capacity pressure) — stop and
@@ -939,6 +971,7 @@ const commandsModule = ({
     // Block count from the block LIST, not allImageIds.length / N — blocks can be shorter than the
     // series once they are z-cropped, so that division no longer counts them.
     const prevBlockCount = describeBlocks(prevLabelmap, imageIds.length).length;
+    if (perf.enabled) _lastLabelmapCtx = { segmentationId, sourceCount: imageIds.length };
 
     const { blockCount, labelmapRepresentation } = buildMultiBlockLabelmapRepresentation({
       segmentationId,
@@ -1528,6 +1561,7 @@ const commandsModule = ({
     },
 
     async sam2() {
+      const _perfT0 = performance.now();
       if (!beginInferenceRunOrQueue()) {
         return;
       }
@@ -1785,6 +1819,7 @@ const commandsModule = ({
                 activeSegmentation.representationData.Labelmap,
                 imageIds.length
               );
+              if (perf.enabled) _lastLabelmapCtx = { segmentationId, sourceCount: imageIds.length };
               existing = true;
             }
           }
@@ -2033,6 +2068,8 @@ const commandsModule = ({
           });
           const end = Date.now();
           console.log(`Time taken: ${(end - start)/1000} Seconds`);
+          perf.measure('sam2', _perfT0);
+          perf.snapshot('afterSam2');
           return response;
         }
       } catch (error) {
@@ -2226,6 +2263,7 @@ const commandsModule = ({
       const _seriesLen: number =
         (labelmapState?.allReferencedImageIds ?? labelmapState?.referencedImageIds ?? []).length;
       const _undoBlocks = describeBlocks(labelmapState, _seriesLen);
+      if (perf.enabled) _lastLabelmapCtx = { segmentationId, sourceCount: _seriesLen };
       const _undoBlockIdx = blockIndexForSegment(_undoBlocks, segmentNumber);
       // Fall back to z0 = 0 ONLY for the legacy uniform layout, where the layer genuinely spans
       // the whole series. Guessing 0 for a cropped block would clear and rewrite the wrong slices.
@@ -2529,6 +2567,7 @@ const commandsModule = ({
       // would flow into buildMultiBlockLabelmapRepresentation as imageIds: [].
       if (srcIds.length === 0) return;
       const blocks = describeBlocks(lm, srcIds.length);
+      if (perf.enabled) _lastLabelmapCtx = { segmentationId, sourceCount: srcIds.length };
       // Keep at least one block: cornerstone needs a primary labelmap to render at all.
       if (blocks.length <= 1) return;
       const bIdx = blockIndexForSegment(blocks, segmentIndex);
@@ -2622,6 +2661,7 @@ const commandsModule = ({
     },
 
     async resetSegment({ segmentationId, segmentIndex }: { segmentationId: string; segmentIndex: number }) {
+      const _perfT0 = performance.now();
       // Reset zeroes the block IMAGES; land any deferred in-place write first so it can't be
       // re-applied afterwards and resurrect the segment.
       materializePendingImageSync(segmentationId);
@@ -2734,6 +2774,8 @@ const commandsModule = ({
           new CustomEvent(csToolsEnums.Events.SEGMENTATION_DATA_MODIFIED, { detail: { segmentationId } })
         );
       }, 0);
+      perf.measure('segReset', _perfT0);
+      perf.snapshot('afterSegReset');
     },
     async medGemma(
       query: string,
@@ -3301,6 +3343,7 @@ const commandsModule = ({
       }
     },
     async nninter(textPrompts?: string | string[]) {
+      const _perfT0 = performance.now();
       if (!beginInferenceRunOrQueue()) {
         return;
       }
@@ -3545,7 +3588,9 @@ const commandsModule = ({
               clearNninterToken();
               await getNninterToken();
               await actions.initNninter();
-              return actions.nninter(textPrompts);
+              const _recovered = await actions.nninter(textPrompts);
+              perf.measure('nninterRecovered', _perfT0);
+              return _recovered;
             }
             if (!seg.length) {
               throw new Error('seg part not found');
@@ -4106,6 +4151,7 @@ const commandsModule = ({
         }
           
                     
+          leakRetain(merged_derivedImages);
           const derivedImageIds = merged_derivedImages.map(image => image.imageId);
           segments[segmentNumber] = {
             segmentIndex: segmentNumber,
@@ -4149,6 +4195,8 @@ const commandsModule = ({
           for (const _oid of _orphanedImageIds) {
             try { cache.removeImageLoadObject(_oid, { force: true }); } catch { /* already gone */ }
           }
+          perf.measure('nninter', _perfT0);
+          perf.snapshot('afterRefine');
           return response;
         }
       } catch (error) {

--- a/Viewers/extensions/default/src/utils/index.ts
+++ b/Viewers/extensions/default/src/utils/index.ts
@@ -1,2 +1,3 @@
 export { addIcon } from './addIcon';
 export * from './Toolbox';
+export { perf, installPerfHandle, setBlockStatsProvider, leakRetain } from './perfTraceBrowser';

--- a/Viewers/extensions/default/src/utils/labelmapBlocks.ts
+++ b/Viewers/extensions/default/src/utils/labelmapBlocks.ts
@@ -306,3 +306,21 @@ export function segmentBlockRange(
 
   return { z0, sliceStart, sliceEnd, reverse };
 }
+
+/**
+ * Perf telemetry helper. With sparse (z-cropped) blocks the meaningful memory
+ * proxy is the TOTAL SLICE COUNT across blocks, not the block count — a segment
+ * cropped to 30 slices costs far less than one spanning 694.
+ */
+export function summarizeBlocks(
+  blocks: Array<{ imageIds: string[] }> | null | undefined
+): { segCount: number; blockCount: number; blockSlices: number } {
+  if (!Array.isArray(blocks)) {
+    return { segCount: -1, blockCount: -1, blockSlices: -1 };
+  }
+  return {
+    segCount: blocks.length,
+    blockCount: blocks.length,
+    blockSlices: blocks.reduce((a, b) => a + (b.imageIds?.length ?? 0), 0),
+  };
+}

--- a/Viewers/extensions/default/src/utils/perfTrace.ts
+++ b/Viewers/extensions/default/src/utils/perfTrace.ts
@@ -1,0 +1,123 @@
+export interface PerfSample {
+  t: number; cycle: number; phase: string;
+  heapMB: number; cacheMB: number; volCount: number; volMB: number;
+  volUnsized: number;
+  imgCount: number; segCount: number; blockCount: number; blockSlices: number;
+  viewportCount: number; listenerCount: number;
+  // Optional extras forwarded from snapshot(phase, extra) — e.g. wallT, studyUID.
+  [key: string]: unknown;
+}
+
+export interface PerfDeps {
+  now(): number;
+  getHeapBytes(): number;
+  getCacheBytes(): number;
+  getVolumes(): Array<{ sizeInBytes: number }>;
+  getImageCount(): number;
+  getBlockStats(): { segCount: number; blockCount: number; blockSlices: number };
+  getViewportCount(): number;
+  getListenerCount(): number;
+}
+
+export interface PerfTrace {
+  enabled: boolean;
+  setCycle(n: number): void;
+  snapshot(phase: string, extra?: Record<string, unknown>): PerfSample | null;
+  measure(name: string, startMs: number, extra?: Record<string, number>): void;
+  dump(): string;
+  reset(): void;
+}
+
+const MB = 1024 * 1024;
+
+/** Never let instrumentation break the app: a failing counter reports -1. */
+function safe<T>(fn: () => T, fallback: T): T {
+  try {
+    return fn();
+  } catch {
+    return fallback;
+  }
+}
+
+export function createPerfTrace(deps: PerfDeps, enabled: boolean): PerfTrace {
+  if (!enabled) {
+    return {
+      enabled: false,
+      setCycle: () => undefined,
+      snapshot: (_phase: string, _extra?: Record<string, unknown>) => null,
+      measure: () => undefined,
+      dump: () => '',
+      reset: () => undefined,
+    };
+  }
+
+  const records: string[] = [];
+  let cycle = 0;
+
+  const snapshot = (phase: string, extra?: Record<string, unknown>): PerfSample => {
+    const vols = safe(() => deps.getVolumes(), null);
+    const blockStats = safe(() => deps.getBlockStats(), null);
+    const sample: PerfSample = {
+      t: safe(() => deps.now(), -1),
+      cycle,
+      phase,
+      heapMB: safe(() => deps.getHeapBytes() / MB, -1),
+      cacheMB: safe(() => deps.getCacheBytes() / MB, -1),
+      volCount: vols === null ? -1 : vols.length,
+      // volMB is a partial sum over volumes that HAVE a finite sizeInBytes.
+      // Still-loading streaming volumes and geometry/labelmap volumes typically
+      // lack a computed size — returning -1 for ANY non-finite entry would make
+      // this counter permanently NO_DATA in a real viewer. Instead we sum the
+      // finite subset and report how many were excluded via volUnsized.
+      // If NO volume has a finite size, volMB stays -1 (nothing could be measured).
+      volMB: vols === null ? -1 : safe(() => {
+        if (vols.length === 0) return 0;
+        const unsizedCount = vols.filter(v => !Number.isFinite(v.sizeInBytes)).length;
+        if (unsizedCount === vols.length) return -1;
+        return vols.filter(v => Number.isFinite(v.sizeInBytes)).reduce((a, v) => a + v.sizeInBytes, 0) / MB;
+      }, -1),
+      // Count of volumes whose sizeInBytes is missing or non-finite (not counted in volMB).
+      // A GROWING volUnsized means the volMB trend is measuring a shifting subset and
+      // cannot be trusted. A STABLE volUnsized means the undercount is constant and
+      // the volMB slope is still meaningful.
+      volUnsized: vols === null ? -1 : safe(() => {
+        if (vols.length === 0) return 0;
+        return vols.filter(v => !Number.isFinite(v.sizeInBytes)).length;
+      }, -1),
+      imgCount: safe(() => deps.getImageCount(), -1),
+      viewportCount: safe(() => deps.getViewportCount(), -1),
+      listenerCount: safe(() => deps.getListenerCount(), -1),
+      segCount: blockStats === null ? -1 : (typeof blockStats.segCount === 'number' ? blockStats.segCount : -1),
+      blockCount: blockStats === null ? -1 : (typeof blockStats.blockCount === 'number' ? blockStats.blockCount : -1),
+      blockSlices: blockStats === null ? -1 : (typeof blockStats.blockSlices === 'number' ? blockStats.blockSlices : -1),
+      ...(extra || {}),
+    };
+    records.push(JSON.stringify({ kind: 'sample', ...sample }));
+    return sample;
+  };
+
+  return {
+    enabled: true,
+    setCycle: (n: number) => {
+      cycle = n;
+    },
+    snapshot,
+    measure: (name, startMs, extra) => {
+      const now = safe(() => deps.now(), null);
+      records.push(
+        JSON.stringify({
+          kind: 'measure',
+          t: now === null ? -1 : now,
+          cycle,
+          name,
+          durMs: now === null ? -1 : (now - startMs),
+          ...(extra || {}),
+        })
+      );
+    },
+    dump: () => records.join('\n'),
+    reset: () => {
+      records.length = 0;
+    },
+  };
+}

--- a/Viewers/extensions/default/src/utils/perfTraceBrowser.ts
+++ b/Viewers/extensions/default/src/utils/perfTraceBrowser.ts
@@ -1,0 +1,229 @@
+import { cache, eventTarget, getRenderingEngines } from '@cornerstonejs/core';
+import { createPerfTrace, PerfDeps, PerfTrace } from './perfTrace';
+
+/**
+ * Reads the perf-enabled flag from two sources:
+ * - `?perf=1` in the query string
+ * - `ohifPerf = '1'` in localStorage (useful for private-browsing where query
+ *   params are not persisted across reloads)
+ *
+ * Both `search` and `storage` are injected so the function can be tested
+ * without touching `window`.
+ */
+export function isPerfEnabled(search: string, storage: Pick<Storage, 'getItem'> | null): boolean {
+  if (new URLSearchParams(search).get('perf') === '1') {
+    return true;
+  }
+  try {
+    return storage?.getItem('ohifPerf') === '1';
+  } catch {
+    // storage can throw in private-browsing modes in some browsers
+    return false;
+  }
+}
+
+/**
+ * Wires real cornerstone 5.0.13 accessors to the PerfDeps interface.
+ *
+ * `_imageCache` and `listeners` are PRIVATE in cornerstone 5.0.13 — there is
+ * no public accessor for either. Both are read defensively: if a future version
+ * renames or removes them the counter degrades to -1 rather than silently
+ * reporting a plausible-looking value (e.g. 0) that would mask a real leak.
+ */
+export function buildCornerstoneDeps(
+  cs: { cache: any; eventTarget: any; getRenderingEngines: () => any[] },
+  getBlockStats: () => { segCount: number; blockCount: number; blockSlices: number }
+): PerfDeps {
+  return {
+    now: () => performance.now(),
+    getHeapBytes: () => (performance as any).memory?.usedJSHeapSize ?? -1,
+    getCacheBytes: () => cs.cache.getCacheSize(),
+    getVolumes: () => {
+      if (typeof cs.cache?.getVolumes !== 'function') {
+        throw new Error('cache.getVolumes unavailable');
+      }
+      return cs.cache.getVolumes();
+    },
+    getImageCount: () => {
+      const m = cs.cache?._imageCache;
+      return m && typeof m.size === 'number' ? m.size : -1;
+    },
+    getBlockStats,
+    getViewportCount: () => {
+      if (typeof cs.getRenderingEngines !== 'function') {
+        return -1;
+      }
+      const engines = cs.getRenderingEngines();
+      if (!Array.isArray(engines)) {
+        return -1;
+      }
+      for (const re of engines) {
+        if (typeof re.getViewports !== 'function') return -1;
+        const vps = re.getViewports();
+        if (!Array.isArray(vps)) return -1;
+      }
+      return engines.reduce(
+        (acc: number, re: any) => acc + (re.getViewports().length),
+        0
+      );
+    },
+    getListenerCount: () => {
+      const l = cs.eventTarget?.listeners;
+      if (!l || typeof l !== 'object') {
+        return -1;
+      }
+      return Object.values(l).reduce<number>(
+        (acc, v) => acc + (Array.isArray(v) ? v.length : 0),
+        0
+      );
+    },
+  };
+}
+
+/**
+ * Block-stats provider. Starts as a stub that reports -1 for all fields;
+ * Task 3 wires in the real implementation via `setBlockStatsProvider` to avoid
+ * creating an import cycle with the segmentation layer here.
+ */
+let blockStatsProvider: () => { segCount: number; blockCount: number; blockSlices: number } = () => ({
+  segCount: -1,
+  blockCount: -1,
+  blockSlices: -1,
+});
+
+export function setBlockStatsProvider(
+  fn: () => { segCount: number; blockCount: number; blockSlices: number }
+): void {
+  blockStatsProvider = fn;
+}
+
+// ---------------------------------------------------------------------------
+// Singleton — evaluated once at module load.
+// When the flag is off, `createPerfTrace` returns no-op stubs bound once;
+// the deps object passed is unused by the disabled path so we pass a bare {}.
+// `window.__ohifPerf` is never set when disabled.
+//
+// IMPORTANT: `window.localStorage` is accessed INSIDE isPerfEnabled's try/catch
+// (not directly here) so that a browser with storage blocked (SecurityError)
+// degrades to perf-disabled instead of crashing the entire default extension at
+// module load (which re-exports this module via utils/index.ts).
+// ---------------------------------------------------------------------------
+let _storage: Pick<Storage, 'getItem'> | null = null;
+if (typeof window !== 'undefined') {
+  try {
+    _storage = window.localStorage;
+  } catch {
+    // Storage blocked (e.g. Safari with "Block All Cookies") — perf stays off.
+    _storage = null;
+  }
+}
+
+const enabled =
+  typeof window !== 'undefined' &&
+  isPerfEnabled(window.location.search, _storage);
+
+export const perf: PerfTrace = createPerfTrace(
+  enabled
+    ? buildCornerstoneDeps({ cache, eventTarget, getRenderingEngines }, () => blockStatsProvider())
+    : ({} as PerfDeps),
+  enabled
+);
+
+export function isPerfLeakEnabled(search: string): boolean {
+  return new URLSearchParams(search).get('perfLeak') === '1';
+}
+
+const leakEnabled = typeof window !== 'undefined' && isPerfLeakEnabled(window.location.search);
+const _leakStore: unknown[] = [];
+let _leakWarnedOnce = false;
+
+/** Bytes of synthetic ballast retained per call. Sized so a short soak produces an
+ *  unmistakable heapMB ramp: the control must never under-fire, because a weak signal
+ *  would be misread as "the detector is broken". */
+const _LEAK_BALLAST_BYTES = 8 * 1024 * 1024;
+
+/**
+ * POSITIVE CONTROL ONLY. Retains a reference so the analyzer has a known-leaking
+ * run to prove it can detect. Never enabled outside a validation soak.
+ *
+ * When enabled (via `?perfLeak=1`), this function retains BOTH:
+ * 1. The passed real object — maintaining realistic object shape
+ * 2. Fixed-size synthetic ballast (~8 MB per call) — ensuring deterministic magnitude
+ *
+ * The synthetic ballast guarantees the control cannot silently under-fire: even if
+ * the real object is already cached elsewhere, the ballast ensures a predictable,
+ * unmistakable heap growth. This makes the leak detector's signal unambiguous.
+ */
+export function leakRetain(obj: unknown): void {
+  if (!leakEnabled) {
+    return;
+  }
+  if (!_leakWarnedOnce) {
+    _leakWarnedOnce = true;
+    console.warn(
+      '[perfLeak] POSITIVE CONTROL ACTIVE — leakRetain is retaining ~8 MB per call. ' +
+      'This is a deliberate leak detector validation run. Do NOT leave ?perfLeak=1 in production.'
+    );
+  }
+  _leakStore.push(obj);
+  // Touch the buffer so it is really committed, not lazily-mapped zero pages.
+  const ballast = new Uint8Array(_LEAK_BALLAST_BYTES);
+  ballast[0] = _leakStore.length & 0xff;
+  ballast[ballast.length - 1] = 1;
+  _leakStore.push(ballast);
+}
+
+/**
+ * Installs `window.__ohifPerf` for the Playwright soak driver.
+ * A no-op when perf is disabled so call-sites do not need to guard.
+ *
+ * @param commandsManager - OHIF commands manager
+ * @param servicesManager - OHIF services manager
+ * @param navigate - Optional React Router navigate function for client-side
+ *   navigation without a full document reload. When provided, exposed as
+ *   `window.__ohifPerf.navigate` so the soak driver can switch studies
+ *   without destroying the JS realm and resetting all counters.
+ * @param toolboxState - Optional toolboxState singleton. When provided,
+ *   exposed as `window.__ohifPerf.toolboxState` so the soak driver can
+ *   set liveMode / selectedModel / locked before prompting, causing the
+ *   real MEASUREMENT_ADDED subscription to fire inference instead of a
+ *   direct runAiSegmentation call.
+ */
+export function installPerfHandle(
+  commandsManager: unknown,
+  servicesManager: unknown,
+  navigate?: ((path: string) => void) | null,
+  toolboxState?: unknown
+): void {
+  if (!perf.enabled || typeof window === 'undefined') {
+    return;
+  }
+  (window as any).__ohifPerf = {
+    snapshot: (phase: string, extra?: Record<string, unknown>) => perf.snapshot(phase, extra),
+    dump: () => perf.dump(),
+    reset: () => perf.reset(),
+    setCycle: (n: number) => perf.setCycle(n),
+    /**
+     * Trigger a GC cycle.  Requires --js-flags=--expose-gc on the browser
+     * launch command; the soak driver asserts `typeof window.gc === 'function'`
+     * before cycle 1 (I11) and fails the test if this is absent.
+     */
+    forceGC: () => (globalThis as any).gc(),
+    /**
+     * Client-side navigation — does NOT reload the document.
+     * Provided so the soak driver can switch studies while keeping the same
+     * JS realm, preserving all module-level counters and caches for
+     * accurate cross-cycle trend detection.
+     */
+    navigate: navigate ?? null,
+    commandsManager,
+    servicesManager,
+    /**
+     * toolboxState singleton — exposed so the soak driver can arm
+     * liveMode + selectedModel before clicking, allowing the real
+     * MEASUREMENT_ADDED subscription to drive inference.  Unreachable
+     * when perf is off (early-return above prevents the entire block).
+     */
+    toolboxState: toolboxState ?? null,
+  };
+}

--- a/monai-label/monailabel/tasks/infer/basic_infer.py
+++ b/monai-label/monailabel/tasks/infer/basic_infer.py
@@ -43,6 +43,15 @@ from monailabel.transform.cache import CacheTransformDatad
 from monailabel.transform.writer import ClassificationWriter, DetectionWriter, Writer
 from monailabel.utils.others.generic import device_list, device_map, name_to_device
 
+try:
+    from monailabel.utils.others.perf_trace import counters_suffix, leak_enabled
+except Exception:  # optional telemetry must never break the inference server
+    def counters_suffix(session=None):
+        return ""
+
+    def leak_enabled():
+        return False
+
 # Disable Transparent Huge Pages for this (long-lived, ~120GB-VmSize) server
 # process. Profiled root cause of intermittent 12-20s init stalls: the large
 # per-request allocations — the 336MB np.load of the img_np disk cache and
@@ -232,6 +241,15 @@ _boot_warmup_done = threading.Event()
 # Guards the once-per-process MainThread cuDNN warmup. Only ever touched from the
 # inference (MainThread) path, so no lock is needed.
 _mainthread_cudnn_warmed = False
+
+# POSITIVE CONTROL ONLY (MONAI_PERF_LEAK=1). Retains fixed-size ballast per request so
+# the soak analyzer has a known-leaking run to prove it can detect one.
+# Deliberately NOT the session object: a session pins a ~1.3GB interactions tensor, so
+# retaining one per cycle could OOM the GPU server this control is meant to validate.
+# Ballast gives the same detectable rss ramp with a bounded, predictable cost.
+_PERF_LEAK_BALLAST_BYTES = 64 * 1024 * 1024  # 64 MB per retained buffer
+_PERF_LEAK_MAX_BYTES = 4 * 1024 * 1024 * 1024  # 4 GB hard ceiling; never OOM the server
+_PERF_LEAK_STORE = []
 
 
 def _warm_mainthread_cudnn() -> None:
@@ -2484,12 +2502,18 @@ class BasicInferTask(InferTask):
             # Components now sum: img_convert + prompt_prep + model_core + loop_overhead
             # + result_retrieve + pre_dispatch == total_nninter. load is a SIBLING
             # window (DICOM I/O before the nnInter block): load + total_nninter ≈ total_request.
+            if leak_enabled():
+                if len(_PERF_LEAK_STORE) * _PERF_LEAK_BALLAST_BYTES < _PERF_LEAK_MAX_BYTES:
+                    _buf = bytearray(_PERF_LEAK_BALLAST_BYTES)
+                    _buf[0] = len(_PERF_LEAK_STORE) & 0xFF
+                    _buf[-1] = 1
+                    _PERF_LEAK_STORE.append(_buf)
             logger.info(
                 f"[timing] load={server_load_elapsed:.3f}s | img_convert={img_convert_elapsed:.3f}s  "
                 f"prompt_prep={prompt_prep_elapsed:.3f}s  model_core={nninter_core_elapsed:.3f}s  "
                 f"loop_overhead={loop_overhead:.3f}s  result_retrieve={result_elapsed:.3f}s  "
                 f"pre_dispatch={pre_dispatch:.3f}s  total_nninter={nninter_elapsed:.3f}s | "
-                f"total_request={time.time()-begin:.3f}s"
+                f"total_request={time.time()-begin:.3f}s" + counters_suffix(session)
             )
 
             final_result_json["prompt_info"] = result_json

--- a/monai-label/monailabel/utils/others/perf_trace.py
+++ b/monai-label/monailabel/utils/others/perf_trace.py
@@ -1,0 +1,82 @@
+"""Opt-in perf/leak counters appended to the existing [timing] log line.
+
+Everything here is gated on MONAI_PERF_TRACE=1. When unset, no counter is
+evaluated -- torch.cuda.memory_allocated() forces a device sync and must not
+run on the hot path by default.
+"""
+
+import logging
+import os
+import threading
+import time
+
+logger = logging.getLogger(__name__)
+
+_MB = 1024 * 1024
+
+
+def perf_enabled() -> bool:
+    return os.environ.get("MONAI_PERF_TRACE", "0") == "1"
+
+
+def leak_enabled() -> bool:
+    return os.environ.get("MONAI_PERF_LEAK", "0") == "1"
+
+
+def _rss_mb() -> float:
+    # /proc/self/statm field 2 is resident pages; avoids a psutil dependency.
+    with open("/proc/self/statm", "r") as f:
+        return int(f.read().split()[1]) * os.sysconf("SC_PAGE_SIZE") / _MB
+
+
+def _safe(fn, fallback=-1):
+    try:
+        return fn()
+    except Exception:
+        return fallback
+
+
+def counters(session=None) -> dict:
+    """Counter snapshot. Every field degrades to -1 rather than raising."""
+    if not perf_enabled():
+        return {}
+
+    def _vram(kind):
+        import torch
+
+        if not torch.cuda.is_available():
+            return -1
+        fn = torch.cuda.memory_allocated if kind == "alloc" else torch.cuda.memory_reserved
+        return fn() / _MB
+
+    def _sessions():
+        from monailabel.tasks.infer.nninter_session_pool import get_pool
+
+        return get_pool().size()
+
+    return {
+        "rss": _safe(_rss_mb),
+        "vram_alloc": _safe(lambda: _vram("alloc")),
+        "vram_reserved": _safe(lambda: _vram("reserved")),
+        "sessions": _safe(_sessions),
+        "threads": _safe(threading.active_count),
+        # Per-session executor backlog -- the PR #69 preprocess-backlog signal.
+        # CAVEAT: qsize() counts only QUEUED tasks; work already running on a worker has
+        # been dequeued and is not counted. A saturated pool with an empty queue reports 0,
+        # so this detects a growing BACKLOG, not worker saturation.
+        "queue_depth": _safe(lambda: session.executor._work_queue.qsize()) if session is not None else -1,
+    }
+
+
+def counters_suffix(session=None) -> str:
+    c = counters(session)
+    if not c:
+        return ""
+    # wallT is the join key for the analyzer: epoch milliseconds, emitted first so
+    # the field is always present for logs produced after this change ships.
+    wall_ms = int(time.time() * 1000)
+    parts = f"wallT={wall_ms} " + " ".join(
+        f"{k}={v:.1f}MB" if k in ("rss", "vram_alloc", "vram_reserved") else f"{k}={v}"
+        for k, v in c.items()
+    )
+    return f" | {parts}"

--- a/tools/perf/.gitignore
+++ b/tools/perf/.gitignore
@@ -1,0 +1,5 @@
+runs/
+reports/
+# Holds DICOM UIDs from a real archive plus machine-specific URLs.
+# Copy fixture.example.json to fixture.json and fill in your own.
+fixture.json

--- a/tools/perf/README.md
+++ b/tools/perf/README.md
@@ -1,0 +1,184 @@
+# Perf telemetry & leak soak
+
+Flag-gated instrumentation for the OHIF viewer, the MONAI Label inference server, and the host.
+**Everything is OFF by default.** With all flags off, `main` behaves exactly as before: no-op stubs
+bound once at module load, `window.__ohifPerf` undefined, the server's `[timing]` line byte-identical,
+and `torch.cuda` never touched (it forces a device sync).
+
+| Flag | Effect |
+|---|---|
+| `?perf=1` or `localStorage.ohifPerf=1` | client telemetry + `window.__ohifPerf` |
+| `MONAI_PERF_TRACE=1` | server counters appended to the `[timing]` line |
+| `?perfLeak=1` (via `PERF_LEAK=1` env for the soak) | client positive control — retains 8 MB/call |
+| `MONAI_PERF_LEAK=1` | server positive control — retains 64 MB/request, hard-capped at 4 GB |
+
+---
+
+## Read this before the first run
+
+Three whole-branch reviews produced two operator-facing warnings. Both will cost you a run if ignored.
+
+**1. `docker-compose.yml` has no `MONAI_PERF_TRACE` passthrough.** That file is deliberately never
+committed (it carries your local port/GPU edits), so you must add this by hand under
+`monai_server.environment`:
+
+```yaml
+      - MONAI_PERF_TRACE=${MONAI_PERF_TRACE:-0}
+      - MONAI_PERF_LEAK=${MONAI_PERF_LEAK:-0}
+```
+
+Setting the variable in your shell alone does **nothing** — compose only forwards what the service
+lists. Without this the server stream is `INCONCLUSIVE` by construction.
+`docker compose restart` does **not** re-read environment variables; use `--force-recreate`.
+
+**2. Run `node tools/perf/preflight.js` first** (see below), then do a 3-cycle smoke run before the 30-cycle soak. `promptPoints` in `fixture.json` are
+normalized canvas coordinates that have **never been executed against a real render**. This is the
+single most likely thing to fail. The driver asserts a segment actually appeared and fails loudly, so
+a bad coordinate aborts rather than soaking a no-op — but expect to tune those numbers.
+
+---
+
+## REQUIRED: pre-flight instrument check
+
+**Run this before every soak.** It loads the fixture study in a real browser, samples the
+client counters in stack and MPR, and fails if any instrument cannot be read.
+
+```bash
+node tools/perf/preflight.js          # uses fixture.json's primary study
+```
+
+Uses the system Chrome (`/usr/bin/google-chrome` is present on this host) via Playwright's
+`channel: 'chrome'` — no `npx playwright install` download required.
+
+Why it is required, not optional: every client counter is unit-tested against fake objects,
+and several only fail on contact with real cornerstone state. Three whole-branch code reviews
+missed three separate `volMB` defects that this check found in one run — including one that
+would have made **every** soak report `INCONCLUSIVE`. It costs a minute; a soak costs an hour
+of shared GPU time.
+
+Known and accepted: `volMB` is unreadable in cornerstone 5.x (streaming voxel managers have no
+materialized scalar data, so `ImageVolume.sizeInBytes` throws). It is allow-listed in
+`analyze.py` so it cannot block a verdict. `volCount` is the load-bearing volume-leak signal —
+this project's historic MPR leak showed up as `volCount` growing while `cacheMB` stayed flat.
+
+
+## Running a soak
+
+```bash
+# 0. add the compose passthrough above (uncommitted), then:
+docker compose build ohif_viewer monai_server
+MONAI_PERF_TRACE=1 docker compose up -d --force-recreate ohif_viewer monai_server
+docker exec monai_server printenv MONAI_PERF_TRACE      # must print 1
+
+# 1. host sampler (read-only; never modifies a container)
+bash tools/perf/sample_host.sh &
+
+# 2. VERIFY THE FIRST 3 TICKS before continuing — see "Sanity checks" below
+
+# 3. smoke run: set cycles=3, refinesPerCycle=1 in fixture.json first
+cd Viewers && npx playwright test --config ../tools/perf/playwright.perf.config.ts
+
+# 4. full soak (restore cycles=30, refinesPerCycle=5)
+cd Viewers && npx playwright test --config ../tools/perf/playwright.perf.config.ts
+
+# 5. analyze
+python3 tools/perf/analyze.py --server <(docker compose logs monai_server)
+
+# 6. clean up ONLY the SEGs this run created — dry run first, always
+python3 tools/perf/cleanup_orthanc.py            # review the "would delete" list
+python3 tools/perf/cleanup_orthanc.py --apply
+```
+
+### Sanity checks that are not optional
+
+Read the sampler's **first three ticks** and confirm all of:
+
+- `container` records for **all three** of `ohif_viewer`, `ohif_orthanc`, `monai_server`
+- at least one `gpu` record
+- `disk` records for **both** `orthanc-db` and `img_cache`
+
+A missing series is now named as `NO_DATA` and forces `INCONCLUSIVE` (it used to vanish silently and
+read CLEAN) — but catching it at tick 3 beats discovering it after an hour.
+
+The real sampler cadence is **~4.5 s**, not the 2 s the gap detector assumes, so an occasional
+spurious gap warning is expected when `du` runs long on the 2.4 GB Orthanc DB.
+
+---
+
+## Validating the detector before trusting a green result
+
+A clean report is only meaningful if the detector demonstrably fires. Run a short soak with both
+controls armed:
+
+```bash
+MONAI_PERF_TRACE=1 MONAI_PERF_LEAK=1 docker compose up -d --force-recreate monai_server
+PERF_LEAK=1 npx playwright test --config ../tools/perf/playwright.perf.config.ts
+```
+
+Expected: **`LEAK/DEGRADED FOUND`**, with `heapMB` showing a Tier-2 slope whose CI excludes zero and
+`server.rssMB` climbing. The run asserts that `[perfLeak] POSITIVE CONTROL ACTIVE` was actually
+observed, so a control that failed to arm aborts instead of producing a misleading pass.
+
+**Do not expect Tier 1 to move.** The client control retains image *references*, growing the heap
+without creating volumes or blocks. Tier 1's growth-detection logic is pinned by the `analyze.py`
+unit tests instead. If `heapMB` comes back CLEAN, the detector is broken — stop and fix it.
+
+`MONAI_PERF_LEAK=1` costs up to **4 GB RSS** on a shared machine. Check free memory first.
+
+---
+
+## Reading the report
+
+**Verdict-bearing rows** — these are the ones that matter:
+
+| Tier | Counters | Phase |
+|---|---|---|
+| 1 (must return to baseline) | `volCount`, `listenerCount`, `viewportCount` | `cycleEnd` (at rest) |
+| 1 | `segCount`, `blockCount`, `blockSlices` | `studyOpen` (in-study — they don't exist at rest) |
+| 2 (slope must span zero) | `heapMB`, `cacheMB`, `server.rssMB`, `server.vramMB`, per-container `memMB` | `cycleEnd` |
+| 3 (degradation) | `nninter`, `nninterRecovered` | per-action |
+
+**Informational rows are excluded from the verdict on purpose:**
+- `host.diskMB[orthanc-db]` — the soak writes ~10 SEGs into the DB it measures, so it always grows.
+- `host.gpuMB[*]` — **all** GPU rows, including the one our server runs on. `nvidia-smi
+  --query-gpu=memory.used` is per-DEVICE and this is a shared DGX: measured on GPU 7,
+  `monai_server` held 826 MiB of 26,929 MiB in use. A neighbouring job would swamp or fake a
+  leak. `--pinned-gpu` (default 7) now only *labels* which row is ours.
+  **`server.vramMB` is the only VRAM signal that can support a verdict** — it comes from
+  `torch.cuda.memory_allocated()` inside our own process, so it is correctly attributed.
+  Without `--server`, VRAM is effectively unmonitored for verdict purposes.
+- `volMB` — allow-listed: cornerstone 5.x streaming voxel managers make `sizeInBytes` throw, so it
+  is usually NO_DATA. `volCount` (Tier 1) is the load-bearing volume-leak signal.
+
+**`INCONCLUSIVE` is a failed run, not a soft pass.** It means a collector produced nothing. Read the
+named reason, fix the collector, re-soak. A verdict of `CLEAN` from a half-broken pipeline is the one
+outcome this whole tool exists to prevent, so missing data is escalated rather than ignored.
+
+Slopes below `--min-slope` (default 0.2 MB/cycle, the spec's own floor) report CLEAN even when
+statistically tight — sub-megabyte drift over a whole run is not a leak.
+
+---
+
+## What a CLEAN verdict does *not* cover
+
+Record these alongside any green result; the soak does not exercise them:
+
+- **SEG export → reload.** The soak exports but never reloads. Given this project's history, SEG
+  reload is its most leak-prone path, and `blockCount`/`blockSlices` is precisely the instrument
+  built to catch it. This is the most consequential gap.
+- **SAM2**, `remount`/`postSeg` legs, and the refine sub-legs (`netOut`…`sliceWrite`) — not emitted.
+- **`sessions` / `threads` / `queue_depth`** — emitted by the server, consumed by nothing. The
+  bounded-monotonic session check and the PR #69 backlog signal are not implemented.
+- Tier 1 compares final-vs-baseline, not true monotonicity: a sawtooth reclaimed on the last cycle
+  reads CLEAN, and a transient `+1` on the last cycle reads LEAK.
+- A perfectly frozen collector is indistinguishable from a genuinely flat one.
+
+## fixture.json is not in the repo
+
+`fixture.json` holds DICOM study/series UIDs from a real archive plus machine-specific URLs and
+tuning, so it is gitignored. Copy `fixture.example.json` to `fixture.json` and fill in UIDs from
+your own Orthanc. Both `preflight.js` and `soak.spec.ts` fail with an explicit message if the file
+is missing or still contains `REPLACE_WITH` placeholders, rather than proceeding on bad input.
+
+`promptPoints` are normalised canvas coordinates and must land inside the anatomy of your series;
+if inference returns empty masks, re-tune them first.

--- a/tools/perf/analyze.py
+++ b/tools/perf/analyze.py
@@ -1,0 +1,1158 @@
+#!/usr/bin/env python3
+"""Merge client/host/server traces and emit a three-tier leak verdict.
+
+Tier 1 -- counts of live objects fully under our control. Must return to the
+         post-warmup baseline. Any monotonic growth is a leak, no statistics.
+         Most counters are fitted on phase='cycleEnd' (canonical at-rest state
+         after the study is closed and GC has run). EXCEPTION: segCount,
+         blockCount, and blockSlices are fitted on phase='studyOpen' — OHIF's
+         onModeExit calls removeAllSegmentations() before cycleEnd is sampled,
+         so those three counters return -1 at cycleEnd and are only observable
+         while the study is still open. See COUNTER_PHASE for the full mapping.
+
+Tier 2 -- byte-valued counters. Slope must be indistinguishable from zero;
+         reported as MB/cycle WITH a confidence interval. Also includes
+         per-container memMB from the host stream (bucketed into cycles by
+         wallT overlap) and server rss/vram_alloc from --server [timing] lines.
+         All streams fitted on cycleEnd samples / their wallT-bucketed equivalent.
+
+Tier 3 -- per-action wall times. Catches leaks that degrade performance without
+         growing unboundedly (GC pressure, cache thrash) -- invisible to 1 and 2.
+
+Host bucketing strategy
+-----------------------
+Host records carry an epoch timestamp `t` (float seconds since epoch).
+Client samples tagged phase='cycleEnd' carry `wallT` (epoch ms).  For each
+cycle N the script finds the cycleEnd wallT[N] and wallT[N+1] (the next cycle's
+cycleEnd, or +inf for the last cycle) and assigns every host record with
+`t` in [wallT[N]/1000, wallT[N+1]/1000) to cycle N.  This is an exact,
+causal assignment with no interpolation; gaps already flagged by check_gaps()
+make the window trustworthy.
+
+Host record kinds emitted by sample_host.sh
+--------------------------------------------
+- ``heartbeat`` — no metrics, used for gap detection only
+- ``container`` — per-container CPU/memory; keyed by the ``container`` field
+- ``gpu``        — per-GPU VRAM; keyed by the ``gpu`` index (int)
+- ``disk``       — per-path disk usage; keyed by the ``path`` field
+
+Each kind is consumed separately so that different containers / GPUs / paths
+are tracked as independent Tier-2 series, never merged.
+
+Server [timing] lines
+---------------------
+Format: `... total_request=0.224s | rss=5559.3MB vram_alloc=855.0MB sessions=2 threads=41 queue_depth=0`
+`rss` and `vram_alloc` are extracted and treated as Tier-2 counters.
+They carry no cycle number so they are bucketed like host records: by the
+wallT range of each cycle's cycleEnd sample.
+"""
+
+import argparse
+import calendar
+import datetime
+import glob
+import json
+import math
+import os
+import re
+
+TIER1 = ["volCount", "volUnsized", "segCount", "blockCount", "blockSlices", "listenerCount", "viewportCount"]
+TIER2 = ["heapMB", "cacheMB", "volMB"]
+
+# ---------------------------------------------------------------------------
+# Expected series that sample_host.sh watches.  If any of these produce ZERO
+# rows (container absent from docker stats, nvidia-smi missing, path not
+# mounted, compose-project rename, etc.) parse_host_stream emits an explicit
+# NO_DATA sentinel row naming the missing series so the overall verdict is
+# INCONCLUSIVE rather than silently clean.
+#
+# SOURCE OF TRUTH: tools/perf/sample_host.sh
+#   Containers: CONTAINERS="ohif_viewer ohif_orthanc monai_server"
+#   Disks:      $ORTHANC_DB → last component "orthanc-db"
+#               $IMG_CACHE  → last component "img_cache"
+#   GPUs:       all indices reported by nvidia-smi (at least one expected)
+# ---------------------------------------------------------------------------
+HOST_EXPECTED_CONTAINERS = frozenset({"ohif_viewer", "ohif_orthanc", "monai_server"})
+HOST_EXPECTED_DISK_SHORTS = frozenset({"orthanc-db", "img_cache"})  # last path component
+# At least one GPU is expected (nvidia-smi present).  The actual index set is
+# determined at runtime; we just require the set to be non-empty.
+HOST_EXPECTED_AT_LEAST_ONE_GPU = True
+
+# ---------------------------------------------------------------------------
+# Informational-only series: these appear in the report with their slopes but
+# MUST NOT contribute to the LEAK/DEGRADED verdict.
+#
+# WHY EACH IS EXCLUDED:
+#   host.diskMB[orthanc-db]  — the soak itself writes ~10 DICOM SEG series into
+#                               this directory per run, so the disk grows monoton-
+#                               ically by design.  Flagging it LEAK on every clean
+#                               run destroys trust in the verdict.
+#   host.gpuMB[*] (ALL GPUs) — nvidia-smi --query-gpu=memory.used reports the
+#                               WHOLE DEVICE, not our process.  On the shared DGX
+#                               measured 2026-08-11: GPU 7 total used = 26,929 MiB
+#                               but monai_server's share = only 826 MiB (~3%); the
+#                               remaining 97% belongs to unrelated tenants.  A
+#                               neighbouring job allocating or releasing a few GB
+#                               would either swamp a genuine VRAM leak in our server
+#                               or manufacture a false LEAK — the row CANNOT support
+#                               a verdict.  This applies to ALL GPU indices, including
+#                               the index pinned to monai_server (--pinned-gpu, default 7).
+#
+#                               The correct process-scoped VRAM signal is
+#                               server.vram_alloc (from torch.cuda.memory_allocated()
+#                               inside our own process), which is Tier-2 VERDICT-BEARING
+#                               when --server is supplied.
+#
+# The --pinned-gpu flag is retained as a LABELLING / ANNOTATION aid so the report
+# can identify which GPU row corresponds to our server — it no longer controls
+# whether a row is verdict-bearing.
+# ---------------------------------------------------------------------------
+INFORMATIONAL_DISK_SHORTS = frozenset({"orthanc-db"})
+
+# ---------------------------------------------------------------------------
+# Phase routing: which phase each Tier-1 counter must be fitted on.
+#
+# WHY THREE COUNTERS DIFFER:
+#   OHIF's onModeExit calls segmentationService.removeAllSegmentations() when the
+#   route changes away from the viewer. This fires BEFORE the cycleEnd sample is
+#   taken (which is after closeStudy + GC). Consequently, at cycleEnd the block-
+#   stats provider sees an empty segmentation service and returns {segCount:-1,
+#   blockCount:-1, blockSlices:-1}. Those -1 sentinels are excluded from every
+#   statistic, so the three counters would be permanently NO_DATA on every run if
+#   fitted on cycleEnd — making the overall verdict permanently INCONCLUSIVE.
+#
+#   The 'studyOpen' sample is taken while the study is STILL OPEN (after the
+#   MPR→stack toggle + GC), so block/segment counters ARE observable there.
+#   It is the ONLY phase at which these three counters can be measured.
+#
+#   All other Tier-1 counters measure objects that survive route changes (volumes,
+#   listeners, viewports) and must be measured at the canonical at-rest state
+#   (cycleEnd) so that "return to baseline" is meaningful.
+# ---------------------------------------------------------------------------
+BLOCK_COUNTERS = frozenset({"segCount", "blockCount", "blockSlices"})
+
+# Maps each Tier-1 counter to the phase its data points must be drawn from.
+COUNTER_PHASE: dict = {
+    "volCount":       "cycleEnd",
+    # volUnsized counts volumes without a computed sizeInBytes (still-loading streaming
+    # volumes, geometry/labelmap volumes). It is a Tier-1 counter because a GROWING
+    # volUnsized means the volMB partial sum is measuring a shifting subset and cannot
+    # be trusted; a STABLE volUnsized means the undercount is constant and the volMB
+    # slope is still meaningful. Measured at cycleEnd (at-rest baseline).
+    "volUnsized":     "cycleEnd",
+    "segCount":       "studyOpen",   # only observable while study is open
+    "blockCount":     "studyOpen",   # only observable while study is open
+    "blockSlices":    "studyOpen",   # only observable while study is open
+    "listenerCount":  "cycleEnd",
+    "viewportCount":  "cycleEnd",
+}
+# NOTE (settled during Task 3): only nninter / sam2 / segReset / nninterRecovered are actually
+# emitted by the client today. segAdd / segDelete / segExport / segLoad live in the cornerstone
+# extension and are NOT instrumented, so they will report NO_DATA — that is expected, not a bug.
+# `nninterRecovered` is the full wall time of a refine that needed a session-pool recovery; it is
+# kept SEPARATE from `nninter` on purpose, because folding a rare pathological event into the main
+# population would add variance that could itself mask a real regression.
+# `sam2` and `segReset` are only exercised if the soak includes those workflow steps; a soak that
+# omits them produces NO_DATA by design, not failure.
+TIER3 = ["nninter", "nninterRecovered", "sam2", "segAdd", "segDelete", "segExport", "segLoad", "segReset"]
+DEGRADE_PCT = 20.0
+
+# Actions/counters that are expected to produce NO_DATA — their absence must not block a CLEAN
+# verdict. These are NOT instrumented in the standard soak (cornerstone extension actions, rare
+# recovery path, and workflow-optional steps).
+EXPECTED_MISSING = {
+    "segAdd", "segDelete", "segExport", "segLoad",  # cornerstone extension, uninstrumented (Task 3)
+    "nninterRecovered",  # only fires on rare session-pool recovery, by design
+    "sam2",    # only exercised if soak includes sam2 workflow steps
+    "segReset",  # only exercised if soak includes segReset workflow steps
+    # ---------------------------------------------------------------------------
+    # volMB — always NO_DATA against cornerstone 5.x (live-probe finding, Task 10)
+    #
+    # Headless probe of the real viewer measured:
+    #   STACK viewport: volCount=0, volMB=0, volUnsized=0  (correct — no volumes)
+    #   MPR   viewport: volCount=1, volMB=-1, volUnsized=1  (one volume, no readable size)
+    #
+    # Root cause — getter chain in @cornerstonejs/core 5.0.13:
+    #   ImageVolume.js:   get sizeInBytes() { return this.voxelManager.sizeInBytes; }
+    #   VoxelManager.js:  get sizeInBytes() { return this.getScalarDataLength() * this.bytePerVoxel; }
+    #   getScalarDataLength() throws for lazy/streaming managers: throw new Error('No scalar data')
+    #
+    # The client correctly degrades to volMB=-1 with volUnsized=1 when the getter throws.
+    # Since _series() excludes values < 0, an all-(-1) volMB trace produces NO_DATA.
+    #
+    # WHY THIS DOES NOT LOSE LEAK COVERAGE:
+    #   The historic MPR volume leak was detected by volCount growing +1 per refine cycle
+    #   WHILE cacheMB stayed flat (the image cache is blind to volume memory).  volCount is
+    #   Tier-1 and works correctly: 0 in STACK, 1 in MPR (verified live).  It remains the
+    #   load-bearing volume-leak signal.  volMB was always supplementary — a byte-level
+    #   cross-check.  Allow-listing its absence does NOT remove detection of the historic leak.
+    #
+    # WHEN volMB IS PRESENT (some volumes do report a size):
+    #   Allow-listing only suppresses the INCONCLUSIVE penalty for NO_DATA.  If volMB
+    #   has real values they flow through tier2_verdict normally and a ramp is still LEAK.
+    #
+    # volUnsized (Tier-1) is the honest indicator of how much of volMB is unmeasurable.
+    #   A GROWING volUnsized → more volumes accumulating without readable sizes → still LEAK.
+    #   A STABLE volUnsized → undercount is constant → volMB slope is still meaningful.
+    # ---------------------------------------------------------------------------
+    "volMB",
+}
+
+
+_DEGENERATE = (None, None, None)  # sentinel: fit is meaningless, yield NO_DATA
+
+
+def fit_slope(xs, ys):
+    """Least-squares slope with a 95% CI. Returns (slope, ci_low, ci_high).
+
+    Returns ``_DEGENERATE`` (None, None, None) when the fit is mathematically
+    undefined (n < 3, sxx == 0, or infinite CI bounds) — callers must check for
+    this and emit NO_DATA rather than CLEAN. A degenerate fit is reachable via
+    timezone skew (all records land in one cycle → sxx == 0) and must never
+    silently pass as CLEAN.
+    """
+    n = len(xs)
+    if n < 3:
+        return _DEGENERATE
+    mx, my = sum(xs) / n, sum(ys) / n
+    sxx = sum((x - mx) ** 2 for x in xs)
+    if sxx == 0:
+        return _DEGENERATE
+    slope = sum((x - mx) * (y - my) for x, y in zip(xs, ys)) / sxx
+    intercept = my - slope * mx
+    resid = [y - (slope * x + intercept) for x, y in zip(xs, ys)]
+    if n <= 2:
+        return _DEGENERATE
+    se = math.sqrt(sum(r * r for r in resid) / (n - 2) / sxx)
+    margin = 1.96 * se
+    lo, hi = slope - margin, slope + margin
+    if math.isinf(lo) or math.isinf(hi):
+        return _DEGENERATE
+    return (slope, lo, hi)
+
+
+def _series(samples, counter, warmup, phase="cycleEnd"):
+    """Extract (xs, ys) from samples.
+
+    Filters on:
+      - kind == 'sample'
+      - phase == the requested phase (default 'cycleEnd')
+      - cycle > warmup
+      - value >= 0 (excludes -1 sentinel)
+
+    If phase is not None (the default 'cycleEnd'), ONLY samples with that exact
+    phase are used. This is the critical invariant: Tier 1 and Tier 2 verdicts
+    must NEVER mix phases, because different phases represent different system
+    states (study open vs. closed, post-GC vs. mid-load).
+    """
+    pts = [(s["cycle"], s[counter]) for s in samples
+           if s.get("kind") == "sample" and counter in s
+           and s["cycle"] > warmup and s[counter] >= 0
+           and (phase is None or s.get("phase") == phase)]
+    return [p[0] for p in pts], [p[1] for p in pts]
+
+
+def _has_cycle_end(samples):
+    """Return True if at least one sample has phase='cycleEnd'."""
+    return any(s.get("kind") == "sample" and s.get("phase") == "cycleEnd"
+               for s in samples)
+
+
+def _has_phase(samples, phase):
+    """Return True if at least one sample with the given phase exists."""
+    return any(s.get("kind") == "sample" and s.get("phase") == phase
+               for s in samples)
+
+
+def tier1_verdict(samples, counter, warmup=2, phase=None):
+    """Tier 1 verdict.
+
+    Fitted on the phase specified by ``phase`` (default: look up COUNTER_PHASE,
+    fall back to 'cycleEnd').  Block counters (segCount, blockCount, blockSlices)
+    must pass phase='studyOpen' — they return -1 at cycleEnd because
+    onModeExit removes all segmentations before that sample is taken.
+
+    Contract:
+    - If NO cycleEnd samples exist at all, returns NO_DATA (trace pre-dates
+      the phase contract).
+    - If the requested phase has no samples, returns NO_DATA.  Callers MUST
+      NOT silently fall back to a different phase — that would reproduce the
+      bug this function fixes.
+    """
+    if phase is None:
+        phase = COUNTER_PHASE.get(counter, "cycleEnd")
+
+    # Always require at least one cycleEnd sample as proof the trace honours
+    # the phase contract (pre-contract traces have no phase at all).
+    if not _has_cycle_end(samples):
+        return {"counter": counter, "tier": 1, "verdict": "NO_DATA",
+                "note": "no cycleEnd samples — trace pre-dates phase contract"}
+
+    # For counters that live on a non-cycleEnd phase, verify that phase exists.
+    # Do NOT fall back to cycleEnd — that would silently fit on -1 sentinels.
+    if phase != "cycleEnd" and not _has_phase(samples, phase):
+        return {"counter": counter, "tier": 1, "verdict": "NO_DATA",
+                "note": f"no '{phase}' samples — trace pre-dates studyOpen phase; "
+                        "block counters require studyOpen to be observable"}
+
+    xs, ys = _series(samples, counter, warmup, phase=phase)
+    # Require at least 3 usable post-warmup points before rendering a CLEAN/LEAK verdict.
+    # With fewer points, growth = ys[-1] - baseline can be trivially 0 even on a crashed
+    # soak, producing a false-CLEAN. Mirror the same floor tier2 uses.
+    if len(ys) < 3:
+        return {"counter": counter, "tier": 1, "verdict": "NO_DATA"}
+    # Baseline is taken from the warmup window (the very first sample for the counter
+    # in the target phase), so growth reflects how far the metric has moved from its
+    # initial steady-state value.
+    warmup_pts = [(s["cycle"], s[counter]) for s in samples
+                  if s.get("kind") == "sample" and counter in s
+                  and s.get("phase") == phase
+                  and s["cycle"] <= warmup and s[counter] >= 0]
+    baseline = warmup_pts[0][1] if warmup_pts else ys[0]
+    growth = ys[-1] - baseline
+    return {
+        "counter": counter, "tier": 1, "phase": phase,
+        "baseline": baseline,
+        "final": ys[-1], "growth": growth, "n": len(ys),
+        "verdict": "LEAK" if growth > 0 else "CLEAN",
+    }
+
+
+def tier2_verdict(samples, counter, warmup=2, min_slope=0.0):
+    """Tier 2 verdict — uses ONLY cycleEnd samples.
+
+    If no cycleEnd samples exist at all, returns NO_DATA.
+    A degenerate fit (sxx==0 or infinite CI) also yields NO_DATA.
+
+    ``min_slope``: minimum effect-size floor (MB/cycle).  See
+    tier2_verdict_from_pairs for full documentation.
+    """
+    if not _has_cycle_end(samples):
+        return {"counter": counter, "tier": 2, "verdict": "NO_DATA",
+                "note": "no cycleEnd samples — trace pre-dates phase contract"}
+    xs, ys = _series(samples, counter, warmup, phase="cycleEnd")
+    if len(ys) < 3:
+        return {"counter": counter, "tier": 2, "verdict": "NO_DATA"}
+    slope, lo, hi = fit_slope(xs, ys)
+    if slope is None:  # degenerate fit
+        return {"counter": counter, "tier": 2, "verdict": "NO_DATA",
+                "note": "degenerate fit (all points in one x-bucket — possible clock/timezone skew)"}
+    if lo <= 0 <= hi:
+        verdict = "CLEAN"
+    elif slope > 0:
+        # I-3: apply minimum effect-size floor before declaring LEAK.
+        if min_slope > 0 and abs(slope) < min_slope:
+            verdict = "CLEAN"
+        else:
+            verdict = "LEAK"
+    else:
+        verdict = "CLEAN"  # a tight NEGATIVE slope is memory being reclaimed
+    row = {
+        "counter": counter, "tier": 2, "slope_per_cycle": round(slope, 4),
+        "ci": [round(lo, 4), round(hi, 4)], "n": len(ys), "verdict": verdict,
+    }
+    if min_slope > 0:
+        row["min_slope_floor"] = min_slope
+    return row
+
+
+def tier3_verdict(measures, name, warmup=2):
+    pts = [(m["cycle"], m["durMs"]) for m in measures
+           if m.get("kind") == "measure" and m.get("name") == name
+           and m["cycle"] > warmup and m["durMs"] >= 0]
+    if len(pts) < 6:
+        return {"action": name, "tier": 3, "verdict": "NO_DATA"}
+    pts.sort()
+    early = [d for _, d in pts[:5]]
+    late = [d for _, d in pts[-5:]]
+    e, l = sum(early) / len(early), sum(late) / len(late)
+    pct = (l - e) / e * 100 if e else 0.0
+    return {
+        "action": name, "tier": 3, "early_ms": round(e, 1), "late_ms": round(l, 1),
+        "pct_change": round(pct, 1), "n": len(pts),
+        "verdict": "DEGRADED" if pct > DEGRADE_PCT else "CLEAN",
+    }
+
+
+def check_gaps(host_records, interval=2.0):
+    """A dead sampler looks exactly like a plateaued counter. Report gaps, never
+    interpolate across them."""
+    ts = sorted(r["t"] for r in host_records if r.get("kind") == "heartbeat")
+    return [(round(a, 1), round(b, 1)) for a, b in zip(ts, ts[1:]) if b - a > interval * 3]
+
+
+def _cycle_windows(samples):
+    """Return a list of (cycle, t_start_sec, t_end_sec) from cycleEnd samples.
+
+    Each window covers [wallT_this / 1000, wallT_next / 1000).
+    The last window's end is +inf.
+    wallT is in epoch milliseconds (as emitted by the soak driver).
+    """
+    ce = sorted(
+        [(s["cycle"], s["wallT"]) for s in samples
+         if s.get("kind") == "sample" and s.get("phase") == "cycleEnd" and "wallT" in s],
+        key=lambda x: x[0],
+    )
+    windows = []
+    for i, (cycle, wallT) in enumerate(ce):
+        t_start = wallT / 1000.0
+        t_end = ce[i + 1][1] / 1000.0 if i + 1 < len(ce) else math.inf
+        windows.append((cycle, t_start, t_end))
+    return windows
+
+
+def _bucket_by_cycle(records, windows, value_key, kind_filter=None):
+    """Map records to cycle numbers using wallT windows.
+
+    Returns a list of (cycle, value) pairs with value >= 0.
+    Records with `t` outside all windows are dropped.
+    """
+    result = []
+    for r in records:
+        if kind_filter and r.get("kind") != kind_filter:
+            continue
+        t = r.get("t")
+        v = r.get(value_key)
+        if t is None or v is None or v < 0:
+            continue
+        for cycle, t_start, t_end in windows:
+            if t_start <= t < t_end:
+                result.append((cycle, v))
+                break
+    return result
+
+
+def tier2_verdict_from_pairs(label, pairs, warmup=2, warn_single_cycle=False, min_slope=0.0):
+    """Tier 2 verdict from (cycle, value) pairs (used for host/server streams).
+
+    ``warn_single_cycle`` is set internally when ALL records mapped to one
+    cycle window — the signature of a clock/timezone mismatch.  The result
+    carries a ``note`` and verdict NO_DATA so the caller can surface it.
+    A degenerate fit (sxx==0 or infinite CI) also yields NO_DATA.
+
+    ``min_slope``: minimum effect-size floor (MB/cycle).  A slope whose
+    magnitude is below this floor is reported as CLEAN even when the CI
+    excludes zero — statistically tight but physically meaningless.  The floor
+    value is recorded in the returned row so the report can state it.
+    Do NOT apply to Tier-1 integer counters; only pass non-zero here for Tier-2.
+    """
+    pts = [(c, v) for c, v in pairs if c > warmup and v >= 0]
+    if len(pts) < 3:
+        return {"counter": label, "tier": 2, "verdict": "NO_DATA"}
+    xs = [p[0] for p in pts]
+    ys = [p[1] for p in pts]
+    # Detect single-cycle collapse (clock mismatch signature)
+    if len(set(xs)) == 1:
+        return {"counter": label, "tier": 2, "verdict": "NO_DATA",
+                "note": f"all {len(pts)} records fell in one cycle window — "
+                        "possible clock/timezone mismatch; rerun with --log-tz"}
+    slope, lo, hi = fit_slope(xs, ys)
+    if slope is None:  # degenerate fit
+        return {"counter": label, "tier": 2, "verdict": "NO_DATA",
+                "note": "degenerate fit (sxx==0 or infinite CI — possible clock/timezone skew)"}
+    if lo <= 0 <= hi:
+        verdict = "CLEAN"
+    elif slope > 0:
+        # I-3: apply minimum effect-size floor before declaring LEAK.
+        # A tight CI on a physically negligible slope is noise, not a real leak.
+        if min_slope > 0 and abs(slope) < min_slope:
+            verdict = "CLEAN"
+        else:
+            verdict = "LEAK"
+    else:
+        verdict = "CLEAN"  # a tight NEGATIVE slope is memory being reclaimed
+    row = {
+        "counter": label, "tier": 2, "slope_per_cycle": round(slope, 4),
+        "ci": [round(lo, 4), round(hi, 4)], "n": len(pts), "verdict": verdict,
+    }
+    if min_slope > 0:
+        row["min_slope_floor"] = min_slope
+    return row
+
+
+# The set of record kinds that sample_host.sh emits and that this analyzer
+# knows how to consume.  Used in tests to detect new kinds added to the sampler
+# without a matching consumer here.
+HOST_KNOWN_KINDS = frozenset({"heartbeat", "container", "gpu", "disk"})
+
+
+def _aggregate_to_one_per_cycle(pairs):
+    """Reduce multiple (cycle, value) pairs per cycle to one value per cycle.
+
+    Host records arrive ~20 per cycle.  Fitting them as independent points
+    underestimates the CI by ~sqrt(20), causing false LEAKs.  We aggregate to
+    the last (most recent) record in each cycle window before fitting.
+
+    Returns a deduplicated list of (cycle, value) pairs, one per cycle.
+    """
+    from collections import defaultdict
+    by_cycle = defaultdict(list)
+    for c, v in pairs:
+        by_cycle[c].append(v)
+    # Use the median value within each cycle window (robust to brief spikes)
+    result = []
+    for cycle in sorted(by_cycle):
+        vals = sorted(by_cycle[cycle])
+        mid = len(vals) // 2
+        result.append((cycle, vals[mid]))
+    return result
+
+
+def parse_host_stream(host_recs, samples, warmup=2, pinned_gpu=7, min_slope=0.0):
+    """Consume the host stream: emit Tier-2 rows for memMB per container,
+    gpuMB per GPU index, and diskMB per path.
+
+    Record kinds consumed (as emitted by sample_host.sh):
+      - ``container``: keyed by ``container`` field → host.memMB[<name>]
+      - ``gpu``:       keyed by ``gpu`` index      → host.gpuMB[<idx>]
+      - ``disk``:      keyed by ``path`` field      → host.diskMB[<path>]
+      - ``heartbeat``: used only by check_gaps(), ignored here
+
+    Host records arrive ~20 per cycle.  Each series is aggregated to ONE value
+    per cycle (median) before fitting, so the CI is not artificially narrowed
+    by within-cycle replication.
+
+    I-1 (missing-series sentinel): If an expected series (container, GPU, or
+    disk) produces ZERO rows — because the container was absent from docker
+    stats, nvidia-smi was missing, a compose-project rename changed the name, or
+    a disk path was not mounted — an explicit NO_DATA sentinel row is emitted
+    naming that series.  This forces INCONCLUSIVE rather than silently clean.
+    The expected set is derived from HOST_EXPECTED_CONTAINERS,
+    HOST_EXPECTED_DISK_SHORTS, and HOST_EXPECTED_AT_LEAST_ONE_GPU.
+
+    I-2 (informational series): orthanc-db disk and ALL GPU indices are
+    classified informational — they appear in the report but do NOT contribute
+    to the LEAK/DEGRADED verdict.  ``pinned_gpu`` is used only as a labelling
+    aid to mark which GPU index corresponds to our server in the report; it no
+    longer controls verdict-bearing status.  nvidia-smi --query-gpu=memory.used
+    reports the WHOLE DEVICE; on the shared DGX the pinned GPU (index 7) showed
+    26,929 MiB total used while monai_server held only 826 MiB (~3%).  The
+    process-scoped VRAM signal is server.vram_alloc (torch.cuda.memory_allocated()
+    inside our process), which is the ONLY VRAM row that can support a verdict.
+    Supply --server to make server.vram_alloc verdict-bearing.
+
+    A non-empty host stream that produces ZERO total rows (e.g. because the
+    sampler emits a kind the analyzer does not know about) is a
+    misconfiguration, not a pass.  An INCONCLUSIVE sentinel row is returned.
+
+    ``min_slope``: forwarded to tier2_verdict_from_pairs for verdict-bearing rows.
+    """
+    windows = _cycle_windows(samples)
+    if not windows:
+        if host_recs:
+            # I9: cycle windows empty but host data was supplied → INCONCLUSIVE
+            return [{"counter": "host._no_cycle_windows", "tier": 2,
+                     "verdict": "NO_DATA",
+                     "note": "host stream present but no cycleEnd wallT anchors — "
+                             "client trace may be pre-contract; cannot bucket host records"}]
+        return []
+
+    rows = []
+    informational_rows = []
+
+    # --- kind=container: one series per container, tracking memMB ---
+    containers: dict = {}
+    for r in host_recs:
+        if r.get("kind") != "container":
+            continue
+        container = r.get("container", "")
+        mem = r.get("memMB")
+        t = r.get("t")
+        if t is None or mem is None or mem < 0:
+            continue
+        containers.setdefault(container, []).append({"t": t, "memMB": mem})
+
+    seen_containers: set = set()
+    for container, recs in containers.items():
+        raw_pairs = _bucket_by_cycle(recs, windows, "memMB")
+        pairs = _aggregate_to_one_per_cycle(raw_pairs)
+        label = f"host.memMB[{container}]" if container else "host.memMB"
+        rows.append(tier2_verdict_from_pairs(label, pairs, warmup, min_slope=min_slope))
+        seen_containers.add(container)
+
+    # I-1: emit NO_DATA sentinel for every expected container that produced no rows.
+    for expected_container in sorted(HOST_EXPECTED_CONTAINERS):
+        if expected_container not in seen_containers:
+            rows.append({
+                "counter": f"host.memMB[{expected_container}]", "tier": 2,
+                "verdict": "NO_DATA",
+                "note": f"series '{expected_container}' produced no records — "
+                        "container may be absent from docker stats, down, or "
+                        "renamed (e.g. compose-project prefix change). "
+                        "Source: tools/perf/sample_host.sh CONTAINERS=",
+            })
+
+    # --- kind=gpu: one series per GPU index, tracking gpuMB ---
+    gpus: dict = {}
+    for r in host_recs:
+        if r.get("kind") != "gpu":
+            continue
+        gpu_idx = r.get("gpu")
+        vmb = r.get("gpuMB")
+        t = r.get("t")
+        if t is None or gpu_idx is None or vmb is None or vmb < 0:
+            continue
+        gpus.setdefault(gpu_idx, []).append({"t": t, "gpuMB": vmb})
+
+    for gpu_idx in sorted(gpus):
+        raw_pairs = _bucket_by_cycle(gpus[gpu_idx], windows, "gpuMB")
+        pairs = _aggregate_to_one_per_cycle(raw_pairs)
+        label = f"host.gpuMB[{gpu_idx}]"
+        is_pinned = (gpu_idx == pinned_gpu)
+        # I-2: ALL GPU rows are informational — nvidia-smi --query-gpu=memory.used
+        # reports the WHOLE DEVICE, not our process.  On a shared DGX (measured
+        # 2026-08-11): GPU 7 total used = 26,929 MiB; monai_server's share =
+        # 826 MiB (~3%).  A neighbour job allocating a few GB would either swamp
+        # a genuine VRAM leak or manufacture a false LEAK — cannot support a
+        # verdict.  Use server.vram_alloc (torch.cuda.memory_allocated()) instead;
+        # it is the ONLY VRAM signal that is process-scoped and verdict-bearing.
+        # --pinned-gpu annotates which row is our server's GPU for readability.
+        row = tier2_verdict_from_pairs(label, pairs, warmup, min_slope=0.0)
+        row["informational"] = True
+        if is_pinned:
+            row["informational_reason"] = (
+                "nvidia-smi --query-gpu=memory.used is per-DEVICE, not per-process. "
+                f"This is the GPU pinned to monai_server (--pinned-gpu={pinned_gpu}). "
+                "Measured 2026-08-11: 26,929 MiB total used, 826 MiB our process (~3%); "
+                "a neighbour job would swamp or manufacture a LEAK signal. "
+                "Process-scoped VRAM: server.vram_alloc (supply --server)."
+            )
+        else:
+            row["informational_reason"] = (
+                "nvidia-smi --query-gpu=memory.used is per-DEVICE, not per-process. "
+                "GPU is shared with other tenants on a DGX; usage cannot be attributed "
+                f"to this workload. Our server runs on GPU {pinned_gpu} (--pinned-gpu). "
+                "Process-scoped VRAM: server.vram_alloc (supply --server)."
+            )
+        informational_rows.append(row)
+
+    # I-1: if nvidia-smi was present (we expect at least one GPU) but produced
+    # no GPU rows at all, emit a sentinel.
+    if HOST_EXPECTED_AT_LEAST_ONE_GPU and not gpus:
+        rows.append({
+            "counter": "host.gpuMB[?]", "tier": 2,
+            "verdict": "NO_DATA",
+            "note": "no GPU records in host stream — nvidia-smi may be absent "
+                    "from PATH or failed. Source: tools/perf/sample_host.sh",
+        })
+
+    # --- kind=disk: one series per path, tracking diskMB ---
+    disks: dict = {}
+    for r in host_recs:
+        if r.get("kind") != "disk":
+            continue
+        path = r.get("path", "")
+        dmb = r.get("diskMB")
+        t = r.get("t")
+        if t is None or dmb is None or dmb < 0:
+            continue
+        disks.setdefault(path, []).append({"t": t, "diskMB": dmb})
+
+    seen_disk_shorts: set = set()
+    for path, recs in disks.items():
+        raw_pairs = _bucket_by_cycle(recs, windows, "diskMB")
+        pairs = _aggregate_to_one_per_cycle(raw_pairs)
+        # Use last path component as the label (keep it readable)
+        short = path.split("/")[-1] or path
+        seen_disk_shorts.add(short)
+        if short in INFORMATIONAL_DISK_SHORTS:
+            # I-2: self-written data directory → informational only.
+            row = tier2_verdict_from_pairs(f"host.diskMB[{short}]", pairs, warmup, min_slope=0.0)
+            row["informational"] = True
+            row["informational_reason"] = (
+                "soak writes ~10 DICOM SEG series into this directory per run — "
+                "monotonic growth is by design, not a leak"
+            )
+            informational_rows.append(row)
+        else:
+            rows.append(tier2_verdict_from_pairs(
+                f"host.diskMB[{short}]", pairs, warmup, min_slope=min_slope))
+
+    # I-1: emit NO_DATA sentinel for every expected disk path that produced no rows.
+    for expected_short in sorted(HOST_EXPECTED_DISK_SHORTS):
+        if expected_short not in seen_disk_shorts:
+            rows.append({
+                "counter": f"host.diskMB[{expected_short}]", "tier": 2,
+                "verdict": "NO_DATA",
+                "note": f"disk path '{expected_short}' produced no records — "
+                        "path may not exist or du may have timed out. "
+                        "Source: tools/perf/sample_host.sh ORTHANC_DB / IMG_CACHE",
+            })
+
+    # Append informational rows (they appear in the report but are excluded from
+    # verdict logic by the render_report and overall-verdict computation).
+    rows.extend(informational_rows)
+
+    # Guard: non-empty stream → zero rows means we consumed nothing useful.
+    non_heartbeat = [r for r in host_recs if r.get("kind") != "heartbeat"]
+    if non_heartbeat and not rows:
+        return [{"counter": "host._zero_rows", "tier": 2,
+                 "verdict": "NO_DATA",
+                 "note": "host stream non-empty but produced zero series rows — "
+                         "sampler may emit kinds the analyzer does not consume; "
+                         f"known kinds: {sorted(HOST_KNOWN_KINDS)}"}]
+
+    return rows
+
+
+# Pattern matching [timing] lines from the server log.
+# Format: `... total_request=0.224s | rss=5559.3MB vram_alloc=855.0MB sessions=2 threads=41 queue_depth=0`
+_TIMING_RE = re.compile(
+    r"\[timing\].*?"
+    r"rss=(?P<rss>-?[\d.]+)MB"
+    r".*?vram_alloc=(?P<vram>-?[\d.]+)MB",
+    re.IGNORECASE,
+)
+_WALLTIME_RE = re.compile(r"wallT=(?P<wallT>\d+)")
+# Python logger timestamp: [YYYY-MM-DD HH:MM:SS,mmm]
+# Optionally preceded by a docker-compose prefix like "monai_server  | "
+_LOGGER_TS_RE = re.compile(r"\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}),(\d{3})\]")
+
+
+def _parse_logger_timestamp(line, tz=None):
+    """Extract epoch seconds (float) from the Python logger timestamp in *line*.
+
+    Format: [YYYY-MM-DD HH:MM:SS,mmm]
+
+    ``tz``: a ``datetime.timezone`` that the logger timestamp is assumed to be
+    in.  Defaults to UTC (containers default to UTC).  Pass the analyzer host's
+    local timezone when the log was written by a host process, or whatever the
+    ``--log-tz`` option resolved to.
+
+    Returns None if the timestamp is absent or unparseable.
+    """
+    if tz is None:
+        tz = datetime.timezone.utc
+    m = _LOGGER_TS_RE.search(line)
+    if not m:
+        return None
+    try:
+        dt = datetime.datetime.strptime(m.group(1), "%Y-%m-%d %H:%M:%S")
+        millis = int(m.group(2))
+        # Attach the caller-supplied timezone and convert to epoch seconds.
+        dt_aware = dt.replace(tzinfo=tz)
+        epoch_sec = dt_aware.timestamp() + millis / 1000.0
+        return epoch_sec
+    except Exception:
+        return None
+
+
+def parse_server_log(path, log_tz=None):
+    """Parse [timing] lines and return a ``_ServerRecordList``.
+
+    Each record is a dict with keys ``t`` (epoch sec) plus any of ``rss`` /
+    ``vram_alloc`` that were present and non-sentinel (>= 0).
+
+    Attributes on the returned list:
+      - ``skipped_counter_no_timestamp`` — counter lines that had no usable
+                                           timestamp (real problem, operator
+                                           should see warning + --log-tz hint)
+      - ``skipped_non_counter_lines``    — [timing] lines without counter values
+                                           (expected & harmless sub-timing lines)
+      - ``timing_lines``  — total [timing] lines seen in the file (C7 guard:
+                            if this is > 0 and records is empty, the log exists
+                            but carried no counters the analyzer understands)
+
+    Primary timestamp source: ``wallT=<epoch_ms>`` (epoch ms, present in logs
+    after Fix 1 / rebuild).
+    Fallback: Python logger timestamp ``[YYYY-MM-DD HH:MM:SS,mmm]``.
+      - ``log_tz``: a ``datetime.timezone`` used when interpreting the logger
+        timestamp.  Defaults to UTC (containers default to UTC).
+        Pass ``datetime.timezone.utc`` explicitly or the result of
+        ``datetime.timezone(datetime.timedelta(hours=N))`` for a different zone.
+        The ``--log-tz`` CLI option converts user input to a timezone object.
+    If BOTH timestamp sources are absent, the line is counted as skipped.
+    """
+    records = []
+    skipped_counter_no_timestamp = 0
+    skipped_non_counter_lines = 0
+    timing_lines = 0
+    if log_tz is None:
+        log_tz = datetime.timezone.utc
+    with open(path) as f:
+        for line in f:
+            if "[timing]" not in line:
+                continue
+            timing_lines += 1
+            m = _TIMING_RE.search(line)
+            if not m:
+                # [timing] line present but doesn't match our counter regex
+                # (e.g. a sub-timing line like session reset, init, dicom_scan)
+                # This is EXPECTED and NOT a problem.
+                skipped_non_counter_lines += 1
+                continue
+            rss = float(m.group("rss"))
+            vram = float(m.group("vram"))
+            # Primary: wallT= (epoch ms, present in logs after Fix 1)
+            wm = _WALLTIME_RE.search(line)
+            if wm:
+                t = int(wm.group("wallT")) / 1000.0
+            else:
+                # Fallback: Python logger timestamp, interpreted in log_tz
+                t = _parse_logger_timestamp(line, log_tz)
+            if t is None:
+                # This line HAS counters but NO usable timestamp — real problem
+                skipped_counter_no_timestamp += 1
+                continue
+            # Exclude -1 sentinels
+            record = {"t": t}
+            if rss >= 0:
+                record["rss"] = rss
+            if vram >= 0:
+                record["vram_alloc"] = vram
+            records.append(record)
+    # Return an augmented list so existing callers (tier2_verdicts_from_server)
+    # work unchanged, while metadata is accessible as attributes.
+    result = _ServerRecordList(records)
+    result.skipped_counter_no_timestamp = skipped_counter_no_timestamp
+    result.skipped_non_counter_lines = skipped_non_counter_lines
+    result.timing_lines = timing_lines
+    return result
+
+
+class _ServerRecordList(list):
+    """A list subclass that carries a ``skipped`` counter alongside the records."""
+    skipped = 0
+
+
+def tier2_verdicts_from_server(server_recs, samples, warmup=2, min_slope=0.0):
+    """Emit Tier-2 rows for server rss and vram_alloc, bucketed by cycleEnd windows.
+
+    server.vram_alloc is the ONLY VRAM signal that can support a leak verdict.
+    It comes from torch.cuda.memory_allocated() inside our own process, so it
+    is process-scoped and unaffected by other GPU tenants.  host.gpuMB[*] from
+    nvidia-smi reports per-DEVICE usage and is always informational (see
+    parse_host_stream and INFORMATIONAL_DISK_SHORTS comment block).
+
+    I9 guard: if cycle windows are empty but server records were supplied, return
+    an INCONCLUSIVE sentinel row rather than silently dropping the stream.
+    """
+    windows = _cycle_windows(samples)
+    if not server_recs:
+        return []
+    if not windows:
+        # I9: server data present but no wallT anchors to bucket against
+        return [{"counter": "server._no_cycle_windows", "tier": 2,
+                 "verdict": "NO_DATA",
+                 "note": "server stream present but no cycleEnd wallT anchors — "
+                         "client trace may be pre-contract; cannot bucket server records"}]
+
+    rows = []
+    for key, label in [("rss", "server.rssMB"), ("vram_alloc", "server.vramMB")]:
+        recs = [r for r in server_recs if key in r]
+        pairs = _bucket_by_cycle(recs, windows, key)
+        rows.append(tier2_verdict_from_pairs(label, pairs, warmup, min_slope=min_slope))
+    return rows
+
+
+def render_report(results):
+    out = ["# Perf Soak Report", "", f"Generated: {results['generated']}", ""]
+    if results.get("gaps"):
+        out += ["> **WARNING** — host sampler gaps detected; plateaus in that window are not trustworthy:",
+                "", *[f"> - {a} → {b}" for a, b in results["gaps"]], ""]
+    # Skipped server lines: distinguish counter lines without timestamp (problem)
+    # from non-counter sub-timing lines (expected)
+    server_skipped_counter_no_timestamp = results.get("server_skipped_counter_no_timestamp", 0)
+    server_skipped_non_counter_lines = results.get("server_skipped_non_counter_lines", 0)
+    server_timing_lines = results.get("server_timing_lines", 0)
+    log_tz_label = results.get("log_tz_label", "UTC")
+
+    # Only warn if counter lines lacked timestamps (real problem)
+    if server_skipped_counter_no_timestamp:
+        msg = (f"> **WARNING** — {server_skipped_counter_no_timestamp} [timing] line(s) carried "
+               f"counters (rss=/vram_alloc=) but had no usable timestamp "
+               f"(no wallT= and no logger timestamp parseable as {log_tz_label}). "
+               f"Those records were excluded from analysis. Try --log-tz if these are false positives.")
+        out += [msg, ""]
+        print(f"WARNING: {server_skipped_counter_no_timestamp} server [timing] counter line(s) skipped — no usable timestamp")
+
+    # Report sub-timing lines neutrally (not as a warning)
+    if server_skipped_non_counter_lines:
+        msg = (f"> _{server_skipped_non_counter_lines} [timing] sub-timing lines seen "
+               f"(session reset, init, dicom_scan, etc. without counters) — expected and excluded._")
+        out += [msg, ""]
+
+    if log_tz_label and log_tz_label != "UTC" and results.get("server_present"):
+        out += [f"> _Logger timestamp assumed timezone: {log_tz_label} (set via --log-tz)_", ""]
+    elif results.get("server_present"):
+        out += ["> _Logger timestamp fallback assumes UTC (containers default to UTC; override with --log-tz)_", ""]
+
+    # I-3: report min_slope floor if non-zero
+    min_slope = results.get("min_slope", 0.0)
+    if min_slope > 0:
+        out += [f"> _Tier-2 minimum effect-size floor: {min_slope} MB/cycle (--min-slope). "
+                "Slopes below this magnitude are reported CLEAN even when the CI excludes zero._", ""]
+
+    # Stream presence summary
+    host_count = results.get("host_count", None)
+    server_present = results.get("server_present", None)
+    server_inconclusive = results.get("server_inconclusive", False)
+    if host_count is not None or server_present is not None:
+        out.append("> **Stream summary:**")
+        if host_count is not None:
+            if host_count == 0:
+                out.append("> - host stream: **absent** — INCONCLUSIVE on host metrics")
+            else:
+                out.append(f"> - host stream: {host_count} records")
+        if server_present is not None:
+            if server_inconclusive:
+                out.append(f"> - server stream: **provided but ALL records were unusable** "
+                           f"({server_timing_lines} [timing] line(s) seen, 0 usable) "
+                           f"— INCONCLUSIVE on server metrics")
+            elif server_present:
+                out.append(f"> - server stream: present")
+            else:
+                out.append(f"> - server stream: **absent** — "
+                           f"no process-scoped VRAM signal available. "
+                           f"host.gpuMB[*] is per-device (nvidia-smi) and cannot be attributed "
+                           f"to this workload on a shared GPU host. "
+                           f"VRAM is effectively unmonitored for verdict purposes in this run; "
+                           f"supply --server to enable server.vram_alloc (torch.cuda.memory_allocated()).")
+        elif server_present is None:
+            # --server was not supplied at all (None means option not given, vs False=given but absent)
+            out.append("> - server stream: **not supplied (--server omitted)** — "
+                       "no process-scoped VRAM signal available. "
+                       "host.gpuMB[*] is per-device (nvidia-smi) and cannot be attributed "
+                       "to this workload on a shared GPU host. "
+                       "VRAM is effectively unmonitored for verdict purposes in this run; "
+                       "supply --server to enable server.vram_alloc (torch.cuda.memory_allocated()).")
+        out.append("")
+
+    # Split rows into verdict-bearing and informational before rendering
+    all_rows = results["rows"]
+    verdict_rows = [r for r in all_rows if not r.get("informational")]
+    info_rows = [r for r in all_rows if r.get("informational")]
+
+    for tier, title in ((1, "Tier 1 — must return to baseline"),
+                        (2, "Tier 2 — slope must span zero"),
+                        (3, "Tier 3 — performance degradation")):
+        rows = [r for r in verdict_rows if r["tier"] == tier]
+        if not rows:
+            continue
+        out += [f"## {title}", ""]
+        if tier == 1:
+            out += ["| counter | phase | baseline | final | growth | verdict |", "|---|---|---|---|---|---|"]
+            out += [f"| {r['counter']} | {r.get('phase', 'cycleEnd')} | {r.get('baseline','-')} | {r.get('final','-')} | {r.get('growth','-')} | **{r['verdict']}** |" for r in rows]
+        elif tier == 2:
+            out += ["| counter | MB/cycle | 95% CI | n | verdict |", "|---|---|---|---|---|"]
+            # Collect volUnsized stats from Tier-1 rows so we can annotate volMB.
+            # volMB is a PARTIAL sum whenever volUnsized > 0; a non-zero baseline
+            # means the figure excludes some volumes, so we flag it for the reader.
+            all_t1 = [r for r in all_rows if r["tier"] == 1]
+            vu_row = next((r for r in all_t1 if r.get("counter") == "volUnsized"), None)
+            vu_baseline = vu_row.get("baseline", 0) if vu_row else 0
+            for r in rows:
+                label = r['counter']
+                if label == "volMB":
+                    if r['verdict'] == "NO_DATA":
+                        # Annotate the NO_DATA row so readers are not left guessing.
+                        # cornerstone 5.x MPR volumes use a lazy/streaming voxel manager
+                        # whose sizeInBytes getter throws; the client degrades to -1 sentinel.
+                        label = f"{label} _(no readable volume size — cornerstone streaming voxel manager)_"
+                    elif vu_baseline and vu_baseline > 0:
+                        label = f"{label} _(partial: {int(vu_baseline)} volumes unsized)_"
+                out.append(
+                    f"| {label} | {r.get('slope_per_cycle','-')} | {r.get('ci','-')} | {r.get('n','-')} | **{r['verdict']}** |"
+                )
+        else:
+            out += ["| action | early ms | late ms | change | verdict |", "|---|---|---|---|---|"]
+            out += [f"| {r['action']} | {r.get('early_ms','-')} | {r.get('late_ms','-')} | {r.get('pct_change','-')}% | **{r['verdict']}** |" for r in rows]
+        out.append("")
+
+    # I-2: render informational rows in a clearly labelled separate section.
+    if info_rows:
+        out += ["## Informational (not verdict-bearing)", ""]
+        out += ["> These series appear for diagnostic purposes only. They are excluded from",
+                "> the LEAK/DEGRADED verdict for the reasons stated below.", ""]
+        out += ["| counter | MB/cycle | 95% CI | n | verdict | reason |", "|---|---|---|---|---|---|"]
+        for r in info_rows:
+            reason = r.get("informational_reason", "excluded by policy")
+            out.append(
+                f"| {r['counter']} | {r.get('slope_per_cycle','-')} | {r.get('ci','-')} "
+                f"| {r.get('n','-')} | **{r['verdict']}** | {reason} |"
+            )
+        out.append("")
+
+    # Verdict logic uses only verdict_rows (not informational).
+    verdicts = [r["verdict"] for r in verdict_rows]
+    # NO_DATA MUST NOT COLLAPSE INTO "CLEAN". A counter that never reported is a
+    # BROKEN COLLECTOR, and a half-failed pipeline that prints "CLEAN" is the single
+    # worst output this tool can produce — it is exactly the false all-clear the
+    # positive control exists to prevent. Surface it as its own verdict.
+    missing = [r.get("counter") or r.get("action") for r in verdict_rows if r["verdict"] == "NO_DATA"]
+    unexpected = [m for m in missing if m not in EXPECTED_MISSING]
+
+    # An absent host stream is itself INCONCLUSIVE — missing collector != healthy system.
+    host_absent = results.get("host_count") == 0
+    # A server stream that was provided but ALL records were unusable is INCONCLUSIVE —
+    # it does NOT mean "no server leak found"; it means we couldn't measure.
+    server_inconclusive = results.get("server_inconclusive", False)
+    server_timing_lines = results.get("server_timing_lines", 0)
+
+    if "LEAK" in verdicts or "DEGRADED" in verdicts:
+        overall = "LEAK/DEGRADED FOUND"
+    elif unexpected or host_absent or server_inconclusive:
+        reasons = []
+        if unexpected:
+            reasons.append(f"{len(unexpected)} counter(s) reported no data: {', '.join(unexpected)}")
+        if host_absent:
+            reasons.append("host stream absent")
+        if server_inconclusive:
+            reasons.append(f"server stream provided but all {server_timing_lines} "
+                           f"[timing] line(s) produced 0 usable records — "
+                           f"check --log-tz or MONAI_PERF_TRACE setting")
+        overall = f"INCONCLUSIVE — {'; '.join(reasons)}"
+    else:
+        overall = "CLEAN"
+
+    out += ["## Overall", "", f"**{overall}**", ""]
+    if unexpected:
+        out += ["> A counter with no data means its collector failed, NOT that the system is healthy.",
+                "> Fix the collector and re-run before treating this soak as evidence of anything.", ""]
+    if host_absent:
+        out += ["> Host stream was absent. The container-memory and GPU counters were not checked.",
+                "> Run the host sampler and re-analyze before treating this as CLEAN.", ""]
+    if missing and not unexpected:
+        out += [f"_({len(missing)} expected-missing series/actions omitted: {', '.join(missing)})_", ""]
+    return "\n".join(out)
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Merge client/host/server soak traces and emit a three-tier memory-leak verdict.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Tier 1  volCount / listenerCount / viewportCount   [phase=cycleEnd]
+        segCount / blockCount / blockSlices           [phase=studyOpen]
+        Any monotonic growth after warmup is a LEAK — no statistics needed.
+        Most counters use phase='cycleEnd' (at-rest baseline). Block/segment
+        counters use phase='studyOpen' because OHIF's onModeExit clears
+        segmentations before cycleEnd — they return -1 at rest.
+
+Tier 2  heapMB / cacheMB / volMB (client)
+        + host.memMB[<container>] / host.gpuMB / host.diskMB (host stream)
+        + server.rssMB / server.vramMB (--server [timing] log)
+        Slope fitted with 95% CI; LEAK only when CI excludes zero on the positive side.
+        Client counters use cycleEnd samples; host/server records are bucketed
+        into cycles by wallT overlap with each cycleEnd sample.
+
+Tier 3  nninter / nninterRecovered / sam2 / segReset  (+ expected-missing seg* actions)
+        Last-5 vs early-5 cycles; DEGRADED when change exceeds 20%.
+
+Cycles 1-2 are warmup and excluded from all fitting.
+-1 values mean "unreadable" and are excluded from statistics; an all-(-1)
+counter surfaces as NO_DATA -> INCONCLUSIVE, never CLEAN.
+
+If no cycleEnd samples exist (old pre-contract trace), the tool yields
+NO_DATA -> INCONCLUSIVE rather than silently mixing phases.
+
+An absent host stream yields INCONCLUSIVE — a missing collector is not the
+same as a healthy one reporting zero growth.
+"""
+    )
+    ap.add_argument("--client", help="client JSONL path (default: newest runs/client-*.jsonl)")
+    ap.add_argument("--host", help="host JSONL path (default: newest runs/host-*.jsonl, optional)")
+    ap.add_argument("--server", metavar="LOGFILE",
+                    help="server log path containing [timing] lines with rss=/vram_alloc= fields")
+    ap.add_argument("--warmup", type=int, default=2, metavar="N",
+                    help="cycles to skip as warmup (default: 2)")
+    ap.add_argument("--out", metavar="PATH",
+                    help="report output path (default: reports/<date>-soak.md)")
+    ap.add_argument("--log-tz", metavar="HOURS", type=float, default=0.0,
+                    help="UTC offset (hours) of the logger timestamp in --server log "
+                         "(default: 0 = UTC, because containers default to UTC). "
+                         "Example: --log-tz=-5 for US Eastern, --log-tz=1 for CET. "
+                         "The assumed timezone is recorded in the report.")
+    ap.add_argument("--pinned-gpu", type=int, default=7, metavar="IDX",
+                    help="GPU device index pinned to monai_server via docker-compose "
+                         "device_ids (default: 7). LABELLING AID ONLY -- all host.gpuMB[*] "
+                         "rows are informational regardless of this value, because "
+                         "nvidia-smi --query-gpu=memory.used reports per-DEVICE usage, not "
+                         "per-process. On a shared DGX the pinned GPU showed 26,929 MiB "
+                         "total vs 826 MiB our process (about 3%%), so the row cannot support a "
+                         "verdict. The annotated row is labelled to show which device is ours. "
+                         "Process-scoped VRAM verdict comes from server.vram_alloc via --server. "
+                         "Source: docker-compose.yml device_ids: ['7:0'].")
+    ap.add_argument("--min-slope", type=float, default=0.2, metavar="MB_PER_CYCLE",
+                    help="Minimum effect-size floor for Tier-2 MB verdicts (default: 0.2 "
+                         "MB/cycle). A positive slope whose magnitude is below this floor is "
+                         "reported as CLEAN even when the CI excludes zero — statistically "
+                         "tight but physically meaningless. Set to 0 to disable. "
+                         "Does NOT apply to Tier-1 integer counters (any growth is real).")
+    a = ap.parse_args()
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    client_path = a.client or max(glob.glob(os.path.join(here, "runs", "client-*.jsonl")), key=os.path.getmtime)
+    recs = [json.loads(l) for l in open(client_path) if l.strip()]
+    samples = [r for r in recs if r.get("kind") == "sample"]
+    measures = [r for r in recs if r.get("kind") == "measure"]
+
+    # Host stream
+    host_recs = []
+    host_glob = glob.glob(os.path.join(here, "runs", "host-*.jsonl"))
+    if a.host or host_glob:
+        hp = a.host or max(host_glob, key=os.path.getmtime)
+        host_recs = [json.loads(l) for l in open(hp) if l.strip()]
+    host_count = len(host_recs)
+
+    # Resolve --log-tz to a datetime.timezone
+    log_tz = datetime.timezone(datetime.timedelta(hours=a.log_tz))
+    log_tz_label = f"UTC{a.log_tz:+.1f}" if a.log_tz else "UTC"
+
+    # Server stream
+    server_recs = []
+    server_present = False
+    server_skipped_counter_no_timestamp = 0
+    server_skipped_non_counter_lines = 0
+    server_timing_lines = 0
+    server_inconclusive = False
+    if a.server:
+        server_recs = parse_server_log(a.server, log_tz=log_tz)
+        server_present = True
+        server_skipped_counter_no_timestamp = getattr(server_recs, "skipped_counter_no_timestamp", 0)
+        server_skipped_non_counter_lines = getattr(server_recs, "skipped_non_counter_lines", 0)
+        server_timing_lines = getattr(server_recs, "timing_lines", 0)
+        # C7: ALL records unusable means the stream was provided but measured nothing.
+        # This includes the case where [timing] lines exist but carry no counters
+        # (server without MONAI_PERF_TRACE) — server_timing_lines > 0 makes that visible.
+        if server_timing_lines > 0 and len(server_recs) == 0:
+            server_inconclusive = True
+
+    # Build rows.
+    # Tier-1 counters are fitted on their phase-specific samples (see COUNTER_PHASE).
+    # Block counters (segCount, blockCount, blockSlices) are fitted on 'studyOpen'
+    # because onModeExit removes all segmentations before 'cycleEnd' is sampled.
+    rows = ([tier1_verdict(samples, c, a.warmup, phase=COUNTER_PHASE.get(c, "cycleEnd")) for c in TIER1]
+            + [tier2_verdict(samples, c, a.warmup, min_slope=a.min_slope) for c in TIER2]
+            + parse_host_stream(host_recs, samples, a.warmup,
+                                pinned_gpu=a.pinned_gpu, min_slope=a.min_slope)
+            + tier2_verdicts_from_server(server_recs, samples, a.warmup, min_slope=a.min_slope)
+            + [tier3_verdict(measures, n, a.warmup) for n in TIER3])
+
+    from datetime import date
+    results = {
+        "generated": str(date.today()),
+        "rows": rows,
+        "gaps": check_gaps(host_recs),
+        "host_count": host_count,
+        "server_present": server_present if a.server else None,
+        "server_skipped_counter_no_timestamp": server_skipped_counter_no_timestamp,
+        "server_skipped_non_counter_lines": server_skipped_non_counter_lines,
+        "server_timing_lines": server_timing_lines,
+        "server_inconclusive": server_inconclusive,
+        "log_tz_label": log_tz_label,
+        "min_slope": a.min_slope,
+    }
+    report = render_report(results)
+
+    out = a.out or os.path.join(here, "reports", f"{date.today()}-soak.md")
+    d = os.path.dirname(out)
+    if d:
+        os.makedirs(d, exist_ok=True)
+    open(out, "w").write(report)
+    print(report)
+    print(f"\nwritten to {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/perf/cleanup_orthanc.py
+++ b/tools/perf/cleanup_orthanc.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Delete ONLY the SEG series a soak run created.
+
+The fixture study already carries 5 pre-existing SEG series from manual testing
+alongside a 694-instance CT series (31 series total). This script is therefore
+STRICTLY ALLOWLIST-DRIVEN: it deletes exactly the Orthanc ids recorded in a
+created-segs-*.json file and nothing else.
+
+It NEVER queries Orthanc for "SEGs on the study".
+It NEVER deletes by modality, by date, or by any heuristic.
+Default behaviour is DRY RUN — pass --apply to delete for real.
+
+If the allowlist file is missing, empty, or unparseable it deletes NOTHING
+and explains why. A failure must be loud and safe, never silent.
+"""
+
+import argparse
+import glob
+import json
+import os
+import sys
+import urllib.request
+
+
+def delete_created(proxy: str, ids: list, dry_run: bool = True) -> list:
+    """Delete exactly the listed Orthanc series ids.
+
+    Args:
+        proxy:   Orthanc base URL, e.g. "http://localhost:1030/pacs".
+        ids:     Allowlist of Orthanc series ids to delete.
+        dry_run: When True (the default) nothing is deleted.
+
+    Returns:
+        List of ids that were successfully deleted.
+        Always empty when dry_run=True or ids=[].
+    """
+    if not ids:
+        print("No ids to delete — nothing to do.")
+        return []
+
+    deleted = []
+    for oid in ids:
+        if dry_run:
+            print(f"[dry-run] would delete {oid}")
+            continue
+        url = f"{proxy}/series/{oid}"
+        req = urllib.request.Request(url, method="DELETE")
+        try:
+            with urllib.request.urlopen(req, timeout=30) as r:
+                if r.status < 300:
+                    deleted.append(oid)
+                    print(f"deleted {oid}")
+                else:
+                    print(f"WARN: unexpected status {r.status} for {oid}")
+        except Exception as e:
+            print(f"FAILED to delete {oid}: {e}")
+    return deleted
+
+
+def load_allowlist(path: str) -> list | None:
+    """Load and validate the allowlist JSON file.
+
+    Returns the list of ids, or None if the file cannot be used safely.
+    Prints a clear explanation in every failure case.
+    """
+    if not os.path.exists(path):
+        print(f"ERROR: allowlist file not found: {path}")
+        print("Deleting NOTHING — supply a valid --run path or ensure a runs/ file exists.")
+        return None
+
+    try:
+        with open(path) as fh:
+            raw = fh.read().strip()
+    except OSError as e:
+        print(f"ERROR: cannot read {path}: {e}")
+        print("Deleting NOTHING.")
+        return None
+
+    if not raw:
+        print(f"ERROR: allowlist file is empty: {path}")
+        print("Deleting NOTHING.")
+        return None
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        print(f"ERROR: allowlist file is not valid JSON: {path}")
+        print(f"  Parse error: {e}")
+        print("Deleting NOTHING — refusing to fall back to any heuristic.")
+        return None
+
+    if not isinstance(data, list):
+        print(f"ERROR: allowlist file must contain a JSON array, got {type(data).__name__}: {path}")
+        print("Deleting NOTHING.")
+        return None
+
+    if len(data) == 0:
+        print(f"Allowlist is an empty array in {path} — nothing to delete.")
+        return []
+
+    # Validate every element is a non-empty string.
+    for idx, elem in enumerate(data):
+        if not isinstance(elem, str) or not elem:
+            print(f"ERROR: allowlist element at index {idx} is not a non-empty string: {elem!r}")
+            print("Deleting NOTHING — all allowlist entries must be valid Orthanc series ids.")
+            return None
+
+    return data
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument(
+        "--proxy",
+        default="http://localhost:1030/pacs",
+        help="Orthanc base URL (default: http://localhost:1030/pacs)",
+    )
+    ap.add_argument(
+        "--run",
+        metavar="PATH",
+        help="Path to created-segs-*.json from a soak run. "
+             "Defaults to the newest file in runs/.",
+    )
+    ap.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually delete. Without this flag the script only prints what it would do.",
+    )
+    a = ap.parse_args()
+
+    # Resolve the allowlist path.
+    if a.run:
+        path = a.run
+    else:
+        pattern = os.path.join(os.path.dirname(os.path.abspath(__file__)), "runs", "created-segs-*.json")
+        candidates = glob.glob(pattern)
+        if not candidates:
+            print(f"ERROR: no created-segs-*.json files found in {os.path.dirname(pattern)}")
+            print("Deleting NOTHING — run the soak first or supply --run <path>.")
+            return 1
+        path = max(candidates, key=os.path.getmtime)
+        print(f"Using newest allowlist: {path}")
+
+    ids = load_allowlist(path)
+    if ids is None:
+        # load_allowlist already printed the reason.
+        return 1
+
+    if len(ids) == 0:
+        return 0
+
+    dry_run = not a.apply
+    mode = "DRY RUN" if dry_run else "LIVE — data will be deleted"
+    print(f"\n{len(ids)} SEG series in allowlist | mode: {mode}")
+    if dry_run:
+        print("Pass --apply to delete for real.\n")
+
+    done = delete_created(a.proxy, ids, dry_run=dry_run)
+
+    if not dry_run:
+        print(f"\nDeleted {len(done)} / {len(ids)} series.")
+        if len(done) < len(ids):
+            failed = len(ids) - len(done)
+            print(f"ERROR: {failed} deletion(s) failed. Aborting.")
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/perf/fixture.example.json
+++ b/tools/perf/fixture.example.json
@@ -1,0 +1,22 @@
+{
+  "_comment": "Copy to fixture.json and fill in UIDs from YOUR Orthanc. fixture.json is gitignored on purpose: it holds DICOM identifiers from a real archive, and its URLs and tuning are machine-specific.",
+
+  "viewerUrl": "http://localhost:1030",
+  "orthancProxy": "http://localhost:1030/pacs",
+
+  "primaryStudyUID": "REPLACE_WITH_YOUR_STUDY_UID",
+  "primarySeriesUID": "REPLACE_WITH_YOUR_SERIES_UID",
+  "primaryOrthancId": "REPLACE_WITH_YOUR_ORTHANC_ID",
+
+  "switchStudyUIDs": [
+    "REPLACE_WITH_YOUR_STUDY_UID",
+    "REPLACE_WITH_A_SECOND_STUDY_UID",
+    "REPLACE_WITH_A_THIRD_STUDY_UID"
+  ],
+
+  "cycles": 30,
+  "refinesPerCycle": 5,
+
+  "_promptPoints": "Normalised canvas coordinates for the scribble/click prompts. These must land INSIDE the anatomy of your chosen series or inference returns an empty mask; re-tune them for your study.",
+  "promptPoints": [[0.45, 0.55], [0.5, 0.6], [0.55, 0.5], [0.48, 0.52], [0.52, 0.58]]
+}

--- a/tools/perf/playwright.perf.config.ts
+++ b/tools/perf/playwright.perf.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Standalone on purpose. Viewers/playwright.config.ts spins up a DEV server
+// (APP_CONFIG=config/e2e.js yarn start) against e2e fixtures; the soak must
+// exercise the DEPLOYED docker stack instead.
+export default defineConfig({
+  testDir: '.',
+  testMatch: /soak\.spec\.ts/,
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  timeout: 4 * 60 * 60 * 1000,
+  globalTimeout: 5 * 60 * 60 * 1000,
+  reporter: [['list']],
+  use: {
+    baseURL: process.env.PERF_VIEWER_URL || 'http://localhost:1030',
+    // Video recording leaks memory in the harness and would poison heapMB.
+    video: 'off',
+    trace: 'off',
+    screenshot: 'only-on-failure',
+    actionTimeout: 120_000,
+  },
+  projects: [
+    {
+      name: 'perf-chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        // Use the SYSTEM Chrome rather than Playwright's downloaded Chromium: this host
+        // has /usr/bin/google-chrome and no ms-playwright browser cache, so `channel`
+        // avoids a ~300MB `npx playwright install`. Verified by tools/perf/preflight.js,
+        // which confirms both flags below actually reach the renderer (window.gc exists).
+        channel: 'chrome',
+        launchOptions: {
+          args: [
+            '--enable-precise-memory-info', // unquantized performance.memory
+            '--js-flags=--expose-gc', // lets us force GC before every sample
+          ],
+        },
+      },
+    },
+  ],
+});

--- a/tools/perf/preflight.js
+++ b/tools/perf/preflight.js
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * Pre-flight instrument check — RUN THIS BEFORE EVERY SOAK.
+ *
+ * Loads the fixture study with ?perf=1 in a real browser, samples the client
+ * counters in both STACK and MPR, and reports which ones cannot be read.
+ *
+ * Why this exists: three whole-branch code reviews did not find the defects this
+ * check found in one run. Every client counter is unit-tested against fake
+ * objects; several only fail on contact with real cornerstone state. Found here:
+ *   - volMB permanently -1 (over-strict rule)
+ *   - volMB reporting -1 for an EMPTY volume cache, at exactly the at-rest phase
+ *     the verdict is computed from
+ *   - volMB permanently NO_DATA forcing INCONCLUSIVE on every run
+ * Any of those alone would have wasted an hour of GPU time on a useless verdict.
+ *
+ * READ-ONLY: loads a study and reads counters. No segmentation, no inference,
+ * no writes to Orthanc, no container changes.
+ *
+ * Usage:
+ *   node tools/perf/preflight.js                 # uses fixture.json's primary study
+ *   node tools/perf/preflight.js <StudyUID>
+ *
+ * Requires a Chrome/Chromium binary. Uses the system Chrome via Playwright's
+ * `channel: 'chrome'`, so no `npx playwright install` download is needed.
+ * Exits non-zero if an instrument is unreadable in a state where it should work.
+ */
+const path = require('path');
+const fs = require('fs');
+const { chromium } = require(path.join(__dirname, '..', '..', 'Viewers', 'node_modules', '@playwright', 'test'));
+
+function loadFixture(dir) {
+  const p = require('path').join(dir, 'fixture.json');
+  let raw;
+  try {
+    raw = require('fs').readFileSync(p, 'utf8');
+  } catch (e) {
+    throw new Error(
+      `tools/perf/fixture.json not found.\n` +
+      `It is gitignored because it holds DICOM UIDs from a real archive.\n` +
+      `Copy tools/perf/fixture.example.json to tools/perf/fixture.json and fill in your own study UIDs.`
+    );
+  }
+  const fx = JSON.parse(raw);
+  const unset = Object.entries(fx).filter(([, v]) =>
+    typeof v === 'string' ? v.startsWith('REPLACE_WITH') :
+    Array.isArray(v) && v.some(x => typeof x === 'string' && x.startsWith('REPLACE_WITH')));
+  if (unset.length) {
+    throw new Error(
+      `tools/perf/fixture.json still has placeholder values: ${unset.map(([k]) => k).join(', ')}.\n` +
+      `Fill them in with UIDs from your own Orthanc before running.`
+    );
+  }
+  return fx;
+}
+
+const fx = loadFixture(__dirname);
+const STUDY = process.argv[2] || fx.primaryStudyUID;
+const BASE = process.env.PERF_VIEWER_URL || fx.viewerUrl || 'http://localhost:1030';
+
+/** Counters that must be readable in BOTH stack and MPR. */
+const ALWAYS = ['heapMB', 'cacheMB', 'volCount', 'volUnsized', 'imgCount', 'viewportCount', 'listenerCount'];
+/** Known-unreadable, with the reason. Not a failure — see analyze.py's allow-list. */
+const KNOWN_UNREADABLE = {
+  volMB: 'cornerstone 5.x streaming voxel managers have no materialized scalar data, ' +
+         'so ImageVolume.sizeInBytes throws. volCount is the load-bearing volume-leak signal.',
+};
+
+(async () => {
+  const browser = await chromium.launch({
+    channel: 'chrome',
+    args: ['--enable-precise-memory-info', '--js-flags=--expose-gc'],
+  });
+  const page = await browser.newPage();
+  const pageErrors = [];
+  page.on('pageerror', e => pageErrors.push(String(e).slice(0, 200)));
+
+  const url = `${BASE}/viewer?StudyInstanceUIDs=${STUDY}&perf=1`;
+  console.log(`loading ${url}`);
+  await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 120000 });
+
+  try {
+    await page.waitForFunction(() => !!window.__ohifPerf, null, { timeout: 120000 });
+  } catch {
+    console.error('\nFAIL: window.__ohifPerf never appeared.');
+    console.error('  - the flag must be present on a FULL document load (?perf=1 in the address bar);');
+    console.error('    clicking through from the worklist will NOT arm it — the module decides once at load.');
+    console.error('  - or the viewer image predates the telemetry: docker compose build ohif_viewer');
+    await browser.close();
+    process.exit(1);
+  }
+
+  await page.waitForSelector('canvas', { timeout: 180000 }).catch(() => {});
+  await page.waitForTimeout(20000);
+
+  const snap = label => page.evaluate(l => {
+    const h = window.__ohifPerf;
+    h.forceGC && h.forceGC();
+    return { gc: typeof window.gc === 'function', ...h.snapshot(l) };
+  }, label);
+
+  const stack = await snap('preflight-stack');
+  await page.evaluate(() =>
+    window.__ohifPerf.commandsManager.runCommand('setHangingProtocol', { protocolId: 'mpr' })
+  ).catch(e => pageErrors.push('mpr: ' + String(e).slice(0, 120)));
+  await page.waitForTimeout(30000);
+  const mpr = await snap('preflight-mpr');
+
+  await browser.close();
+
+  const fmt = s => ALWAYS.concat(Object.keys(KNOWN_UNREADABLE))
+    .map(k => `${k}=${s[k]}`).join('  ');
+  console.log(`\nstack: ${fmt(stack)}`);
+  console.log(`mpr  : ${fmt(mpr)}`);
+  console.log(`gc available: ${stack.gc}`);
+  if (pageErrors.length) console.log('page errors:', pageErrors.slice(0, 3));
+
+  const bad = [];
+  for (const k of ALWAYS) {
+    for (const [state, s] of [['stack', stack], ['mpr', mpr]]) {
+      if (s[k] === -1) bad.push(`${k} unreadable in ${state}`);
+    }
+  }
+  // Block counters are legitimately -1 until a segmentation exists; not checked here.
+  for (const [k, why] of Object.entries(KNOWN_UNREADABLE)) {
+    if (stack[k] === -1 || mpr[k] === -1) console.log(`\nnote: ${k} unreadable — ${why}`);
+  }
+  if (!stack.gc) {
+    console.log('\nnote: window.gc absent — heap TRENDS are unreliable without forced GC.');
+  }
+
+  if (bad.length) {
+    console.error('\nFAIL — instruments unreadable against real cornerstone:');
+    bad.forEach(b => console.error('  - ' + b));
+    console.error('Fix these before soaking; a soak cannot produce a verdict from counters that report -1.');
+    process.exit(1);
+  }
+  console.log('\nPASS — every required instrument reports a real value in both stack and MPR.');
+})();

--- a/tools/perf/sample_host.sh
+++ b/tools/perf/sample_host.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Host-side perf sampler. Runs OUTSIDE the containers so it keeps recording even
+# if the browser or the MONAI server dies mid-soak.
+# Usage: tools/perf/sample_host.sh [output.jsonl] [interval_seconds]
+#
+# Produces JSONL with records:
+#   heartbeat  — one per tick, always; lets the analyzer detect sampler death
+#   container  — memMB, memLimitMB, cpuPct per container per tick
+#   gpu        — gpuMB, gpuUtil per GPU per tick
+#   disk       — diskMB for each watched directory per tick
+#
+# Missing containers, GPUs, or paths yield either no record (container down) or
+# explicit -1 values — never a fake 0 that looks healthy.
+set -uo pipefail
+
+OUT="${1:-tools/perf/runs/host-$(date +%Y%m%d-%H%M%S).jsonl}"
+INTERVAL="${2:-2}"
+CONTAINERS="ohif_viewer ohif_orthanc monai_server"
+
+# Derive repo root from script location so paths work from any working directory
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ORTHANC_DB="$REPO_ROOT/Viewers/platform/app/.recipes/Nginx-Orthanc/volumes/orthanc-db"
+IMG_CACHE="$REPO_ROOT/monai-label/img_cache"
+
+mkdir -p "$(dirname "$OUT")"
+echo "sampling to $OUT every ${INTERVAL}s; Ctrl-C to stop" >&2
+
+# Warn at startup if any watched path does not exist
+for p in "$ORTHANC_DB" "$IMG_CACHE"; do
+  if [ ! -d "$p" ]; then
+    echo "WARNING: watched path does not exist: $p" >&2
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# to_mb: convert docker memory strings (e.g. "1.5GiB", "900MiB", "12.3MB")
+# to a numeric MB value.  Returns -1 on any unparseable input — never 0,
+# never empty, so a broken reading can be distinguished from a healthy zero.
+# Must be defined before first use (called inline in the main loop below).
+# ---------------------------------------------------------------------------
+to_mb() {
+  echo "$1" | awk '
+    /TiB/ {gsub(/TiB/,""); printf "%.1f", $1*1024*1024; exit}
+    /GiB/ {gsub(/GiB/,""); printf "%.1f", $1*1024;      exit}
+    /MiB/ {gsub(/MiB/,""); printf "%.1f", $1;           exit}
+    /KiB/ {gsub(/KiB/,""); printf "%.3f", $1/1024;      exit}
+    /TB/  {gsub(/TB/,"");  printf "%.1f", $1*1000*1000; exit}
+    /GB/  {gsub(/GB/,"");  printf "%.1f", $1*1000;      exit}
+    /MB/  {gsub(/MB/,"");  printf "%.1f", $1;           exit}
+    /kB/  {gsub(/kB/,"");  printf "%.3f", $1/1000;      exit}
+    {printf "-1"}'
+}
+export -f to_mb
+
+# ---------------------------------------------------------------------------
+# to_num: emit a numeric string unchanged, or -1 if it is not a bare number
+# (handles nvidia-smi's "[N/A]" for MIG-mode GPUs).
+# ---------------------------------------------------------------------------
+to_num() {
+  echo "$1" | awk '$1+0==$1 {print $1+0; exit} {print -1}'
+}
+
+# ---------------------------------------------------------------------------
+# Main sampling loop
+# ---------------------------------------------------------------------------
+while true; do
+  TS=$(date +%s.%N)
+
+  # --- heartbeat (always first; must succeed even if everything else fails) ---
+  echo "{\"t\":$TS,\"kind\":\"heartbeat\"}" >>"$OUT"
+
+  # --- container stats ---
+  # Use process substitution instead of pipe to avoid running to_mb in a
+  # subshell that might not inherit the exported function on some bash builds.
+  while IFS=$'\t' read -r name mem cpu; do
+    used=$(echo "$mem" | awk -F' / ' '{print $1}')
+    lim=$(echo "$mem"  | awk -F' / ' '{print $2}')
+    # Strip trailing '%' from cpu; route through to_num to ensure numeric value
+    cpuval="${cpu%\%}"
+    cpunum=$(to_num "$cpuval")
+    echo "{\"t\":$TS,\"kind\":\"container\",\"container\":\"$name\",\"memMB\":$(to_mb "$used"),\"memLimitMB\":$(to_mb "$lim"),\"cpuPct\":$cpunum}"
+  done < <(docker stats --no-stream \
+               --format '{{.Name}}\t{{.MemUsage}}\t{{.CPUPerc}}' \
+               $CONTAINERS 2>/dev/null) >>"$OUT"
+
+  # --- GPU stats (nvidia-smi may be absent or fail — tolerate both) ---
+  if command -v nvidia-smi >/dev/null 2>&1; then
+    while IFS=', ' read -r idx used util; do
+      # Trim whitespace that nvidia-smi sometimes adds after the comma
+      idx="${idx// /}"; used="${used// /}"; util="${util// /}"
+      echo "{\"t\":$TS,\"kind\":\"gpu\",\"gpu\":$(to_num "$idx"),\"gpuMB\":$(to_num "$used"),\"gpuUtil\":$(to_num "$util")}"
+    done < <(nvidia-smi --query-gpu=index,memory.used,utilization.gpu \
+                        --format=csv,noheader,nounits 2>/dev/null) >>"$OUT"
+  fi
+
+  # --- disk usage ---
+  # du -s on large directories can be slow.  Run each du in the background,
+  # collect results, and cap the wait so a slow du cannot stall the cadence.
+  declare -A du_pids du_files
+  for p in "$ORTHANC_DB" "$IMG_CACHE"; do
+    if [ -d "$p" ]; then
+      tmpf=$(mktemp)
+      du -sm "$p" >"$tmpf" 2>/dev/null &
+      du_pids["$p"]=$!
+      du_files["$p"]=$tmpf
+    fi
+  done
+  # Wait up to (INTERVAL - 0.5) seconds for du results; skip if still running
+  du_deadline=$(awk "BEGIN{print $INTERVAL - 0.5}")
+  for p in "${!du_pids[@]}"; do
+    pid=${du_pids[$p]}
+    tmpf=${du_files[$p]}
+    if kill -0 "$pid" 2>/dev/null; then
+      # Poll briefly rather than blocking indefinitely
+      waited=0
+      while kill -0 "$pid" 2>/dev/null && awk "BEGIN{exit ($waited >= $du_deadline)}"; do
+        sleep 0.1
+        waited=$(awk "BEGIN{print $waited + 0.1}")
+      done
+    fi
+    if kill -0 "$pid" 2>/dev/null; then
+      # Still running — skip this tick, do not block
+      kill "$pid" 2>/dev/null
+      rm -f "$tmpf"
+    else
+      mb=$(cut -f1 <"$tmpf" 2>/dev/null)
+      [ -z "$mb" ] && mb="-1"
+      echo "{\"t\":$TS,\"kind\":\"disk\",\"path\":\"$p\",\"diskMB\":$mb}" >>"$OUT"
+      rm -f "$tmpf"
+    fi
+  done
+  unset du_pids du_files
+
+  sleep "$INTERVAL"
+done

--- a/tools/perf/soak.spec.ts
+++ b/tools/perf/soak.spec.ts
@@ -1,0 +1,867 @@
+import { test, expect, Page } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Set PERF_LEAK=1 in the environment to enable the positive leak-detector
+// control: the viewer will retain ~8 MB of ballast per study open, producing
+// a deterministic heap ramp that proves the analyzer can detect leaks.
+// Example: PERF_LEAK=1 npx playwright test --config ...
+// Default is OFF (no extra query param appended).
+const PERF_LEAK = process.env.PERF_LEAK === '1';
+
+function loadFixture(dir) {
+  const p = require('path').join(dir, 'fixture.json');
+  let raw;
+  try {
+    raw = require('fs').readFileSync(p, 'utf8');
+  } catch (e) {
+    throw new Error(
+      `tools/perf/fixture.json not found.\n` +
+      `It is gitignored because it holds DICOM UIDs from a real archive.\n` +
+      `Copy tools/perf/fixture.example.json to tools/perf/fixture.json and fill in your own study UIDs.`
+    );
+  }
+  const fx = JSON.parse(raw);
+  const unset = Object.entries(fx).filter(([, v]) =>
+    typeof v === 'string' ? v.startsWith('REPLACE_WITH') :
+    Array.isArray(v) && v.some(x => typeof x === 'string' && x.startsWith('REPLACE_WITH')));
+  if (unset.length) {
+    throw new Error(
+      `tools/perf/fixture.json still has placeholder values: ${unset.map(([k]) => k).join(', ')}.\n` +
+      `Fill them in with UIDs from your own Orthanc before running.`
+    );
+  }
+  return fx;
+}
+
+const fx: any = loadFixture(__dirname);
+const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+const runsDir = path.join(__dirname, 'runs');
+const clientOut = path.join(runsDir, `client-${stamp}.jsonl`);
+const createdOut = path.join(runsDir, `created-segs-${stamp}.json`);
+const orphanOut = path.join(runsDir, `orphan-warning-${stamp}.txt`);
+// Per-step timing log. Written with appendFileSync so a kill -9 still leaves
+// everything up to the stalled step on disk. The LAST "start" entry with no
+// matching "end" entry IS the stalled step — search for it with:
+//   jq 'select(.event=="start")' runs/steps-<stamp>.jsonl | tail -1
+const stepsOut = path.join(runsDir, `steps-${stamp}.jsonl`);
+
+// =========================================================================
+// Per-step timing helper.
+//
+// Writes one JSON line the moment a step STARTS and another when it ENDS:
+//   {"t":<epoch ms>,"cycle":N,"step":"<name>","event":"start"|"end","ms":<duration on end>}
+//
+// Uses fs.appendFileSync so a kill -9 still preserves everything written so far.
+// The last "start" line with no matching "end" line IS the stalled step.
+//
+// Also enforces a per-step timeout: if fn() does not resolve within timeoutMs,
+// throws immediately with a message naming the step, the cycle, and the budget.
+// This makes it impossible for any single step to hang the entire soak.
+//
+// Echoes each step completion to stdout as:
+//   [perf] cycle N step <name> <ms>ms
+// so a live run is watchable via the forwarded console output.
+// =========================================================================
+async function step<T>(
+  cycle: number,
+  name: string,
+  fn: () => Promise<T>,
+  timeoutMs: number
+): Promise<T> {
+  const startMs = Date.now();
+  fs.appendFileSync(
+    stepsOut,
+    JSON.stringify({ t: startMs, cycle, step: name, event: 'start' }) + '\n'
+  );
+  let result: T;
+  try {
+    result = await Promise.race([
+      fn(),
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () =>
+            reject(
+              new Error(
+                `[perf] STALL: cycle ${cycle} step "${name}" exceeded budget of ${timeoutMs}ms. ` +
+                  `This is where the run stalled — check steps-${stamp}.jsonl for prior steps.`
+              )
+            ),
+          timeoutMs
+        )
+      ),
+    ]);
+  } catch (err) {
+    // Record a timeout/error end event so the file stays parseable.
+    const durationMs = Date.now() - startMs;
+    fs.appendFileSync(
+      stepsOut,
+      JSON.stringify({ t: Date.now(), cycle, step: name, event: 'end', ms: durationMs, error: String(err) }) + '\n'
+    );
+    throw err;
+  }
+  const durationMs = Date.now() - startMs;
+  fs.appendFileSync(
+    stepsOut,
+    JSON.stringify({ t: Date.now(), cycle, step: name, event: 'end', ms: durationMs }) + '\n'
+  );
+  console.log(`[perf] cycle ${cycle} step ${name} ${durationMs}ms`);
+  return result;
+}
+
+/** Force GC then sample. Without the GC, retained memory and uncollected garbage
+ *  are indistinguishable and every run looks like a leak.
+ *  The optional `extra` object is forwarded into the record (e.g. wallT, studyUID). */
+async function sample(page: Page, phase: string, extra?: Record<string, unknown>) {
+  await page.evaluate(
+    async ([p, ex]) => {
+      const h = (window as any).__ohifPerf;
+      h.forceGC?.();
+      await new Promise(r => setTimeout(r, 250));
+      h.snapshot(p, ex ?? undefined);
+    },
+    [phase, extra ?? null] as [string, Record<string, unknown> | null]
+  );
+}
+
+/**
+ * Open a study via CLIENT-SIDE navigation (does NOT reload the document).
+ * `window.__ohifPerf.navigate` is a wrapper around React Router's `navigate()`
+ * that was wired up in commandsModule.ts → installPerfHandle.
+ *
+ * C5 FIX: navigate is NOT called via `?.` — a null navigate must throw, not
+ * silently no-op. `history.navigate` is only assigned while the viewer route is
+ * mounted (Mode.tsx:56); calling this from the worklist would swallow the nav
+ * and then time out three minutes later on the canvas waitForSelector. We make
+ * the failure loud and immediate instead.
+ *
+ * We wait for a canvas to appear as the signal that the viewer has rendered.
+ * `__ohifPerf` itself persists because it is module-level — no re-init needed.
+ */
+async function openStudy(page: Page, studyUID: string) {
+  const urlBefore = page.url();
+  await page.evaluate(uid => {
+    const h = (window as any).__ohifPerf;
+    // Explicitly guard — do NOT use `?.` here. A null navigate silently
+    // no-ops (C5): the worklist never mounts the viewer route so history.navigate
+    // is null there, and `?.` would swallow the call without moving the URL.
+    const nav = h && h.navigate;
+    if (typeof nav !== 'function') {
+      throw new Error(
+        '[perf C5] window.__ohifPerf.navigate is null or not a function. ' +
+        'history.navigate is only assigned while the viewer route is mounted ' +
+        '(Mode.tsx:56). If this is cycle 1 it means the first openStudy() was ' +
+        'incorrectly invoked from the worklist — use page.goto() for cycle 1, ' +
+        'not openStudy(). Check the soak initialization sequence.'
+      );
+    }
+    nav(`/viewer?StudyInstanceUIDs=${uid}&perf=1`);
+  }, studyUID);
+  // Verify that client-side navigation actually moved the URL.  If navigate was
+  // a no-op (e.g. wrong route mounted, stale closure), the canvas wait below
+  // would silently time out three minutes later — fail fast and name C5.
+  await page.waitForFunction(
+    ([before, uid]) => {
+      const url = window.location.href;
+      return url !== before && url.includes(uid);
+    },
+    [urlBefore, studyUID] as [string, string],
+    { timeout: 10_000 }
+  ).catch(() => {
+    throw new Error(
+      `[perf C5] Client-side navigation did not change the URL after 10 s ` +
+      `(still at ${urlBefore}). The navigate call was silently swallowed — ` +
+      `history.navigate was not wired up or was null at call time. ` +
+      `Check installPerfHandle in commandsModule.ts and Mode.tsx:56.`
+    );
+  });
+  await page.waitForSelector('canvas', { timeout: 180_000 });
+  await page.waitForTimeout(3000); // let initial series load settle
+}
+
+/**
+ * Close the current study and return to the study list via CLIENT-SIDE navigation.
+ * Does NOT reload the document — the JS realm and all counters are preserved.
+ */
+async function closeStudy(page: Page) {
+  await page.evaluate(() => {
+    const nav = (window as any).__ohifPerf?.navigate;
+    if (!nav) {
+      throw new Error(
+        '[perf] window.__ohifPerf.navigate is not available for closeStudy.'
+      );
+    }
+    nav('/');
+  });
+  // Wait for the study list to render (a table row or the worklist heading).
+  // Use a broad selector that is stable regardless of data-cy attributes.
+  await page.waitForFunction(
+    () => !document.querySelector('canvas'),
+    { timeout: 30_000 }
+  );
+  await page.waitForTimeout(1000); // let unload/cleanup settle
+}
+
+async function segmentCount(page: Page): Promise<number> {
+  return page.evaluate(() => (window as any).__ohifPerf.snapshot('probe').segCount);
+}
+
+/** The segmentation commands all take an explicit segmentationId. */
+async function activeSegmentationId(page: Page): Promise<string> {
+  const id = await page.evaluate(() => {
+    const sm = (window as any).__ohifPerf.servicesManager.services;
+    const svc = sm.segmentationService;
+    // getActiveSegmentation requires a viewportId (verified: SegmentationService.ts:824).
+    // Obtain it from viewportGridService.getActiveViewportId() (verified: ViewportGridService.ts:175).
+    const viewportId = sm.viewportGridService?.getActiveViewportId?.() ?? undefined;
+    return (
+      (viewportId ? svc.getActiveSegmentation?.(viewportId)?.segmentationId : undefined) ??
+      svc.getSegmentations?.()?.[0]?.segmentationId ??
+      null
+    );
+  });
+  expect(id, 'no active segmentation to drive segment commands').not.toBeNull();
+  return id as string;
+}
+
+/** Return the set of segment indices present on a segmentation. */
+async function segmentIndices(page: Page, segId: string): Promise<number[]> {
+  return page.evaluate(id => {
+    const svc = (window as any).__ohifPerf.servicesManager.services.segmentationService;
+    const segs = svc.getSegmentations?.() ?? [];
+    const seg = segs.find((s: any) => s.segmentationId === id);
+    if (!seg?.segments) return [];
+    return Object.keys(seg.segments).map(Number);
+  }, segId);
+}
+
+test('perf soak', async ({ page }) => {
+  // Belt-and-suspenders: set localStorage before any page navigation so
+  // __ohifPerf is enabled even if the router strips the ?perf=1 query param.
+  await page.addInitScript(() => localStorage.setItem('ohifPerf', '1'));
+
+  // Suppress the onboarding tour. FOUND BY AN ACTUAL RUN, not by review: on a fresh
+  // browser profile OHIF shows a 12-step Shepherd tour ('basicViewerTour') with a modal
+  // backdrop that SWALLOWS the canvas click. No annotation is created, MEASUREMENT_ADDED
+  // never fires, and the soak reports "no segment appeared" — with the real cause
+  // invisible in any log. The failure screenshot is what exposed it.
+  // Suppression contract: utilities.ts does `getShownTours().includes(tourId)` over
+  // JSON.parse(localStorage.getItem('shownTours')), so pre-seeding the id is enough.
+  await page.addInitScript(() =>
+    localStorage.setItem('shownTours', JSON.stringify(['basicViewerTour']))
+  );
+
+  fs.mkdirSync(runsDir, { recursive: true });
+  const createdSegs: string[] = [];
+  // Print the allowlist path NOW so an operator whose run dies knows where to look.
+  console.log(`created SEG allowlist -> ${createdOut}  (written incrementally)`);
+  // Print the steps file path so a stalled run can be diagnosed immediately.
+  // The last "start" entry with no matching "end" entry in this file IS the stalled step.
+  console.log(`step timing log      -> ${stepsOut}  (written incrementally; last start-without-end = stall)`);
+
+  let deleteSkipCount = 0;
+  let primaryCycleCount = 0;
+
+  // I-4 FIX: forward both [perf] and [perfLeak] messages.
+  // '[perfLeak] POSITIVE CONTROL ACTIVE'.startsWith('[perf]') is FALSE — the
+  // old filter silently swallowed the one signal confirming the control armed.
+  // '[perfLeak]'.startsWith('[perf') is TRUE — both prefixes now pass.
+  const perfLeakMessages: string[] = [];
+  page.on('console', m => {
+    const t = m.text();
+    if (t.startsWith('[perf')) {
+      console.log(t);
+      if (t.includes('[perfLeak]')) perfLeakMessages.push(t);
+    }
+  });
+
+  // =========================================================================
+  // C5 FIX: Seed the router with the FIRST study via a REAL document navigation.
+  //
+  // history.navigate is only assigned while the viewer ROUTE is mounted
+  // (Mode.tsx:56). Landing on the worklist first (/?perf=1) means
+  // history.navigate is null, openStudy()'s `?.` swallows the call silently,
+  // and the canvas waitForSelector times out three minutes later.
+  //
+  // Solution: for cycle 1 only, use page.goto('/viewer?StudyInstanceUIDs=...'),
+  // which mounts the viewer route and assigns history.navigate.  All subsequent
+  // openStudy() calls use client-side navigation — the document is never replaced
+  // after this point, so all counters and module-level state are preserved.
+  //
+  // The leak-control query param (&perfLeak=1) is appended when PERF_LEAK=1 is
+  // set in the environment — see the top of this file for usage instructions.
+  // =========================================================================
+  const firstStudyUID = fx.switchStudyUIDs[1 % fx.switchStudyUIDs.length];
+  const leakParam = PERF_LEAK ? '&perfLeak=1' : '';
+  const seedURL = `/viewer?StudyInstanceUIDs=${firstStudyUID}&perf=1${leakParam}`;
+  await page.goto(seedURL);
+  // Wait for the perf handle to appear — it is installed by installPerfHandle
+  // which runs after the viewer route mounts and commandsModule activates.
+  await page.waitForFunction(() => !!(window as any).__ohifPerf, null, { timeout: 120_000 });
+  // Also wait for a canvas so we know the viewer actually rendered before we
+  // stamp the nonce.  Without this, the nonce might be captured before the
+  // viewer is fully up and subsequent client-side navs would look like the
+  // first cycle is still loading.
+  await page.waitForSelector('canvas', { timeout: 180_000 });
+  await page.waitForTimeout(3000); // let initial series load settle
+
+  // CONTINUITY INVARIANT: stamp a nonce AFTER the first real navigation.
+  // The nonce is asserted at the start of every subsequent cycle.
+  // If any navigation replaced the document, the nonce will be absent or wrong
+  // and the test fails loudly — because a fresh document resets all counters to
+  // zero and cross-cycle trends become meaningless.
+  // NOTE: The nonce is stamped here (after first real goto), not at the worklist.
+  // This means the continuity invariant covers cycles 2..N — the cycles where
+  // accumulation actually matters.
+  const nonce = await page.evaluate(() => {
+    (window as any).__ohifPerf.__nonce ??= Math.random();
+    return (window as any).__ohifPerf.__nonce;
+  });
+
+  // =========================================================================
+  // I11 FIX: Hard-assert that --expose-gc reached the renderer before cycle 1.
+  //
+  // forceGC() calls globalThis.gc() (no `?.`) — if gc is absent every sample
+  // measures retained garbage as heap growth, making every run look like a leak.
+  // The playwright config passes --js-flags=--expose-gc; if that flag was
+  // dropped or overridden, this assertion fails immediately with a clear message
+  // rather than silently producing false positives for the entire run.
+  // =========================================================================
+  await page.evaluate(() => {
+    if (typeof (window as any).gc !== 'function') {
+      throw new Error(
+        '[perf I11] window.gc is not a function — --js-flags=--expose-gc did not ' +
+        'reach the renderer process. Without forced GC, retained memory and ' +
+        'uncollected garbage are indistinguishable and every run will look like ' +
+        'a leak (false positive). Fix: verify launchOptions.args in ' +
+        'playwright.perf.config.ts includes --js-flags=--expose-gc.'
+      );
+    }
+  });
+
+  // =========================================================================
+  // I3 FIX: Activate Probe2 + nnInteractive + live mode BEFORE the loop.
+  // toolboxState defaults: liveMode=true, selectedModel='nnInteractive'.
+  // We still force them here to be resilient to future default changes.
+  // Command names VERIFIED against registry:
+  //   setToolActive   -> extensions/cornerstone/src/commandsModule.ts:764
+  //   runAiSegmentation -> extensions/default/src/commandsModule.ts:1067,4593
+  // toolboxState.setSelectedModel / setLiveMode are module-level setters
+  // accessed via the servicesManager path (no public command, set directly).
+  // =========================================================================
+  await page.evaluate(() => {
+    const h = (window as any).__ohifPerf;
+    // Prefer commandsManager to activate the tool so tool groups are updated.
+    h.commandsManager.runCommand('setToolActive', { toolName: 'Probe2' });
+    // Arm toolboxState via the perf handle (exposed by installPerfHandle after
+    // the fix in perfTraceBrowser.ts). These three conditions gate the
+    // MEASUREMENT_ADDED subscription in commandsModule.ts:81-96 — all must
+    // hold or the subscription bails before calling runAiSegmentationCommand.
+    // Setter names verified in stores/toolboxState.ts:70,99,112.
+    const ts = h.toolboxState;
+    ts.setSelectedModel('nnInteractive');
+    ts.setLiveMode(true);
+    ts.setLocked(false);
+  });
+
+  // =========================================================================
+  // Cycle 1: the first study is ALREADY OPEN (seeded via page.goto above).
+  // Run the full in-study workflow on it, then enter the normal loop starting
+  // at cycle 2.  We track the current studyUID separately so the loop body
+  // can assume the study is already open at loop entry.
+  // =========================================================================
+
+  for (let cycle = 1; cycle <= fx.cycles; cycle++) {
+    // Cycle 1 uses firstStudyUID (already open via page.goto).
+    // Cycles 2..N pick from the round-robin list and open via client-side nav.
+    const studyUID = cycle === 1
+      ? firstStudyUID
+      : fx.switchStudyUIDs[cycle % fx.switchStudyUIDs.length];
+
+    // CONTINUITY ASSERTION: the nonce must survive every cycle (cycles 2..N).
+    // Cycle 1's nonce was stamped just above, so assert from cycle 2 onward.
+    // If it changed, the document was replaced and all counters restarted from
+    // zero — the soak can no longer observe cross-cycle trends.
+    if (cycle > 1) {
+      const currentNonce = await page.evaluate(() => (window as any).__ohifPerf?.__nonce);
+      expect(
+        currentNonce,
+        `CONTINUITY VIOLATION at start of cycle ${cycle}: document was replaced ` +
+          `(nonce changed from ${nonce} to ${currentNonce}). ` +
+          `All counters reset to zero — cross-cycle trends are meaningless. ` +
+          `Fix: ensure no page.goto or full-reload occurs inside the loop.`
+      ).toBe(nonce);
+    }
+
+    // I-4 FIX: When PERF_LEAK=1 is set, hard-assert that the positive control
+    // actually armed before cycle 2.  A control that silently fails to fire is
+    // the same failure class as a detector that silently fails to detect — both
+    // produce false confidence.  We check at the START of cycle 2 (after cycle 1
+    // has fully executed) so the browser has had time to emit the console message.
+    if (PERF_LEAK && cycle === 2) {
+      const armed = perfLeakMessages.some(msg => msg.includes('POSITIVE CONTROL ACTIVE'));
+      expect(
+        armed,
+        '[perf I-4] PERF_LEAK=1 was set but the "[perfLeak] POSITIVE CONTROL ACTIVE" ' +
+          'console message was NEVER observed before cycle 2. ' +
+          'The leak injector did not arm — the positive control run is invalid. ' +
+          'Check that &perfLeak=1 was appended to the seed URL and that the ' +
+          'leakRetain() hook in the viewer is reachable.'
+      ).toBe(true);
+    }
+
+    // Cycle 1: already open via page.goto — do not call openStudy().
+    // Cycles 2..N: client-side navigation via window.__ohifPerf.navigate.
+    if (cycle > 1) {
+      await step(cycle, 'openStudy', () => openStudy(page, studyUID), 240_000);
+    }
+    await page.evaluate(c => (window as any).__ohifPerf.setCycle(c), cycle);
+    await step(cycle, 'studyOpenSample', () => sample(page, 'afterOpen', { wallT: Date.now(), studyUID }), 60_000);
+
+    // --- nnInteractive: new segment + K refines (pinned fixture study only) ---
+    if (studyUID === fx.primaryStudyUID) {
+      // Re-activate Probe2 each primary cycle in case a prior cycle left a
+      // different tool active (e.g. from the MPR toggle restoring Pan).
+      // Also arm toolboxState so the MEASUREMENT_ADDED subscription fires
+      // inference — this is the real user path (verified root cause: calling
+      // runAiSegmentation directly bypasses the 50ms defer that lets
+      // _calculateCachedStats populate cachedStats[targetId].scribble, causing
+      // nninter to receive an empty prompt and return an empty prediction).
+      // Setters verified in stores/toolboxState.ts: setLiveMode (line 70),
+      // setSelectedModel (line 99), setLocked (line 112).
+      await page.evaluate(() => {
+        const h = (window as any).__ohifPerf;
+        h.commandsManager.runCommand('setToolActive', { toolName: 'Probe2' });
+        // Force the three conditions that gate the MEASUREMENT_ADDED handler:
+        //   toolboxState.getLiveMode()        must be true
+        //   toolboxState.getSelectedModel()   must be 'nnInteractive'
+        //   toolboxState.getLocked()          must be false (default, forced here)
+        const ts = h.toolboxState;
+        ts.setSelectedModel('nnInteractive');
+        ts.setLiveMode(true);
+        ts.setLocked(false);
+      });
+
+      for (let i = 0; i < fx.refinesPerCycle; i++) {
+        const [nx, ny] = fx.promptPoints[i % fx.promptPoints.length];
+        const box = await page.locator('canvas').first().boundingBox();
+        expect(box, 'canvas must be present for prompt clicks').not.toBeNull();
+
+        await step(cycle, `promptClick${i}`, async () => {
+          // Click only — do NOT call runAiSegmentation manually.
+          // The click creates a Probe2 annotation, which fires MEASUREMENT_ADDED,
+          // which the commandsModule subscription defers 50ms (past the RAF that
+          // populates cachedStats[targetId].scribble), then calls runAiSegmentation.
+          // Bypassing this path caused prompt_info:{} / empty prediction in the
+          // smoke run (server logged model_core=0.000s, nninter_first_interaction_ts=None).
+          await page.mouse.click(box!.x + box!.width * nx, box!.y + box!.height * ny);
+        }, 30_000);
+
+        // FAIL FAST: wait for a segment to appear with a 60-second bound.
+        // If no segment appears the soak must abort immediately, not hang for
+        // 25 minutes. Likely causes if this throws:
+        //   - liveMode is off (setLiveMode(true) above did not apply)
+        //   - selectedModel is not 'nnInteractive'
+        //   - the Probe2 annotation produced no scribble in cachedStats
+        //   - toolboxState.getLocked() returned true (inference guard bailed)
+        //   - the MONAI server is unreachable or returned an empty prediction
+        const segAppeared = await step(cycle, `segAppears${i}`, () =>
+          page.waitForFunction(
+            () => {
+              const sm = (window as any).__ohifPerf?.servicesManager?.services;
+              if (!sm) return false;
+              const svc = sm.segmentationService;
+              const viewportId = sm.viewportGridService?.getActiveViewportId?.() ?? undefined;
+              const activeSeg = viewportId ? svc.getActiveSegmentation?.(viewportId) : null;
+              if (!activeSeg?.segments) return false;
+              return Object.keys(activeSeg.segments).length > 0;
+            },
+            undefined,
+            { timeout: 60_000 }
+          ).catch(() => null),
+          60_000
+        );
+
+        if (!segAppeared) {
+          throw new Error(
+            `[perf] Prompt ${i + 1}/${fx.refinesPerCycle} on cycle ${cycle}: ` +
+            `no segment appeared within 60 s after the Probe2 click. ` +
+            `Likely causes: liveMode is off, selectedModel is not nnInteractive, ` +
+            `Probe2 annotation produced no scribble in cachedStats (scribble not ` +
+            `populated before nninter read it), or MONAI server returned an empty prediction. ` +
+            `The 25-minute hang is prevented — fix the upstream cause and re-run.`
+          );
+        }
+
+        await step(cycle, `afterRefineSample${i}`, () => sample(page, `afterRefine${i}`, { wallT: Date.now(), studyUID }), 60_000);
+      }
+
+      // Fail loudly: a soak that silently measures nothing is the main failure mode.
+      // Assert on live segmentation segments via segmentationService (not the
+      // block-derived segCount which is known to be stale).
+      const liveSegCount = await page.evaluate(() => {
+        const sm = (window as any).__ohifPerf.servicesManager.services;
+        const svc = sm.segmentationService;
+        const viewportId = sm.viewportGridService?.getActiveViewportId?.() ?? undefined;
+        const activeSeg = viewportId ? svc.getActiveSegmentation?.(viewportId) : null;
+        if (!activeSeg?.segments) return 0;
+        return Object.keys(activeSeg.segments).length;
+      });
+      expect(liveSegCount, 'nnInteractive produced no segment (live segmentation check)').toBeGreaterThan(0);
+    }
+
+    // --- segment add / delete / export (primary study only) ---
+    // The nnInteractive block above is already gated on primaryStudyUID; keeping
+    // the segment-mutation block on the same gate prevents SEG writes into the
+    // non-primary studies opened during switching cycles.
+    //
+    // Command names VERIFIED against the registry:
+    //   addSegment / deleteSegment / storeSegmentation -> extensions/cornerstone/src/commandsModule.ts:2066,2099,2090
+    //   setHangingProtocol                             -> extensions/default/src/commandsModule.ts
+    //   MPR protocol id 'mpr'                          -> extensions/cornerstone/src/hps/mpr.ts:5
+    if (studyUID === fx.primaryStudyUID) {
+      primaryCycleCount++;
+
+      const segId = await step(cycle, 'activeSegmentationId', () => activeSegmentationId(page), 60_000);
+
+      // Snapshot the index set BEFORE add so we can identify the new index exactly.
+      const indicesBefore = await step(cycle, 'segmentIndicesBefore', () => segmentIndices(page, segId), 60_000);
+
+      await step(cycle, 'addSegment', () =>
+        page.evaluate(
+          id => (window as any).__ohifPerf.commandsManager.runCommand('addSegment', { segmentationId: id }),
+          segId
+        ).then(() => page.waitForTimeout(1500)),
+        60_000
+      );
+      await step(cycle, 'afterSegAddSample', () => sample(page, 'afterSegAdd', { wallT: Date.now(), studyUID }), 60_000);
+
+      // Determine the new index: the one present after add but not before.
+      const indicesAfter = await step(cycle, 'segmentIndicesAfter', () => segmentIndices(page, segId), 60_000);
+      const newIndices = indicesAfter.filter(i => !indicesBefore.includes(i));
+      if (newIndices.length === 1) {
+        // Delete exactly the segment we just created — not an arbitrary one.
+        await step(cycle, 'deleteSegment', () =>
+          page.evaluate(
+            ([id, idx]) =>
+              (window as any).__ohifPerf.commandsManager.runCommand('deleteSegment', {
+                segmentationId: id,
+                segmentIndex: idx,
+              }),
+            [segId, newIndices[0]] as [string, number]
+          ).then(() => page.waitForTimeout(1500)),
+          60_000
+        );
+        await step(cycle, 'afterSegDeleteSample', () => sample(page, 'afterSegDelete', { wallT: Date.now(), studyUID }), 60_000);
+      } else {
+        // Cannot identify the new segment unambiguously — skip delete and record it.
+        deleteSkipCount++;
+        console.warn(
+          `[perf] cycle ${cycle}: skipping deleteSegment — could not identify new index ` +
+            `(before=${JSON.stringify(indicesBefore)}, after=${JSON.stringify(indicesAfter)})`
+        );
+        await step(cycle, 'afterSegDeleteSkippedSample', () => sample(page, 'afterSegDeleteSkipped', { wallT: Date.now(), studyUID }), 60_000);
+      }
+
+      // --- SEG export, recording the created UID for cleanup ---
+      const uidsBefore = await step(cycle, 'listSegUidsBefore', () => listSegUids(fx, studyUID), 60_000);
+
+      // storeSegmentation blocks on a modal dialog ("Store Segmentation") that
+      // requires a report name and a Save click before it resolves.  Awaiting it
+      // directly causes a permanent stall — confirmed by instrumented run showing
+      // "STALL: storeSegmentation exceeded budget of 300000ms" with Orthanc never
+      // receiving a write.  Fix: kick off the export WITHOUT awaiting, fill the
+      // dialog, click Save, THEN await the promise so the 300 s budget covers only
+      // the actual DICOM write (which is genuinely slow for 694-slice studies).
+      const reportName = `perf-soak-${stamp}-c${cycle}`;
+      console.log(`[perf] cycle ${cycle} storeSegmentation reportName=${reportName}`);
+
+      // Step 1: open the dialog.  The export command fires but will not resolve
+      // until after we interact with the modal — do NOT await yet.
+      // storeSegmentation takes ONLY { segmentationId } — verified at
+      // extensions/cornerstone-dicom-seg/src/commandsModule.ts:374.
+      const exportPromise = page.evaluate(
+        id =>
+          (window as any).__ohifPerf.commandsManager.runCommand('storeSegmentation', {
+            segmentationId: id,
+          }),
+        segId
+      );
+
+      // Step 2: wait for the dialog, fill in the report name, click Save.
+      // Budget: 60 s — if the dialog never appears the export flow has changed
+      // and the driver needs updating (do NOT silently skip).
+      await step(cycle, 'storeSegmentationDialog', async () => {
+        const inputSelector = 'input[placeholder="Report name"]';
+        const appeared = await page.waitForSelector(inputSelector, { timeout: 60_000 }).catch(() => null);
+        if (!appeared) {
+          throw new Error(
+            `[perf] cycle ${cycle}: "Store Segmentation" dialog did not appear within 60 s. ` +
+            `Export may have changed to a non-modal flow — update the soak driver to match.`
+          );
+        }
+        await page.fill(inputSelector, reportName);
+        await page.getByRole('button', { name: 'Save' }).click();
+      }, 60_000);
+
+      // Step 3: now await the actual DICOM write.  The 300 s budget here covers
+      // the real write latency (694-slice SEG can be slow), not dialog wait time.
+      await step(cycle, 'storeSegmentation', () =>
+        exportPromise.then(() => page.waitForTimeout(8000)),
+        300_000
+      );
+      // Wrap uidsAfter: if the query fails AFTER the SEG was already written to Orthanc,
+      // record an orphan warning to a separate file and rethrow so the run still aborts loudly.
+      // Do NOT put the sentinel in createdOut — that file must only contain confirmed ids.
+      let uidsAfter: string[];
+      try {
+        uidsAfter = await step(cycle, 'listSegUidsAfter', () => listSegUids(fx, studyUID), 60_000);
+      } catch (err) {
+        const warning =
+          `ORPHAN WARNING — ${new Date().toISOString()}\n` +
+          `A SEG was written to Orthanc but the post-export UID query failed.\n` +
+          `Study UID : ${studyUID}\n` +
+          `Cycle     : ${cycle}\n` +
+          `Error     : ${String(err)}\n` +
+          `Action    : Check study ${studyUID} in Orthanc for an untracked SEG and remove it manually.\n`;
+        fs.appendFileSync(orphanOut, warning + '\n');
+        console.error(`[perf] orphan warning written to ${orphanOut}`);
+        throw err;
+      }
+      uidsAfter.filter(u => !uidsBefore.includes(u)).forEach(u => createdSegs.push(u));
+      // (a) Write the allowlist incrementally after every cycle so an abort leaves a usable record.
+      fs.writeFileSync(createdOut, JSON.stringify(createdSegs, null, 2));
+      await step(cycle, 'afterSegExportSample', () => sample(page, 'afterSegExport', { wallT: Date.now(), studyUID }), 60_000);
+
+      // --- SEG reload leg ---
+      // PURPOSE: exercise and measure the export→reload path, which is the
+      // most leak-prone path in the codebase (sparse labelmap blocks, SEG
+      // truncation history).  The 'studyOpen' canonical sample is taken AFTER
+      // this step, so Tier-1 block counters (segCount/blockCount/blockSlices)
+      // fitted on 'studyOpen' automatically capture any per-cycle block leakage
+      // introduced by reload.
+      //
+      // IDENTIFY the newly-exported SEG displaySet:
+      //   displaySetService.getActiveDisplaySets() — verified:
+      //   Viewers/platform/core/src/services/DisplaySetService/DisplaySetService.ts:114
+      //   Returns the live activeDisplaySets array (pushed in insertion order).
+      //   Filter by Modality === 'SEG' (set by getSopClassHandlerModule.ts:34)
+      //   and SeriesDescription === reportName (set via storeSegmentation options:
+      //   cornerstone-dicom-seg/src/commandsModule.ts:403).
+      //   This combination uniquely identifies the SEG this cycle just created.
+      //
+      // LOAD via:
+      //   loadSegmentationDisplaySetsForViewport — registered at
+      //   extensions/cornerstone/src/commandsModule.ts:2160, implemented at :1858.
+      //   Takes { viewportId, displaySetInstanceUIDs: [uid] }.
+      //
+      // ASSERT reload actually happened: a silent no-op here would recreate the
+      // exact class of bug this project has hit repeatedly (reload path changed,
+      // service returns stale data, command resolves before hydration completes).
+      await step(cycle, 'segReload', async () => {
+        // Locate the newly-exported SEG displaySet by SeriesDescription match.
+        // displaySetService.getActiveDisplaySets() is verified at:
+        //   Viewers/platform/core/src/services/DisplaySetService/DisplaySetService.ts:114-115
+        // Modality 'SEG' is set at: cornerstone-dicom-seg/src/getSopClassHandlerModule.ts:34
+        // SeriesDescription is set from the dialog's reportName at:
+        //   cornerstone-dicom-seg/src/commandsModule.ts:403
+        const segDisplaySet = await page.evaluate(rn => {
+          const sm = (window as any).__ohifPerf.servicesManager.services;
+          const dss = sm.displaySetService.getActiveDisplaySets() as any[];
+          // Primary strategy: exact SeriesDescription match for this cycle's export.
+          let found = dss.find(
+            (ds: any) => ds.Modality === 'SEG' && ds.SeriesDescription === rn
+          );
+          // Fallback: most recently added SEG (last in insertion-order array).
+          if (!found) {
+            const segs = dss.filter((ds: any) => ds.Modality === 'SEG');
+            found = segs[segs.length - 1] ?? null;
+          }
+          if (!found) return null;
+          return {
+            uid: found.displaySetInstanceUID as string,
+            desc: found.SeriesDescription as string,
+          };
+        }, reportName);
+
+        if (!segDisplaySet) {
+          throw new Error(
+            `[perf] cycle ${cycle} segReload: no SEG displaySet found in ` +
+            `getActiveDisplaySets() (Modality=SEG, SeriesDescription="${reportName}"). ` +
+            `The export may not have added the displaySet to the active set, or ` +
+            `DicomMetadataStore.addInstances() did not trigger displaySet creation. ` +
+            `Cannot proceed with reload.`
+          );
+        }
+        console.log(
+          `[perf] cycle ${cycle} segReload uid=${segDisplaySet.uid} desc="${segDisplaySet.desc}"`
+        );
+
+        // Get the active viewportId — same pattern used throughout this file.
+        // viewportGridService.getActiveViewportId() verified at:
+        //   Viewers/platform/core/src/services/ViewportGridService/ViewportGridService.ts:175
+        const viewportId = await page.evaluate(
+          () =>
+            (window as any).__ohifPerf.servicesManager.services.viewportGridService.getActiveViewportId()
+        );
+
+        // Load the SEG displaySet into the active viewport.
+        // Command registered at extensions/cornerstone/src/commandsModule.ts:2160.
+        // Implementation at :1858 — calls getUpdatedViewportsForSegmentation then
+        // viewportGridService.setDisplaySetsForViewport for each updated viewport.
+        await page.evaluate(
+          ([vId, uid]) =>
+            (window as any).__ohifPerf.commandsManager.runCommand(
+              'loadSegmentationDisplaySetsForViewport',
+              { viewportId: vId, displaySetInstanceUIDs: [uid] }
+            ),
+          [viewportId, segDisplaySet.uid] as [string, string]
+        );
+        // Allow the hydration pipeline to settle (a 694-slice SEG hydrate is genuinely slow).
+        await page.waitForTimeout(8000);
+      }, 180_000);
+
+      // ASSERT the reload actually happened — a silent no-op would produce a
+      // 'studyOpen' sample indistinguishable from before the reload, giving a
+      // false clean verdict just as the pre-reload segmentation still being
+      // loaded would.  This is the same live check used by the prompt guard above.
+      const reloadedSegCount = await page.evaluate(() => {
+        const sm = (window as any).__ohifPerf.servicesManager.services;
+        const svc = sm.segmentationService;
+        const viewportId = sm.viewportGridService?.getActiveViewportId?.() ?? undefined;
+        const activeSeg = viewportId ? svc.getActiveSegmentation?.(viewportId) : null;
+        if (!activeSeg?.segments) return 0;
+        return Object.keys(activeSeg.segments).length;
+      });
+      if (reloadedSegCount === 0) {
+        throw new Error(
+          `[perf] cycle ${cycle} segReload: reload completed but segmentationService ` +
+          `reports 0 segments in the active segmentation after 8 s settle. ` +
+          `The reload was a silent no-op — the SEG was loaded into the viewport but ` +
+          `the segmentation service was not updated, or the hydration pipeline did ` +
+          `not complete within the settle window. Increase the waitForTimeout or ` +
+          `investigate the loadSegmentationDisplaySetsForViewport→hydrate path.`
+        );
+      }
+
+      await step(cycle, 'afterSegReloadSample', () =>
+        sample(page, 'afterSegReload', { wallT: Date.now(), studyUID }),
+        60_000
+      );
+    }
+
+    // --- MPR toggle (the historic volume-leak path) — runs on ALL studies ---
+    await step(cycle, 'mprToggle', () =>
+      page.evaluate(() =>
+        (window as any).__ohifPerf.commandsManager.runCommand('setHangingProtocol', { protocolId: 'mpr' })
+      ).then(() => page.waitForTimeout(6000)),
+      120_000
+    );
+    await step(cycle, 'afterMPRSample', () => sample(page, 'afterMPR', { wallT: Date.now(), studyUID }), 60_000);
+
+    await step(cycle, 'stackToggle', () =>
+      page.evaluate(() =>
+        (window as any).__ohifPerf.commandsManager.runCommand('setHangingProtocol', { protocolId: 'default' })
+      ).then(() => page.waitForTimeout(4000)),
+      120_000
+    );
+    await step(cycle, 'afterStackSample', () => sample(page, 'afterStack', { wallT: Date.now(), studyUID }), 60_000);
+
+    // =========================================================================
+    // C6 FIX: CANONICAL 'studyOpen' sample — taken while the study is STILL OPEN.
+    //
+    // WHY TWO CANONICAL PHASES EXIST:
+    //   - 'cycleEnd' (below) measures return-to-baseline at rest: after
+    //     closeStudy(), OHIF's onModeExit fires removeAllSegmentations(), so
+    //     the segmentation service is empty.  Block-stat counters (segCount,
+    //     blockCount, blockSlices) therefore return {-1,-1,-1} at cycleEnd and
+    //     are permanently NO_DATA — they CANNOT be observed at rest.
+    //   - 'studyOpen' is the ONLY point where per-study block/segment counters
+    //     are observable. It is taken after the MPR→stack toggle has settled
+    //     (the historic volume-leak path) and after a forced GC, so it is a
+    //     stable in-study resting state.
+    //
+    // THE ANALYZER must fit block counter trends (segCount, blockCount,
+    // blockSlices) on 'studyOpen' samples, NOT on 'cycleEnd' samples.
+    // wallT and studyUID are carried so the analyzer can align records across
+    // cycles exactly as it does for cycleEnd.
+    // =========================================================================
+    await step(cycle, 'studyOpenSampleCanonical', () => sample(page, 'studyOpen', { wallT: Date.now(), studyUID }), 60_000);
+
+    // --- Close the study via client-side navigation (NO document reload) ---
+    // dump BEFORE navigating away: the perf records live in the browser's JS heap
+    // and are preserved across client-side nav, but we dump here to keep per-cycle
+    // records granular and avoid the final dump growing unbounded.
+    // The dump+reset happen BEFORE the canonical cycleEnd sample so that the
+    // cycleEnd sample itself is NOT included in the per-cycle dump (it is
+    // captured in the NEXT iteration's dump or the final flush).
+    await step(cycle, 'closeStudy', () => closeStudy(page), 120_000);
+
+    // C2 FIX: canonical per-cycle sample.
+    // Taken at the CANONICAL RESTING STATE: after the study is closed, back at
+    // the study list, after forceGC. With nothing loaded, every cycle is
+    // comparable — this is what makes Tier-1's "must return to baseline" meaningful.
+    // wallT (epoch ms) and studyUID make records self-describing for the analyzer.
+    await step(cycle, 'cycleEndSample', () => sample(page, 'cycleEnd', { wallT: Date.now(), studyUID }), 60_000);
+
+    // dump this cycle's records (includes all intermediate phases + cycleEnd).
+    const cycleDump = await step(cycle, 'cycleDump', async () => {
+      const dump = await page.evaluate(() => (window as any).__ohifPerf?.dump?.() ?? '');
+      expect(dump, `cycle ${cycle} produced no telemetry records`).not.toBe('');
+      fs.appendFileSync(clientOut, dump + '\n');
+      return dump;
+    }, 60_000);
+    // Reset so records do not accumulate / duplicate across cycles.
+    await page.evaluate(() => (window as any).__ohifPerf?.reset?.());
+
+    // Continuity post-check: after reset, nonce must still be present.
+    const nonceAfterReset = await page.evaluate(() => (window as any).__ohifPerf?.__nonce);
+    expect(
+      nonceAfterReset,
+      `CONTINUITY VIOLATION after cycle ${cycle} reset: nonce changed ` +
+        `(expected ${nonce}, got ${nonceAfterReset}). Document was replaced.`
+    ).toBe(nonce);
+  }
+
+  // Final flush: in case any records were captured after the last reset
+  // (e.g. by navigation listeners) before the test ends.
+  const finalDump = await page.evaluate(() => (window as any).__ohifPerf?.dump?.() ?? '');
+  if (finalDump) fs.appendFileSync(clientOut, finalDump + '\n');
+
+  // Final write (harmless — already written incrementally during the loop).
+  fs.writeFileSync(createdOut, JSON.stringify(createdSegs, null, 2));
+  console.log(`client trace -> ${clientOut}`);
+  console.log(`created SEG UIDs -> ${createdOut} (${createdSegs.length})`);
+
+  // GAP 2: fail if the delete workflow was skipped on EVERY primary-study cycle.
+  // A blind spot that does not report itself is exactly the failure mode this project keeps hitting.
+  if (primaryCycleCount > 0 && deleteSkipCount === primaryCycleCount) {
+    throw new Error(
+      `[perf] delete workflow was NEVER exercised — skipped on all ${primaryCycleCount} ` +
+        `primary-study cycles. The soak has a blind spot: check seg.segments shape and fix segmentIndices().`
+    );
+  }
+  if (deleteSkipCount > 0) {
+    console.warn(
+      `[perf] SUMMARY: delete workflow skipped on ${deleteSkipCount}/${primaryCycleCount} primary-study cycles — partial blind spot, investigate seg.segments shape.`
+    );
+  }
+});
+
+/** Orthanc instance ids of SEG series on a study. Used to diff before/after export
+ *  so cleanup only ever touches instances THIS RUN created. */
+async function listSegUids(fxCfg: any, studyUID: string): Promise<string[]> {
+  const res = await fetch(`${fxCfg.orthancProxy}/tools/find`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ Level: 'Series', Query: { StudyInstanceUID: studyUID, Modality: 'SEG' } }),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '(unreadable)');
+    throw new Error(
+      `Orthanc /tools/find failed with ${res.status} ${res.statusText}: ${body}. ` +
+        `Aborting — a failed query must never silently degrade into an empty baseline.`
+    );
+  }
+  return (await res.json()) as string[];
+}

--- a/tools/perf/tsconfig.json
+++ b/tools/perf/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "baseUrl": ".",
+    "typeRoots": [
+      "../../Viewers/node_modules/@types"
+    ],
+    "paths": {
+      "@playwright/test": ["../../Viewers/node_modules/@playwright/test"]
+    }
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
Opt-in performance and memory telemetry across client, server and host, plus a scripted Playwright soak that drives the real workflows and analyses the result.

**This is the instrument, not the fixes.** The bugs it found have already merged separately as #90 and #91. This branch is the measuring apparatus, rebased onto current `main` with those six fix commits dropped.

## What it found

Running a 30-cycle soak against a real study surfaced a client-side event-listener leak invisible to ordinary logging, because nothing ever failed — every operation succeeded:

```
listenerCount at rest (study closed, after forced GC):
379, 409, 1133, 1159, 1185, 1215, ... 1841, 1871   strictly monotonic over 30 cycles
```

**27.5 listeners per cycle**, heap **+15.89 MB/cycle** (95% CI [10.0, 21.78], n=28). Six root causes, all the same defect class — a listener that could never be removed. Fixed in #91, bringing it to **~0.2 per cycle**. Chasing volume growth with the same instrument later led to #90's 40MB-per-refine leak.

## Design

**Unreadable counters report `-1`, never a plausible value.** This is the core contract. A measurement that silently defaults to `0` or `[]` reads as good news and produces confident wrong conclusions. During development this rule caught several would-be false negatives, including fallbacks that would have reported "no leak" from an empty cache, and a soak driver that discarded every sample yet would still have "passed".

**Off by default, and inert when off.** Client behind `?perf=1` (or `localStorage.ohifPerf=1`); server behind `MONAI_PERF_TRACE=1`. The server-side import is wrapped so telemetry can never break startup — if it fails to load, it degrades to no-ops.

**Three time series on one wall-clock axis** — client, server, host — so a stall can be attributed to the browser, the server, or the GPU rather than guessed at.

**Testable core.** `perfTrace.ts` is dependency-injected and framework-free; `perfTraceBrowser.ts` holds the cornerstone binding.

## Layout

- `Viewers/extensions/default/src/utils/perfTrace.ts` — DI core
- `Viewers/extensions/default/src/utils/perfTraceBrowser.ts` — cornerstone binding, `window.__ohifPerf`
- `monai-label/monailabel/utils/others/perf_trace.py` — RSS, VRAM, sessions, threads, queue depth appended to the existing timing line
- `tools/perf/` — soak spec, host sampler, analyser, preflight check, runbook

Analysis is three-tier: return-to-baseline counts, slope with confidence interval, and duration degradation.

## Cost, stated plainly

~3,250 lines to carry, and four product files gain instrumentation hooks: `commandsModule.ts`, `labelmapBlocks.ts`, `utils/index.ts`, `basic_infer.py`. The soak depends on a fixture study remaining present in Orthanc.

It has already paid for itself by finding the leak and leading to two `main` bugs. Whether it earns continued upkeep depends on whether it will be re-run; if not, a tag would preserve it just as well as `main` would.

## Verification

- Rebased onto `main` with the six merged fix commits dropped; all nine of their files confirmed **byte-identical to `main`** afterwards, and every telemetry file **byte-identical to the pre-rebase branch**.
- Dockerfile diff against `main` is now **empty** (its only changes were the leak-fix `COPY` lines, now upstream); 29 override `COPY` lines on both sides, no duplicates.
- Builds clean; `__ohifPerf` present in the bundle and `main`'s merged overrides still byte-match in the shipped source maps.
- `node tools/perf/preflight.js` fails loudly if any instrument stops reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
