### PR TITLE
AI segmentation readiness gating with real download progress

### DIFF
--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -37,6 +37,15 @@ import {
 import { parseMultipart } from './utils/multipart';
 import { callInputDialog } from './utils/callInputDialog';
 import { getNninterToken, clearNninterToken } from './utils/nninterSession';
+import {
+  noteAiInitStarted,
+  noteAiInitSuccess,
+  noteAiInitError,
+  ensureAiReadyForInference,
+  isAiWarmupError,
+  startAiServerProgressPolling,
+} from './utils/aiReadiness';
+import { watchAiVolumeReadiness, watchAiClientDownload } from './utils/aiReadinessVolumeWatch';
 import { perf, installPerfHandle, setBlockStatsProvider, leakRetain } from './utils';
 import { summarizeBlocks, describeBlocks, blockIndexForSegment, replaceBlockAt, appendBlock, flattenBlocks, flipIndex, withoutBlockAt, blockContains, clampRange, snapRangeToGrid, shouldShrinkBlock, sourceRangeForWorking, MIN_BLOCK_SLICES, BLOCK_GRID_SLICES, BLOCK_SHRINK_FACTOR } from './utils/labelmapBlocks';
 // Separate: LabelmapBlock is a type, and isolatedModules requires type-only imports be marked so
@@ -1561,6 +1570,9 @@ const commandsModule = ({
     },
 
     async sam2() {
+      if (!ensureAiReadyForInference(servicesManager)) {
+        return;
+      }
       const _perfT0 = performance.now();
       if (!beginInferenceRunOrQueue()) {
         return;
@@ -2110,6 +2122,17 @@ const commandsModule = ({
         toolboxState.setPosNeg(false);
       }
 
+      noteAiInitStarted({
+        seriesUID: currentDisplaySets.SeriesInstanceUID,
+        seriesChanged: _seriesChanged,
+        servicesManager,
+      });
+      watchAiVolumeReadiness({ displaySet: currentDisplaySets, servicesManager });
+      const _seriesImageIds = (currentDisplaySets.images ?? currentDisplaySets.instances ?? [])
+        .map(i => i?.imageId)
+        .filter(Boolean);
+      watchAiClientDownload({ imageIds: _seriesImageIds, servicesManager });
+
       let nninterToken = '';
       try {
         nninterToken = await getNninterToken();
@@ -2130,12 +2153,6 @@ const commandsModule = ({
         nninter_token: nninterToken,
       };
 
-      // Show notification only on the first initNninter for a new series.
-      // _seriesChanged is false for all repeat triggers (other MPR panes loading the
-      // same series, viewport-type switches stack↔volume, active-viewport clicks, etc.)
-      // so a single _seriesChanged gate is sufficient — no need to check viewport type.
-      const _showNotification = _seriesChanged;
-
       let data = MonaiLabelClient.constructFormData(params, null);
 
       // Create the axios promise
@@ -2145,15 +2162,10 @@ const commandsModule = ({
           accept: 'application/json, multipart/form-data',
         },
       });
-
-      if (_showNotification) {
-        uiNotificationService.show({
-          title: 'NNInit',
-          message: 'Initializing nninter...',
-          type: 'info',
-          duration: 3000,
-        });
-      }
+      startAiServerProgressPolling({
+        seriesUID: currentDisplaySets.SeriesInstanceUID,
+        servicesManager,
+      });
 
       try {
         const response = await initPromise;
@@ -2162,53 +2174,51 @@ const commandsModule = ({
           if (_initBody.includes('session_expired')) {
             if (_sessionRetry) {
               console.warn('Init nninter: session expired again after reclaim; giving up');
+              noteAiInitError({
+                error: { message: 'nnInteractive session expired and could not be reclaimed' },
+                seriesUID: currentDisplaySets.SeriesInstanceUID,
+                servicesManager,
+                retry: () => actions.initNninter(options),
+                forceHard: true,
+              });
               return response;
             }
             clearNninterToken();
             await getNninterToken();
             return actions.initNninter(options, true);
           }
-          if (_showNotification) {
-            uiNotificationService.show({
-              title: 'NNInit',
-              message: 'Init nninter - Successful',
-              type: 'success',
-              duration: 3000,
-            });
-          }
+          noteAiInitSuccess({
+            seriesUID: currentDisplaySets.SeriesInstanceUID,
+            servicesManager,
+          });
           return response;
         }
       } catch (error) {
-        // The MONAI server returns 502/503/504 while it is still starting up — that's expected,
-        // not a real failure. Surface it as a warning (and don't rethrow as an error) so the user
-        // isn't alarmed by a red error while the server warms up; it re-inits on next use.
-        const status = error?.response?.status;
-        if (status === 502 || status === 503 || status === 504) {
-          console.warn(`Init nninter: MONAI server not ready yet (HTTP ${status}); will retry when used.`);
-          if (_showNotification) {
-            uiNotificationService.show({
-              title: 'NNInit',
-              message: 'MONAI server is still starting up — nnInteractive will be ready shortly.',
-              type: 'warning',
-              duration: 5000,
-            });
-          }
-          return;
+        // The MONAI server returns 502/503/504 while it is still starting up — expected,
+        // not a real failure. noteAiInitError keeps the persistent toast up and schedules
+        // an automatic retry; with the AI tools gated, nothing else could re-trigger init.
+        const isWarmup = isAiWarmupError(error);
+        if (isWarmup) {
+          console.warn(`Init nninter: MONAI server not ready yet (HTTP ${error?.response?.status ?? 'no response'}); retrying automatically.`);
+        } else {
+          console.error('Init nninter error:', error);
         }
-        console.error('Init nninter error:', error);
-        if (_showNotification) {
-          uiNotificationService.show({
-            title: 'NNInit',
-            message: `Init nninter - Failed: ${error.message || 'Unknown error'}`,
-            type: 'error',
-            duration: 5000,
-          });
+        noteAiInitError({
+          error,
+          seriesUID: currentDisplaySets.SeriesInstanceUID,
+          servicesManager,
+          retry: () => actions.initNninter(options),
+        });
+        if (!isWarmup) {
+          throw error;
         }
-        throw error;
       }
 
     },
     async undoNninter() {
+      if (!ensureAiReadyForInference(servicesManager)) {
+        return;
+      }
       if (toolboxState.getLocked()) {
         return;
       }
@@ -2488,6 +2498,9 @@ const commandsModule = ({
     },
 
     async resetNninter(options: {clearMeasurements: boolean} = {clearMeasurements: false}){
+      if (!ensureAiReadyForInference(servicesManager)) {
+        return;
+      }
       if (toolboxState.getLocked()) {
         return;
       }
@@ -3343,6 +3356,9 @@ const commandsModule = ({
       }
     },
     async nninter(textPrompts?: string | string[]) {
+      if (!ensureAiReadyForInference(servicesManager)) {
+        return;
+      }
       const _perfT0 = performance.now();
       if (!beginInferenceRunOrQueue()) {
         return;
@@ -4209,6 +4225,9 @@ const commandsModule = ({
 
     async textPromptSegmentation() {
       if (toolboxState.getLocked()) {
+        return;
+      }
+      if (!ensureAiReadyForInference(servicesManager)) {
         return;
       }
 

--- a/Viewers/extensions/default/src/getToolbarModule.tsx
+++ b/Viewers/extensions/default/src/getToolbarModule.tsx
@@ -1,5 +1,6 @@
 import { ToolbarButton as ToolbarButtonLegacy } from '@ohif/ui';
 import { ToolButton, utils } from '@ohif/ui-next';
+import { evaluateAiSegmentationReady } from './utils/aiReadiness';
 
 import ToolbarLayoutSelectorWithServices from './Toolbar/ToolbarLayoutSelector';
 
@@ -73,6 +74,10 @@ export default function getToolbarModule({ commandsManager, servicesManager }: w
           className: utils.getToggledClassName(isToggled),
         };
       },
+    },
+    {
+      name: 'evaluate.aiSegmentationReady',
+      evaluate: () => evaluateAiSegmentationReady(),
     },
   ];
 }

--- a/Viewers/extensions/default/src/index.ts
+++ b/Viewers/extensions/default/src/index.ts
@@ -31,6 +31,8 @@ import colorPickerDialog from './utils/colorPickerDialog';
 
 import promptSaveReport from './utils/promptSaveReport';
 import promptLabelAnnotation from './utils/promptLabelAnnotation';
+import { teardownAiReadiness } from './utils/aiReadiness';
+import { stopAiClientDownload, stopAiVolumeWatch } from './utils/aiReadinessVolumeWatch';
 import usePatientInfo from './hooks/usePatientInfo';
 import { PanelStudyBrowserHeader } from './Panels/StudyBrowser/PanelStudyBrowserHeader';
 import * as utils from './utils';
@@ -45,7 +47,10 @@ const defaultExtension: Types.Extensions.Extension = {
    */
   id,
   preRegistration,
-  onModeExit() {
+  onModeExit({ servicesManager }) {
+    teardownAiReadiness(servicesManager);
+    stopAiClientDownload(servicesManager.services.uiNotificationService);
+    stopAiVolumeWatch();
     useViewportGridStore.getState().clearViewportGridState();
     useUIStateStore.getState().clearUIState();
     useDisplaySetSelectorStore.getState().clearDisplaySetSelectorMap();

--- a/Viewers/extensions/default/src/stores/toolboxState.ts
+++ b/Viewers/extensions/default/src/stores/toolboxState.ts
@@ -8,6 +8,11 @@ let selectedModel: 'nnInteractive' | 'sam2' | 'medsam2' | 'sam3' = 'nnInteractiv
 let locked = false;
 let inferenceInFlight = false;
 let pendingInferenceRun = false;
+// AI segmentation readiness: gate AI tools until the client volume stream and the
+// server-side fetch/preprocess (initNninter) are both done for the active series.
+let aiVolumeLoaded = false;
+let aiServerReady = false;
+let aiReadinessSeriesUID: string | null = null;
 let promptsVisible = false; // default: hide prompts after each inference; pencil toggle to always-show
 let currentActiveSegment = 1;
 let medgemmaResult: string | null = null;
@@ -124,6 +129,21 @@ export const toolboxState = {
     pendingInferenceRun = false;
     return pending;
   },
+  getAiVolumeLoaded: () => aiVolumeLoaded,
+  setAiVolumeLoaded: (loaded: boolean) => {
+    aiVolumeLoaded = loaded;
+  },
+  getAiServerReady: () => aiServerReady,
+  setAiServerReady: (ready: boolean) => {
+    aiServerReady = ready;
+  },
+  getAiReadinessSeriesUID: () => aiReadinessSeriesUID,
+  resetAiReadiness: (seriesUID: string | null) => {
+    aiVolumeLoaded = false;
+    aiServerReady = false;
+    aiReadinessSeriesUID = seriesUID;
+  },
+  getAiSegmentationReady: () => aiVolumeLoaded && aiServerReady,
   getCurrentActiveSegment: () => currentActiveSegment,
   setCurrentActiveSegment: (segment: number) => {
     currentActiveSegment = segment;

--- a/Viewers/extensions/default/src/utils/aiReadiness.ts
+++ b/Viewers/extensions/default/src/utils/aiReadiness.ts
@@ -1,0 +1,236 @@
+import { toolboxState } from '../stores/toolboxState';
+
+export const AI_SERVER_TOAST_ID = 'ai-server-readiness';
+export const AI_VOLUME_TOAST_ID = 'ai-volume-download';
+export const AI_SERVER_TOAST_TITLE = 'Server';
+export const AI_CLIENT_TOAST_TITLE = 'Client';
+export const WARMUP_RETRY_MS = 5000;
+
+const WARMUP_STATUSES = [502, 503, 504];
+
+/** Warm-up = the server is coming up (gateway errors) or unreachable (no HTTP response). */
+export function isAiWarmupError(error) {
+  const status = error?.response?.status;
+  return WARMUP_STATUSES.includes(status) || !error?.response;
+}
+
+let _warmupRetryTimer: ReturnType<typeof setTimeout> | null = null;
+
+export function refreshAiToolbar(servicesManager) {
+  const { toolbarService, viewportGridService } = servicesManager.services;
+  toolbarService.refreshToolbarState({
+    viewportId: viewportGridService.getActiveViewportId(),
+  });
+}
+
+/** Toolbar evaluator body: undefined when ready, else disabled with the reason. */
+export function evaluateAiSegmentationReady() {
+  if (toolboxState.getAiSegmentationReady()) {
+    return undefined;
+  }
+  return {
+    disabled: true,
+    disabledText: toolboxState.getAiVolumeLoaded()
+      ? 'Server downloading and preparing images…'
+      : 'Client caching images…',
+  };
+}
+
+function cancelWarmupRetry() {
+  if (_warmupRetryTimer !== null) {
+    clearTimeout(_warmupRetryTimer);
+    _warmupRetryTimer = null;
+  }
+}
+
+export const AI_SERVER_PROGRESS_POLL_MS = 1000;
+
+let _progressPollTimer: ReturnType<typeof setInterval> | null = null;
+let _progressEndpointMissing = false; // old server image (404) — off for the session
+let _pollGeneration = 0;
+
+export function stopAiServerProgressPolling() {
+  if (_progressPollTimer !== null) {
+    clearInterval(_progressPollTimer);
+    _progressPollTimer = null;
+  }
+  _pollGeneration++;
+}
+
+/** Test-only: clears the session-permanent 404 disable and any live poll timer. */
+export function _resetAiServerProgressPollingForTests() {
+  stopAiServerProgressPolling();
+  _progressEndpointMissing = false;
+}
+
+/**
+ * Display-only: refines the persistent server toast with real percentages
+ * while the init request is in flight. Never touches readiness flags.
+ */
+export function startAiServerProgressPolling({ seriesUID, servicesManager }) {
+  stopAiServerProgressPolling();
+  if (_progressEndpointMissing) {
+    return;
+  }
+  const { uiNotificationService } = servicesManager.services;
+  _pollGeneration++;
+  const gen = _pollGeneration;
+  _progressPollTimer = setInterval(async () => {
+    try {
+      const res = await fetch(`/monai/nninter/session/progress?image=${encodeURIComponent(seriesUID)}`);
+      if (gen !== _pollGeneration) {
+        return;
+      }
+      if (res.status === 404) {
+        _progressEndpointMissing = true;
+        stopAiServerProgressPolling();
+        return;
+      }
+      if (!res.ok) {
+        return; // transient (e.g. 502 during warm-up) — keep polling
+      }
+      const p = await res.json();
+      if (gen !== _pollGeneration) {
+        return;
+      }
+      if (seriesUID !== toolboxState.getAiReadinessSeriesUID()) {
+        stopAiServerProgressPolling();
+        return;
+      }
+      if (p.phase === 'downloading' && p.total > 0) {
+        uiNotificationService.show({
+          id: AI_SERVER_TOAST_ID,
+          title: AI_SERVER_TOAST_TITLE,
+          message: `Downloading images… ${Math.floor((100 * p.fetched) / p.total)}%`,
+          type: 'info',
+          duration: Infinity,
+        });
+      } else if (p.phase === 'preparing') {
+        uiNotificationService.show({
+          id: AI_SERVER_TOAST_ID,
+          title: AI_SERVER_TOAST_TITLE,
+          message: 'Preparing images…',
+          type: 'info',
+          duration: Infinity,
+        });
+      }
+      // 'unknown' → leave the current message as-is
+    } catch (e) {
+      stopAiServerProgressPolling(); // network error — static message stands
+    }
+  }, AI_SERVER_PROGRESS_POLL_MS);
+}
+
+/** Call from initNninter once the series UID and its change-state are known. */
+export function noteAiInitStarted({ seriesUID, seriesChanged, servicesManager }) {
+  if (!seriesChanged) {
+    return;
+  }
+  cancelWarmupRetry();
+  stopAiServerProgressPolling();
+  toolboxState.resetAiReadiness(seriesUID);
+  const { uiNotificationService } = servicesManager.services;
+  uiNotificationService.hide(AI_VOLUME_TOAST_ID);
+  uiNotificationService.show({
+    id: AI_SERVER_TOAST_ID,
+    title: AI_SERVER_TOAST_TITLE,
+    message: 'Downloading and preparing images…',
+    type: 'info',
+    duration: Infinity,
+  });
+  refreshAiToolbar(servicesManager);
+}
+
+/** Call when the init request resolved successfully (after any session reclaim). */
+export function noteAiInitSuccess({ seriesUID, servicesManager }) {
+  if (seriesUID !== toolboxState.getAiReadinessSeriesUID()) {
+    return; // stale response for a previous series
+  }
+  cancelWarmupRetry();
+  stopAiServerProgressPolling();
+  const wasReady = toolboxState.getAiServerReady();
+  toolboxState.setAiServerReady(true);
+  const { uiNotificationService } = servicesManager.services;
+  if (wasReady) {
+    return;
+  }
+  // Same id: sonner replaces the persistent "Preparing…" toast in place.
+  uiNotificationService.show({
+    id: AI_SERVER_TOAST_ID,
+    title: AI_SERVER_TOAST_TITLE,
+    message: 'Segmentation ready',
+    type: 'success',
+    duration: 3000,
+  });
+  refreshAiToolbar(servicesManager);
+}
+
+/**
+ * Call when the init request failed. Warm-up failures (gateway 502/503/504 or no
+ * HTTP response at all) auto-retry: without this the gated tools could never
+ * trigger the old click-to-retry path, deadlocking the UI. Hard failures get an
+ * error toast with a manual Retry action instead.
+ */
+export function noteAiInitError({ error, seriesUID, servicesManager, retry, forceHard = false }) {
+  if (seriesUID !== toolboxState.getAiReadinessSeriesUID()) {
+    return;
+  }
+  stopAiServerProgressPolling();
+  const { uiNotificationService } = servicesManager.services;
+  const isWarmup = forceHard ? false : isAiWarmupError(error);
+  if (isWarmup) {
+    uiNotificationService.show({
+      id: AI_SERVER_TOAST_ID,
+      title: AI_SERVER_TOAST_TITLE,
+      message: 'Starting up — retrying automatically…',
+      type: 'info',
+      duration: Infinity,
+    });
+    cancelWarmupRetry();
+    _warmupRetryTimer = setTimeout(() => {
+      _warmupRetryTimer = null;
+      if (seriesUID === toolboxState.getAiReadinessSeriesUID()) {
+        retry();
+      }
+    }, WARMUP_RETRY_MS);
+    return;
+  }
+  uiNotificationService.hide(AI_SERVER_TOAST_ID);
+  uiNotificationService.show({
+    title: AI_SERVER_TOAST_TITLE,
+    message: `Segmentation setup failed: ${error?.message || 'unknown error'}`,
+    type: 'error',
+    duration: 8000,
+    action: { label: 'Retry', onClick: retry },
+  });
+}
+
+/**
+ * Guard for inference entry points. Hotkeys (P/B/L/S…) bypass toolbar disabling,
+ * so the commands themselves must refuse and explain. Returns true to proceed.
+ */
+export function ensureAiReadyForInference(servicesManager) {
+  if (toolboxState.getAiSegmentationReady()) {
+    return true;
+  }
+  const { uiNotificationService } = servicesManager.services;
+  const volumeLoaded = toolboxState.getAiVolumeLoaded();
+  uiNotificationService.show({
+    title: volumeLoaded ? AI_SERVER_TOAST_TITLE : AI_CLIENT_TOAST_TITLE,
+    message: volumeLoaded
+      ? 'Segmentation not ready — still downloading the images.'
+      : 'Segmentation not ready — images still caching.',
+    type: 'warning',
+    duration: 4000,
+  });
+  return false;
+}
+
+/** Full teardown for mode exit: no AI readiness timer or toast may outlive the mode. */
+export function teardownAiReadiness(servicesManager) {
+  cancelWarmupRetry();
+  stopAiServerProgressPolling();
+  const { uiNotificationService } = servicesManager.services;
+  uiNotificationService.hide(AI_SERVER_TOAST_ID);
+  uiNotificationService.hide(AI_VOLUME_TOAST_ID);
+}

--- a/Viewers/extensions/default/src/utils/aiReadinessVolumeWatch.ts
+++ b/Viewers/extensions/default/src/utils/aiReadinessVolumeWatch.ts
@@ -1,0 +1,162 @@
+import { cache, eventTarget, Enums } from '@cornerstonejs/core';
+import { toolboxState } from '../stores/toolboxState';
+import { AI_VOLUME_TOAST_ID, AI_CLIENT_TOAST_TITLE, refreshAiToolbar } from './aiReadiness';
+
+const TICK_MS = 500;
+const PROGRESS_STEP = 10; // only re-toast on moves of > 10 percentage points
+
+// ---------------------------------------------------------------------------
+// Volume-readiness watch (flag duty only — no toast)
+// ---------------------------------------------------------------------------
+
+let _watch: {
+  volumeId: string;
+  intervalId: ReturnType<typeof setInterval>;
+  listener: (evt) => void;
+} | null = null;
+
+export function stopAiVolumeWatch() {
+  if (!_watch) {
+    return;
+  }
+  clearInterval(_watch.intervalId);
+  eventTarget.removeEventListener(
+    Enums.Events.IMAGE_VOLUME_LOADING_COMPLETED,
+    _watch.listener
+  );
+  _watch = null;
+}
+
+function markLoaded(servicesManager) {
+  stopAiVolumeWatch();
+  if (!toolboxState.getAiVolumeLoaded()) {
+    toolboxState.setAiVolumeLoaded(true);
+    refreshAiToolbar(servicesManager);
+  }
+}
+
+/**
+ * Track client-side streaming progress for the active series' source volume.
+ * Called from initNninter on every trigger; safe to call repeatedly.
+ * This function only manages the aiVolumeLoaded flag — toast duties belong to
+ * watchAiClientDownload.
+ */
+export function watchAiVolumeReadiness({ displaySet, servicesManager }) {
+  const volumeId = `cornerstoneStreamingImageVolume:${displaySet.displaySetInstanceUID}`;
+  const volume = cache.getVolume(volumeId);
+
+  // Stack viewports have no streaming volume — nothing client-side to wait on
+  // (the server segments its own full copy; prompt coordinates are geometric).
+  if (!volume || volume.loadStatus?.loaded) {
+    markLoaded(servicesManager);
+    return;
+  }
+
+  if (_watch?.volumeId === volumeId) {
+    return; // already watching this volume
+  }
+
+  stopAiVolumeWatch();
+  toolboxState.setAiVolumeLoaded(false);
+  refreshAiToolbar(servicesManager);
+
+  const listener = evt => {
+    if (evt?.detail?.volumeId === volumeId) {
+      markLoaded(servicesManager);
+    }
+  };
+  eventTarget.addEventListener(Enums.Events.IMAGE_VOLUME_LOADING_COMPLETED, listener);
+
+  const intervalId = setInterval(() => {
+    const v = cache.getVolume(volumeId);
+    if (!v || v.loadStatus?.loaded) {
+      markLoaded(servicesManager);
+    }
+  }, TICK_MS);
+
+  _watch = { volumeId, intervalId, listener };
+}
+
+// ---------------------------------------------------------------------------
+// Client slice-download ticker (display-only — never touches readiness flags)
+// ---------------------------------------------------------------------------
+
+let _download: {
+  key: string;
+  intervalId: ReturnType<typeof setInterval>;
+  lastShownPct: number;
+} | null = null;
+
+export function stopAiClientDownload(uiNotificationService?) {
+  if (!_download) {
+    return;
+  }
+  clearInterval(_download.intervalId);
+  uiNotificationService?.hide(AI_VOLUME_TOAST_ID);
+  _download = null;
+}
+
+function downloadPct(imageIds) {
+  const loaded = imageIds.filter(id => cache.getImage(id)).length;
+  return Math.floor((100 * loaded) / imageIds.length);
+}
+
+function showDownloadToast(uiNotificationService, pct) {
+  uiNotificationService.show({
+    id: AI_VOLUME_TOAST_ID,
+    title: AI_CLIENT_TOAST_TITLE,
+    message: `Caching images… ${pct}%`,
+    type: 'info',
+    duration: Infinity,
+  });
+}
+
+/**
+ * Display-only slice ticker: shows caching progress ONLY while the client side
+ * actually gates segmentation — i.e. while `aiVolumeLoaded` is false (an MPR
+ * volume actively streaming). Stack view lazy-loads slices by design, so a
+ * partially-filled cache there is normal and gets no toast. Never touches
+ * readiness flags.
+ */
+export function watchAiClientDownload({ imageIds, servicesManager }) {
+  const { uiNotificationService } = servicesManager.services;
+  if (!imageIds?.length) {
+    stopAiClientDownload(uiNotificationService);
+    return;
+  }
+  if (toolboxState.getAiVolumeLoaded()) {
+    // Client isn't blocking anything; lazy loading is intentional — stay quiet.
+    stopAiClientDownload(uiNotificationService);
+    return;
+  }
+  const key = `${imageIds.length}:${imageIds[0]}:${imageIds[imageIds.length - 1]}`;
+  if (_download?.key === key) {
+    return; // same series, already ticking
+  }
+  stopAiClientDownload(uiNotificationService);
+
+  const initialPct = downloadPct(imageIds);
+  if (initialPct >= 100) {
+    return; // fully cached — nothing to show
+  }
+  showDownloadToast(uiNotificationService, initialPct);
+
+  const intervalId = setInterval(() => {
+    if (toolboxState.getAiVolumeLoaded()) {
+      // The volume finished (or the viewport stopped gating) — purpose served.
+      stopAiClientDownload(uiNotificationService);
+      return;
+    }
+    const pct = downloadPct(imageIds);
+    if (pct >= 100) {
+      stopAiClientDownload(uiNotificationService);
+      return;
+    }
+    if (_download && pct > _download.lastShownPct + PROGRESS_STEP) {
+      _download.lastShownPct = pct;
+      showDownloadToast(uiNotificationService, pct);
+    }
+  }, TICK_MS);
+
+  _download = { key, intervalId, lastShownPct: initialPct };
+}

--- a/Viewers/modes/longitudinal/src/toolbarButtons.ts
+++ b/Viewers/modes/longitudinal/src/toolbarButtons.ts
@@ -244,7 +244,7 @@ const toolbarButtons: Button[] = [
       label: 'Point',
       tooltip: 'Point [P]',
       commands: toggleToolActiveToolbar,
-      evaluate: 'evaluate.cornerstoneTool',
+      evaluate: ['evaluate.cornerstoneTool', 'evaluate.aiSegmentationReady'],
     },
   },
   {
@@ -444,7 +444,7 @@ const toolbarButtons: Button[] = [
       label: 'BBox',
       tooltip: 'Bounding Box [B]',
       commands: toggleToolActiveToolbar,
-      evaluate: 'evaluate.cornerstoneTool',
+      evaluate: ['evaluate.cornerstoneTool', 'evaluate.aiSegmentationReady'],
     },
   },
   {
@@ -477,7 +477,7 @@ const toolbarButtons: Button[] = [
       label: 'Lasso',
       tooltip: 'Lasso [L]',
       commands: toggleToolActiveToolbar,
-      evaluate: 'evaluate.cornerstoneTool',
+      evaluate: ['evaluate.cornerstoneTool', 'evaluate.aiSegmentationReady'],
     },
   },
   {
@@ -488,7 +488,7 @@ const toolbarButtons: Button[] = [
       label: 'Scribble',
       tooltip: 'Scribble [S]',
       commands: toggleToolActiveToolbar,
-      evaluate: 'evaluate.cornerstoneTool',
+      evaluate: ['evaluate.cornerstoneTool', 'evaluate.aiSegmentationReady'],
     },
   },
   {
@@ -619,6 +619,7 @@ const toolbarButtons: Button[] = [
       label: 'run segmentation',
       tooltip: 'run',
       commands: 'runAiSegmentation',
+      evaluate: 'evaluate.aiSegmentationReady',
     },
   },
   {
@@ -630,6 +631,7 @@ const toolbarButtons: Button[] = [
       label: 'Undo',
       tooltip: 'Undo (Ctrl+Z)',
       commands: 'undoNninter',
+      evaluate: 'evaluate.aiSegmentationReady',
     },
   },
   {
@@ -641,6 +643,7 @@ const toolbarButtons: Button[] = [
       label: 'Text Prompt',
       tooltip: 'VoxTell',
       commands: 'textPromptSegmentation',
+      evaluate: 'evaluate.aiSegmentationReady',
     },
   },
   {
@@ -671,6 +674,7 @@ const toolbarButtons: Button[] = [
       label: 'SAM2',
       tooltip: 'sam2',
       commands: 'sam2',
+      evaluate: 'evaluate.aiSegmentationReady',
     },
   },
   {
@@ -682,6 +686,7 @@ const toolbarButtons: Button[] = [
       label: 'resetNninter',
       tooltip: 'resetNninter',
       commands: 'resetNninter',
+      evaluate: 'evaluate.aiSegmentationReady',
     },
   },
   {

--- a/monai-label/monailabel/datastore/utils/dicom.py
+++ b/monai-label/monailabel/datastore/utils/dicom.py
@@ -11,6 +11,9 @@
 
 import logging
 import os
+import shutil
+import tempfile
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
 
@@ -19,6 +22,7 @@ from pydicom.dataset import Dataset
 from pydicom.filereader import dcmread
 
 from monailabel.utils.others.generic import md5_digest, run_command
+from monailabel.utils.others.progress_registry import clear, set_download_progress
 
 logger = logging.getLogger(__name__)
 
@@ -75,15 +79,50 @@ def dicom_web_download_series(study_id, series_id, save_dir, client: DICOMwebCli
         )
         study_id = str(meta["StudyInstanceUID"].value)
 
-    os.makedirs(save_dir, exist_ok=True)
+    # Progress is advisory/display-only: a registry or metadata failure must
+    # never fail the download itself.
+    try:
+        total = len(client.retrieve_series_metadata(study_id, series_id))
+    except Exception:
+        logger.debug("series metadata count failed; progress total unknown", exc_info=True)
+        total = 0
+
     if not frame_fetch:
-        instances = client.retrieve_series(study_id, series_id)
-        for instance in instances:
-            instance_id = str(instance["SOPInstanceUID"].value)
-            file_name = os.path.join(save_dir, f"{instance_id}.dcm")
-            instance.save_as(file_name)
+        set_download_progress(series_id, 0, total)
+        fetched = 0
+        # Stream into a temp sibling and publish atomically: save_dir must never
+        # exist in a partial state, because the datastore treats any non-empty
+        # dir as a complete cached series (datastore/dicom.py get_image_uri).
+        # The parent chain must exist for mkdtemp, but save_dir itself must not.
+        parent_dir = os.path.dirname(save_dir) or "."
+        os.makedirs(parent_dir, exist_ok=True)
+        tmp_dir = tempfile.mkdtemp(prefix=".download-", dir=parent_dir)
+        try:
+            for instance in client.iter_series(study_id, series_id):
+                instance_id = str(instance["SOPInstanceUID"].value)
+                instance.save_as(os.path.join(tmp_dir, f"{instance_id}.dcm"))
+                fetched += 1
+                set_download_progress(series_id, fetched, total)
+            try:
+                os.rename(tmp_dir, save_dir)
+            except OSError:
+                if os.path.isdir(save_dir) and os.listdir(save_dir):
+                    # a concurrent request already published a complete dir; keep theirs
+                    shutil.rmtree(tmp_dir, ignore_errors=True)
+                else:
+                    raise
+        except Exception:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            clear(series_id)
+            raise
     else:
+        os.makedirs(save_dir, exist_ok=True)
         # TODO:: This logic (combining meta+pixeldata) needs improvement
+        meta_list = client.retrieve_series_metadata(study_id, series_id)
+        total = len(meta_list)
+        progress_lock = threading.Lock()
+        fetched_box = [0]
+
         def save_from_frame(m):
             d = Dataset.from_json(m)
             instance_id = str(d["SOPInstanceUID"].value)
@@ -101,11 +140,18 @@ def dicom_web_download_series(study_id, series_id, save_dir, client: DICOMwebCli
             file_name = os.path.join(save_dir, f"{instance_id}.dcm")
             logger.info(f"++ Saved {os.path.basename(file_name)}")
             d.save_as(file_name)
+            with progress_lock:
+                fetched_box[0] += 1
+                set_download_progress(series_id, fetched_box[0], total)
 
-        meta_list = client.retrieve_series_metadata(study_id, series_id)
         logger.info(f"++ Saving DCM into: {save_dir}")
-        with ThreadPoolExecutor(max_workers=2, thread_name_prefix="DICOMFetch") as executor:
-            executor.map(save_from_frame, meta_list)
+        try:
+            with ThreadPoolExecutor(max_workers=2, thread_name_prefix="DICOMFetch") as executor:
+                # list() forces exceptions from workers to surface here
+                list(executor.map(save_from_frame, meta_list))
+        except Exception:
+            clear(series_id)
+            raise
 
     logger.info(f"Time to download: {time.time() - start} (sec)")
 

--- a/monai-label/monailabel/endpoints/infer.py
+++ b/monai-label/monailabel/endpoints/infer.py
@@ -30,6 +30,7 @@ import numpy as np
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from fastapi.background import BackgroundTasks
 from fastapi.responses import FileResponse, Response
+from starlette.concurrency import run_in_threadpool
 from requests_toolbelt import MultipartEncoder
 
 import pydicom
@@ -44,6 +45,7 @@ from monailabel.endpoints.user.auth import RBAC, User
 from monailabel.interfaces.app import MONAILabelApp
 from monailabel.interfaces.utils.app import app_instance
 from monailabel.utils.others.generic import get_mime_type, remove_file
+from monailabel.utils.others.progress_registry import clear as clear_progress
 from monailabel.utils.others.stream import stream_multipart
 
 from monailabel.datastore.utils.dicom import dicom_web_upload_dcm
@@ -350,4 +352,16 @@ async def api_run_inference(
     output: Optional[ResultType] = None,
     user: User = Depends(RBAC(settings.MONAI_LABEL_AUTH_ROLE_USER)),
 ):
-    return run_inference(background_tasks, model, image, session_id, params, file, label, output)
+    try:
+        # run_inference is fully synchronous (DICOM download, sitk reads, GPU
+        # preprocess). Called directly from this async handler it would run ON
+        # the event loop and stall every other request — including the
+        # read-only progress endpoint whose whole purpose is to answer DURING
+        # this request. Hand it to the threadpool so the loop stays free.
+        return await run_in_threadpool(
+            run_inference, background_tasks, model, image, session_id, params, file, label, output
+        )
+    finally:
+        # Entry is display-only; whatever happened, this request is over.
+        if image:
+            clear_progress(image)

--- a/monai-label/monailabel/endpoints/nninter_session.py
+++ b/monai-label/monailabel/endpoints/nninter_session.py
@@ -10,6 +10,7 @@ import logging
 from fastapi import APIRouter
 
 from monailabel.tasks.infer import nninter_session_pool
+from monailabel.utils.others import progress_registry
 
 logger = logging.getLogger(__name__)
 
@@ -31,3 +32,9 @@ def claim_session():
 def release_session(token: str):
     nninter_session_pool.get_pool().release(token)
     return {"released": True}
+
+
+@router.get("/progress", summary="Read-only download/preprocess progress for a series (display only)")
+def get_progress(image: str):
+    entry = progress_registry.get(image)
+    return entry if entry is not None else {"phase": "unknown"}

--- a/monai-label/monailabel/tasks/infer/basic_infer.py
+++ b/monai-label/monailabel/tasks/infer/basic_infer.py
@@ -42,6 +42,7 @@ from monailabel.interfaces.utils.transform import dump_data, run_transforms
 from monailabel.transform.cache import CacheTransformDatad
 from monailabel.transform.writer import ClassificationWriter, DetectionWriter, Writer
 from monailabel.utils.others.generic import device_list, device_map, name_to_device
+from monailabel.utils.others.progress_registry import set_phase
 
 try:
     from monailabel.utils.others.perf_trace import counters_suffix, leak_enabled
@@ -1554,6 +1555,13 @@ class BasicInferTask(InferTask):
                 if _SERIES_UID_TAG in dcm_img_sample else path_uid
             )
             logger.info(f"Series Instance UID: {seriesInstanceUID}")
+
+            # Download (if any) is done by now; the pixel read + set_image
+            # stretch is what remains. Display-only: never let this fail infer.
+            try:
+                set_phase(seriesInstanceUID, "preparing")
+            except Exception:
+                logger.debug("progress set_phase failed", exc_info=True)
 
             instanceNumber  = dcm_img_sample[0x00200013].value  if 0x00200013 in dcm_img_sample  else None
             instanceNumber2 = dcm_img_sample_2[0x00200013].value if 0x00200013 in dcm_img_sample_2 else None

--- a/monai-label/monailabel/utils/others/progress_registry.py
+++ b/monai-label/monailabel/utils/others/progress_registry.py
@@ -1,0 +1,47 @@
+"""In-memory per-series download/preprocess progress for the nnInteractive init path.
+
+Single-process by design: monailabel runs one uvicorn worker (the in-memory
+session pool already relies on this), so the infer path and the progress
+endpoint share this module's state. Entries are advisory/display-only — a
+registry problem must never fail a download or an infer.
+"""
+
+import threading
+import time
+from typing import Optional
+
+STALE_AFTER_S = 600  # a crashed request must not look "downloading" forever
+
+_lock = threading.Lock()
+_entries: dict = {}
+
+
+def set_download_progress(series_uid: str, fetched: int, total: int) -> None:
+    with _lock:
+        _entries[series_uid] = {
+            "phase": "downloading",
+            "fetched": fetched,
+            "total": total,
+            "updated": time.time(),
+        }
+
+
+def set_phase(series_uid: str, phase: str) -> None:
+    with _lock:
+        entry = _entries.get(series_uid, {"fetched": 0, "total": 0})
+        entry["phase"] = phase
+        entry["updated"] = time.time()
+        _entries[series_uid] = entry
+
+
+def get(series_uid: str) -> Optional[dict]:
+    with _lock:
+        entry = _entries.get(series_uid)
+        if entry is None or time.time() - entry["updated"] > STALE_AFTER_S:
+            return None
+        return {"phase": entry["phase"], "fetched": entry["fetched"], "total": entry["total"]}
+
+
+def clear(series_uid: str) -> None:
+    with _lock:
+        _entries.pop(series_uid, None)


### PR DESCRIPTION
## What

Until now, opening a first-time study left users staring at enabled AI segmentation tools that silently did nothing while images downloaded — in the browser and, dominantly, on the MONAI server (Orthanc fetch + preprocess). This PR makes readiness explicit, gates the tools until it's real, and shows live progress for the slow parts.

### Readiness gating (v1)
- Two flags in `toolboxState`, keyed to the active series: `aiVolumeLoaded` (cornerstone streaming volume) and `aiServerReady` (`initNninter` success — the request already fired at study open; its completion IS the readiness signal).
- `evaluate.aiSegmentationReady` greys out exactly the 9 AI buttons (Point/BBox/Lasso/Scribble prompts + run/SAM2/VoxTell/undo/reset) with phase-specific tooltips. Manual tools untouched.
- Guards inside `nninter()`/`sam2()`/`textPromptSegmentation()`/`undoNninter()`/`resetNninter()` — hotkeys bypass toolbar disabling, so the commands refuse with a warning toast instead of dying silently.
- Warm-up auto-retry every 5 s on 502/503/504 or no response (single classifier `isAiWarmupError`): required, because gated tools can no longer trigger the old click-to-retry path.

### Real progress (v2)
- **Server**: streaming `iter_series` download reports per-instance progress into an in-memory registry; `basic_infer` marks the preprocess phase; read-only `GET /nninter/session/progress?image=<seriesUID>`; entry cleared in `api_run_inference`'s `finally`.
- **Client**: a 1 s poller updates the persistent toast in place — **Server / "Downloading images… X%" → "Preparing images…" → "Segmentation ready"** — with silent fallback to a static message on old server images (404). A 500 ms slice ticker shows **Client / "Caching images… X%"**, but only while an MPR volume stream actually gates segmentation; stack view lazy-loads by design and stays quiet.

## Notable fixes surfaced by review/testing

- **Event-loop blocker**: `api_run_inference` (async) called the fully-sync `run_inference` directly, parking entire infers on the uvicorn event loop — every concurrent request queued behind them (the progress endpoint could never answer mid-infer, and multi-user concurrency was an illusion). Now `await run_in_threadpool(...)`; verified live with 200 ms sampling: `downloading 32/694 → 694/694 → preparing → cleared`.
- **Partial-download cache poisoning**: streaming writes broke the accidental atomicity of the old buffered `retrieve_series`; a died-mid-stream download would leave a directory the datastore forever treated as a complete series. Downloads now stream into a temp sibling dir and publish via atomic `os.rename`.
- Poller generation guard (in-flight fetch surviving `clearInterval` could resurrect a dismissed toast), full timer/toast teardown on mode exit, and a session-expired dead end that would have wedged the gated UI behind a permanent toast.

## Verification

- 43 client unit tests (readiness suites) + 14 server unit tests (registry, atomic streaming download) — all passing; tests live untracked per repo convention.
- Live end-to-end: fresh-cache study open shows both progress phases; warm-up drill (server down → auto-recover) verified; endpoint smoke via the nginx proxy.
- Two full multi-agent review passes (per-task + whole-branch) with all Critical/Important findings fixed and re-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)