### PR TITLE
fix(nninter): re-fetch weights when the local snapshot is incomplete

### DIFF
--- a/monai-label/monailabel/tasks/infer/basic_infer.py
+++ b/monai-label/monailabel/tasks/infer/basic_infer.py
@@ -129,16 +129,42 @@ MODEL_NAME = "nnInteractive_v1.0"  # Updated models may be available in the futu
 DOWNLOAD_DIR = "/code/checkpoints"  # Specify the download directory
 
 
+def _nninter_artifacts_present(model_dir):
+    """True when model_dir holds the metadata nnInteractive needs to load a model.
+
+    Checked explicitly because `local_files_only=True` CANNOT be used as a
+    completeness test: huggingface_hub >= 0.36 RETURNS an existing local_dir
+    unchanged when the hub is unreachable ("Returning existing local_dir ... as
+    remote repo cannot be accessed"), even if the snapshot inside it is empty or
+    half-written.
+    """
+    return any(
+        os.path.isfile(os.path.join(model_dir, name))
+        for name in ("inference_info.json", "inference_session_class.json")
+    )
+
+
 def _snapshot_download_cached(**kwargs):
     """snapshot_download that skips the HF Hub network round-trip when the model
     files are already present locally. The weights live in the checkpoints volume,
     so the steady-state case is a cache hit; local_files_only avoids the (~0.5-2s)
-    hub metadata check on every boot. Falls back to a real network fetch on a cold
-    cache (fresh machine)."""
-    try:
-        return snapshot_download(local_files_only=True, **kwargs)
-    except Exception:
-        return snapshot_download(**kwargs)
+    hub metadata check on every boot.
+
+    The offline fast path is taken ONLY when the artifacts are verifiably on disk.
+    Trusting local_files_only alone made an interrupted first download permanent:
+    the aborted fetch leaves an incomplete <local_dir>/<MODEL_NAME>/, every later
+    boot then "succeeded" offline against that directory, the real download was
+    never retried, and the failure surfaced much later as a FileNotFoundError from
+    nnInteractive naming a file nothing had ever tried to fetch.
+    """
+    local_dir = kwargs.get("local_dir")
+    model_dir = os.path.join(local_dir, MODEL_NAME) if local_dir else None
+    if model_dir and _nninter_artifacts_present(model_dir):
+        try:
+            return snapshot_download(local_files_only=True, **kwargs)
+        except Exception:
+            pass  # fall through to a real fetch rather than fail on a stale cache
+    return snapshot_download(**kwargs)
 
 
 download_path = _snapshot_download_cached(


### PR DESCRIPTION
A fresh machine can end up **permanently unable to start the server**:

```
FileNotFoundError: Neither capability metadata
(/code/checkpoints/nnInteractive_v1.0/inference_info.json) nor legacy metadata
(inference_session_class.json) was found.
```

The artifact load runs at **import time**, so this takes down the whole MONAI Label server, not just nnInteractive.

## Cause

The offline fast path added in #73 assumed `local_files_only=True` raises when the model is not cached, and used that as the signal to fall back to a real download.

`huggingface_hub >= 0.36` does not behave that way. When the hub cannot be reached it **returns the existing `local_dir` unchanged**, even if the snapshot inside is empty or half-written:

```
Returning existing local_dir `/code/checkpoints` as remote repo cannot be accessed in `snapshot_download` (None).
```

Verified against the version in our image (0.36.2):

| state of the checkpoints dir | `local_files_only=True` | result |
|---|---|---|
| completely empty | **raises** | falls back, downloads correctly |
| contains an incomplete `nnInteractive_v1.0/` | **returns OK** | download silently skipped, **permanently** |

That distinction is what makes it a trap rather than a transient failure. The true first run has no model directory, raises, and downloads fine. But if that download is interrupted — Ctrl-C, OOM, container restart, network blip — it leaves an incomplete `nnInteractive_v1.0/`, and from then on **every boot "succeeds" offline against that directory and never retries.** The failure then surfaces from a different module, naming a file nothing ever tried to fetch, which is why it reads as a broken install rather than an aborted download.

## Fix

Take the offline path only when the metadata is verifiably on disk, checking **both** the current and legacy filenames — the same two the loader looks for. An incomplete directory now falls through to a real fetch.

Where the weights are complete the fast path still applies, so the boot-time saving from #73 is unchanged (measured: still 0.00s, no network).

## Verification

Decision logic exercised across every state:

| scenario | behaviour |
|---|---|
| empty checkpoints dir (true first run) | network fetch |
| model dir exists but empty (**the bug**) | network fetch |
| model dir with a stray partial file | network fetch |
| complete, `inference_info.json` | offline only |
| complete, legacy `inference_session_class.json` | offline only |

Confirmed against real `huggingface_hub` 0.36.2 in the `monai:latest` image, and on a machine with complete weights the offline path is still taken with no network call. Worth noting the dev machine here carries the **legacy** metadata filename, so checking only `inference_info.json` would have regressed it.

## Workaround for an already-stuck machine

```bash
rm -rf monai-label/checkpoints/nnInteractive_v1.0
docker compose up monai_server   # re-downloads; let it finish
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
