### PR TITLE
fix(monai): timeout_context must not install SIGALRM off the main thread

### DIFF
--- a/monai-label/monailabel/utils/others/helper.py
+++ b/monai-label/monailabel/utils/others/helper.py
@@ -1,6 +1,7 @@
 import math
 import numpy as np
 import signal
+import threading
 from contextlib import contextmanager
 
 def clean_and_densify_polyline(polyline, max_segment_length=1):
@@ -377,10 +378,20 @@ class TimeoutError(Exception):
 
 @contextmanager
 def timeout_context(seconds):
-    """Context manager for timeout protection using signal.alarm"""
+    """Context manager for timeout protection using signal.alarm.
+
+    SIGALRM handlers can only be installed from the main thread. Infer
+    requests now run in the FastAPI threadpool (so they don't block the
+    event loop), where the alarm is impossible — degrade to a passthrough
+    there instead of raising and killing the interaction.
+    """
+    if threading.current_thread() is not threading.main_thread():
+        yield
+        return
+
     def timeout_handler(signum, frame):
         raise TimeoutError(f"Operation timed out after {seconds} seconds")
-    
+
     old_handler = signal.signal(signal.SIGALRM, timeout_handler)
     signal.alarm(seconds)
     


### PR DESCRIPTION
## What broke

After #95, infer requests run in the FastAPI threadpool (`run_in_threadpool`) so the event loop stays free for the progress endpoint. But `timeout_context` — the 100 s safety net around nnInteractive interactions (`basic_infer._safe_interaction`) — installs a `SIGALRM` handler, and Python only allows that **on the main thread**. Every interaction failed with:

```
ValueError: signal only works in main thread of the main interpreter
```

## Fix

`timeout_context` is now thread-aware: unchanged on the main thread; in a worker thread it degrades to a passthrough (no alarm). That's a POSIX limitation, not a choice — signal-based timeouts cannot exist off the main thread, and a lost best-effort timeout is strictly better than every interaction crashing.

## Verification

In-container, post-rebuild — the context manager runs cleanly from both contexts:

```
worker thread: ok
main thread  : ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
