### PR TITLE
fix(seg): stop crosshair rotation from ghosting multi-block segmentations and leaking labelmap volumes

### DIFF
--- a/Viewers/backup/esm/@cornerstonejs/tools/dist/esm/eventListeners/segmentation/imageChangeEventListener.js
+++ b/Viewers/backup/esm/@cornerstonejs/tools/dist/esm/eventListeners/segmentation/imageChangeEventListener.js
@@ -38,6 +38,7 @@ const disable = function (element) {
     element.removeEventListener(Enums.Events.CAMERA_MODIFIED, _imageChangeEventListener);
     if (viewportId) {
         perViewportManualTriggers.delete(viewportId);
+        cancelCapabilityLossTrigger(viewportId);
     }
 };
 // PROJECT OVERRIDE. When a viewport rendering labelmaps through the volume-slice image
@@ -45,10 +46,34 @@ const disable = function (element) {
 // false and upstream's CAMERA_MODIFIED branch returned without triggering anything — the
 // render-plan switch away from the image mapper then happened only whenever some unrelated
 // segmentation event arrived, leaving a stale slice actor on screen until it did. The
-// capability-LOSS transition now fires exactly one segmentation render: the tracked state
-// key doubles as "was in image-mapper mode", and deleting it before triggering makes later
-// oblique camera frames no-ops.
+// capability-LOSS transition now fires exactly one segmentation render. The tracked state
+// key doubles as "was in image-mapper mode".
+//
+// The trigger is DEFERRED until the camera has been quiet for a beat: firing it on the
+// first oblique frame remounts legacy volume actors (with a full labelmap texture upload)
+// in the middle of the crosshair drag, which visibly disrupted the rotation gesture. Every
+// further camera frame while the viewport stays oblique re-arms the timer, so the plan
+// switch lands once, just after the drag pauses.
 const perViewportManualTriggers = new Map();
+const pendingCapabilityLossTimers = new Map();
+const CAPABILITY_LOSS_SETTLE_MS = 250;
+function armCapabilityLossTrigger(viewportId) {
+    const existingTimer = pendingCapabilityLossTimers.get(viewportId);
+    if (existingTimer !== undefined) {
+        clearTimeout(existingTimer);
+    }
+    pendingCapabilityLossTimers.set(viewportId, setTimeout(() => {
+        pendingCapabilityLossTimers.delete(viewportId);
+        triggerSegmentationRender(viewportId);
+    }, CAPABILITY_LOSS_SETTLE_MS));
+}
+function cancelCapabilityLossTrigger(viewportId) {
+    const existingTimer = pendingCapabilityLossTimers.get(viewportId);
+    if (existingTimer !== undefined) {
+        clearTimeout(existingTimer);
+        pendingCapabilityLossTimers.delete(viewportId);
+    }
+}
 function _imageChangeEventListener(evt) {
     const eventData = evt.detail;
     const { viewportId, renderingEngineId } = eventData;
@@ -71,6 +96,7 @@ function _imageChangeEventListener(evt) {
     });
     if (evt.type === Enums.Events.CAMERA_MODIFIED) {
         if (hasVolumeImageMapperRepresentation) {
+            cancelCapabilityLossTrigger(viewportId);
             const nextState = getVolumeViewportLabelmapImageMapperState(viewport);
             const previousState = perViewportManualTriggers.get(viewportId);
             if (previousState === nextState.key) {
@@ -84,7 +110,10 @@ function _imageChangeEventListener(evt) {
         if (!isPlanarNext) {
             if (perViewportManualTriggers.has(viewportId)) {
                 perViewportManualTriggers.delete(viewportId);
-                triggerSegmentationRender(viewportId);
+                armCapabilityLossTrigger(viewportId);
+            }
+            else if (pendingCapabilityLossTimers.has(viewportId)) {
+                armCapabilityLossTrigger(viewportId);
             }
             return;
         }

--- a/Viewers/backup/esm/@cornerstonejs/tools/dist/esm/eventListeners/segmentation/imageChangeEventListener.js
+++ b/Viewers/backup/esm/@cornerstonejs/tools/dist/esm/eventListeners/segmentation/imageChangeEventListener.js
@@ -1,0 +1,114 @@
+import { BaseVolumeViewport } from '@cornerstonejs/core';
+import { getEnabledElement, Enums, getEnabledElementByIds, } from '@cornerstonejs/core';
+import { triggerSegmentationRender } from '../../stateManagement/segmentation/SegmentationRenderingEngine';
+import { SegmentationRepresentations } from '../../enums';
+import getViewportLabelmapRenderMode from '../../stateManagement/segmentation/helpers/getViewportLabelmapRenderMode';
+import { canRenderVolumeViewportLabelmapAsImage, getVolumeViewportLabelmapImageMapperState, shouldUseSliceRendering, } from '../../stateManagement/segmentation/helpers/labelmapImageMapperSupport';
+import { getSegmentationRepresentations } from '../../stateManagement/segmentation/getSegmentationRepresentation';
+import { getSegmentation } from '../../stateManagement/segmentation/getSegmentation';
+import { syncStackLabelmapActors } from '../../tools/displayTools/Labelmap/syncStackLabelmapActors';
+const enable = function (element) {
+    if (!element) {
+        return;
+    }
+    const enabledElement = getEnabledElement(element);
+    if (!enabledElement) {
+        return;
+    }
+    const { viewport } = enabledElement;
+    const isVolumeViewport = viewport instanceof BaseVolumeViewport;
+    const isPlanarViewport = viewport.type === Enums.ViewportType.PLANAR_NEXT;
+    const canUseStackImageEvents = typeof viewport
+        .getCurrentImageId === 'function';
+    if (isVolumeViewport || isPlanarViewport) {
+        element.addEventListener(Enums.Events.CAMERA_MODIFIED, _imageChangeEventListener);
+    }
+    if (isVolumeViewport ||
+        !canUseStackImageEvents ||
+        getViewportLabelmapRenderMode(viewport) !== 'image') {
+        return;
+    }
+    element.addEventListener(Enums.Events.PRE_STACK_NEW_IMAGE, _imageChangeEventListener);
+    element.addEventListener(Enums.Events.IMAGE_RENDERED, _imageChangeEventListener);
+};
+const disable = function (element) {
+    const viewportId = getEnabledElement(element)?.viewport?.id;
+    element.removeEventListener(Enums.Events.PRE_STACK_NEW_IMAGE, _imageChangeEventListener);
+    element.removeEventListener(Enums.Events.IMAGE_RENDERED, _imageChangeEventListener);
+    element.removeEventListener(Enums.Events.CAMERA_MODIFIED, _imageChangeEventListener);
+    if (viewportId) {
+        perViewportManualTriggers.delete(viewportId);
+    }
+};
+// PROJECT OVERRIDE. When a viewport rendering labelmaps through the volume-slice image
+// mapper turns oblique (crosshair rotation), canRenderVolumeViewportLabelmapAsImage flips
+// false and upstream's CAMERA_MODIFIED branch returned without triggering anything — the
+// render-plan switch away from the image mapper then happened only whenever some unrelated
+// segmentation event arrived, leaving a stale slice actor on screen until it did. The
+// capability-LOSS transition now fires exactly one segmentation render: the tracked state
+// key doubles as "was in image-mapper mode", and deleting it before triggering makes later
+// oblique camera frames no-ops.
+const perViewportManualTriggers = new Map();
+function _imageChangeEventListener(evt) {
+    const eventData = evt.detail;
+    const { viewportId, renderingEngineId } = eventData;
+    const enabledElement = getEnabledElementByIds(viewportId, renderingEngineId);
+    if (!enabledElement) {
+        return;
+    }
+    const { viewport } = enabledElement;
+    const isVolumeViewport = viewport instanceof BaseVolumeViewport;
+    const representations = getSegmentationRepresentations(viewportId);
+    if (!representations?.length) {
+        perViewportManualTriggers.delete(viewportId);
+        return;
+    }
+    const labelmapRepresentations = representations.filter((representation) => representation.type === SegmentationRepresentations.Labelmap);
+    const hasVolumeImageMapperRepresentation = labelmapRepresentations.some((representation) => {
+        const segmentation = getSegmentation(representation.segmentationId);
+        return (canRenderVolumeViewportLabelmapAsImage(viewport) &&
+            shouldUseSliceRendering(segmentation, representation.config));
+    });
+    if (evt.type === Enums.Events.CAMERA_MODIFIED) {
+        if (hasVolumeImageMapperRepresentation) {
+            const nextState = getVolumeViewportLabelmapImageMapperState(viewport);
+            const previousState = perViewportManualTriggers.get(viewportId);
+            if (previousState === nextState.key) {
+                return;
+            }
+            perViewportManualTriggers.set(viewportId, nextState.key);
+            triggerSegmentationRender(viewportId);
+            return;
+        }
+        const isPlanarNext = viewport.type === Enums.ViewportType.PLANAR_NEXT;
+        if (!isPlanarNext) {
+            if (perViewportManualTriggers.has(viewportId)) {
+                perViewportManualTriggers.delete(viewportId);
+                triggerSegmentationRender(viewportId);
+            }
+            return;
+        }
+    }
+    if (getViewportLabelmapRenderMode(viewport) !== 'image') {
+        return;
+    }
+    if (canRenderVolumeViewportLabelmapAsImage(viewport)) {
+        return;
+    }
+    if (typeof viewport
+        .getCurrentImageId !== 'function') {
+        return;
+    }
+    const stackViewport = viewport;
+    labelmapRepresentations.forEach((representation) => {
+        const { segmentationId } = representation;
+        syncStackLabelmapActors(stackViewport, segmentationId);
+        if (evt.type === Enums.Events.IMAGE_RENDERED) {
+            stackViewport.element.removeEventListener(Enums.Events.IMAGE_RENDERED, _imageChangeEventListener);
+        }
+    });
+}
+export default {
+    enable,
+    disable,
+};

--- a/Viewers/backup/esm/@cornerstonejs/tools/dist/esm/tools/displayTools/Labelmap/labelmapRenderPlan/planarGenericVolumeLabelmap.js
+++ b/Viewers/backup/esm/@cornerstonejs/tools/dist/esm/tools/displayTools/Labelmap/labelmapRenderPlan/planarGenericVolumeLabelmap.js
@@ -1,0 +1,99 @@
+import { ActorRenderMode, Enums, cache, utilities, } from '@cornerstonejs/core';
+import { createLabelmapRepresentationUID } from '../labelmapRepresentationUID';
+function isPlanarNextVolumeViewport(viewport) {
+    const genericViewport = viewport;
+    return (genericViewport.type === Enums.ViewportType.PLANAR_NEXT &&
+        typeof genericViewport.getVolumeId === 'function' &&
+        typeof genericViewport.getViewReference === 'function' &&
+        typeof genericViewport.getViewState === 'function' &&
+        typeof genericViewport.addDisplaySet === 'function' &&
+        typeof genericViewport.setDisplaySetPresentation === 'function' &&
+        typeof genericViewport.setViewReference === 'function');
+}
+// PROJECT OVERRIDE. Upstream seeds each overlay display set with
+// `initialImageIdIndex = min(viewport current index, layer length - 1)` — an index into the
+// VIEWPORT'S source stack clamped into the LAYER'S own imageIds. That only lines up when the
+// layer spans the source stack 1:1; a z-cropped block (160 of 694 slices) gets an unrelated
+// block-local slice. The current source image is instead mapped through the layer's
+// referencedImageIds; when the block does not cover the current slice the index is omitted,
+// which the planar viewport supports (setViewReference below places the overlay
+// geometrically). Layers without referencedImageIds keep upstream's behavior.
+async function addLabelmapToPlanarGenericViewport(args) {
+    const { blendMode, labelmapLayers, segmentationId, viewport, visibility } = args;
+    const sourceVolumeRenderMode = getPlanarNextVolumeRenderMode(viewport);
+    if (!sourceVolumeRenderMode) {
+        return;
+    }
+    const sourceVolumeId = viewport.getVolumeId();
+    const sourceViewReference = sourceVolumeId
+        ? viewport.getViewReference({ volumeId: sourceVolumeId })
+        : viewport.getViewReference();
+    const requestedOrientation = viewport.getViewState().orientation;
+    const currentImageIdIndex = Math.max(0, viewport.getCurrentImageIdIndex?.() ?? 0);
+    const currentSourceImageId = viewport.getCurrentImageId?.();
+    let firstActorEntry;
+    for (const layer of labelmapLayers) {
+        if (!layer.volumeId) {
+            continue;
+        }
+        const volume = cache.getVolume(layer.volumeId);
+        if (!volume) {
+            throw new Error(`imageVolume with id: ${layer.volumeId} does not exist, you need to create/allocate the volume first`);
+        }
+        const representationUID = createLabelmapRepresentationUID({
+            segmentationId,
+            referencedId: layer.labelmapId,
+        });
+        const dataId = representationUID;
+        const referencedImageIds = layer.referencedImageIds;
+        let initialImageIdIndex;
+        if (Array.isArray(referencedImageIds) && referencedImageIds.length) {
+            const mappedIndex = currentSourceImageId
+                ? referencedImageIds.indexOf(currentSourceImageId)
+                : -1;
+            initialImageIdIndex = mappedIndex >= 0 ? mappedIndex : undefined;
+        }
+        else {
+            initialImageIdIndex = Math.min(currentImageIdIndex, Math.max(volume.imageIds.length - 1, 0));
+        }
+        utilities.genericViewportDataSetMetadataProvider.add(dataId, {
+            kind: 'planar',
+            imageIds: volume.imageIds,
+            initialImageIdIndex,
+            reference: {
+                kind: 'segmentation',
+                segmentationId,
+                representationUID,
+                labelmapId: layer.labelmapId,
+            },
+            volumeId: layer.volumeId,
+        });
+        await viewport.addDisplaySet(dataId, {
+            orientation: requestedOrientation,
+            role: 'overlay',
+        });
+        viewport.setDisplaySetPresentation(dataId, {
+            blendMode,
+            visible: visibility,
+        });
+        firstActorEntry ||= viewport
+            .getActors?.()
+            .find((actorEntry) => actorEntry.representationUID === representationUID);
+    }
+    viewport.setViewReference(sourceViewReference);
+    viewport.render?.();
+    if (firstActorEntry) {
+        return {
+            uid: firstActorEntry.uid,
+            actor: firstActorEntry.actor,
+        };
+    }
+}
+function getPlanarNextVolumeRenderMode(viewport) {
+    const renderMode = viewport.getDefaultActor?.()?.actorMapper?.renderMode;
+    if (renderMode === ActorRenderMode.CPU_VOLUME ||
+        renderMode === ActorRenderMode.VTK_VOLUME_SLICE) {
+        return renderMode;
+    }
+}
+export { addLabelmapToPlanarGenericViewport, isPlanarNextVolumeViewport, };

--- a/Viewers/backup/esm/@cornerstonejs/tools/dist/esm/tools/displayTools/Labelmap/syncStackLabelmapActors.js
+++ b/Viewers/backup/esm/@cornerstonejs/tools/dist/esm/tools/displayTools/Labelmap/syncStackLabelmapActors.js
@@ -1,0 +1,140 @@
+import vtkDataArray from '@kitware/vtk.js/Common/Core/DataArray';
+import vtkImageData from '@kitware/vtk.js/Common/DataModel/ImageData';
+import { ActorRenderMode, cache, utilities, } from '@cornerstonejs/core';
+import { triggerSegmentationRender } from '../../../stateManagement/segmentation/SegmentationRenderingEngine';
+import { updateLabelmapSegmentationImageReferences } from '../../../stateManagement/segmentation/updateLabelmapSegmentationImageReferences';
+import { getCurrentLabelmapImageIdsForViewport } from '../../../stateManagement/segmentation/getCurrentLabelmapImageIdForViewport';
+import { getLabelmapActorEntries } from '../../../stateManagement/segmentation/helpers/getSegmentationActor';
+import getViewportLabelmapRenderMode from '../../../stateManagement/segmentation/helpers/getViewportLabelmapRenderMode';
+import { createLabelmapRepresentationUID } from './labelmapRepresentationUID';
+import removeLabelmapRepresentationData from './removeLabelmapRepresentationData';
+// PROJECT OVERRIDE. Upstream stamped every layer's vtkImageData with the CURRENTLY VIEWED
+// slice's origin (imageData.setOrigin(currentOrigin)) and never revisited an actor's origin
+// on update. Both are only correct when the resolved labelmap image really belongs to the
+// current slice; whenever the resolver hands back an image for a different slice (its
+// isReferenceViewable fallback can), the overlay is drawn at the wrong z — the "ghost copy"
+// failure mode of z-cropped multi-block labelmaps. A derived labelmap image carries its own
+// referenced slice's plane metadata, so its own origin is always the right one: identical to
+// currentOrigin in the healthy case, and the true position (instead of a ghost) otherwise.
+export function syncStackLabelmapActors(viewport, segmentationId) {
+    if (typeof viewport
+        .getCurrentImageId !== 'function') {
+        return;
+    }
+    const currentImageId = viewport.getCurrentImageId();
+    if (!currentImageId) {
+        return;
+    }
+    updateLabelmapSegmentationImageReferences(viewport.id, segmentationId);
+    const derivedImageIds = getCurrentLabelmapImageIdsForViewport(viewport.id, segmentationId) ?? [];
+    const derivedImageIdSet = new Set(derivedImageIds);
+    const labelmapActorEntries = getLabelmapActorEntries(viewport.id, segmentationId) ?? [];
+    const staleActorEntries = labelmapActorEntries.filter((actorEntry) => !derivedImageIdSet.has(actorEntry.referencedId));
+    let shouldTriggerSegmentationRender = false;
+    let shouldRenderViewport = staleActorEntries.length > 0;
+    if (staleActorEntries.length) {
+        const legacyActorEntryUIDs = [];
+        staleActorEntries.forEach((actorEntry) => {
+            if (removeLabelmapRepresentationData(viewport, segmentationId, actorEntry)) {
+                return;
+            }
+            legacyActorEntryUIDs.push(actorEntry.uid);
+        });
+        if (legacyActorEntryUIDs.length) {
+            viewport.removeActors(legacyActorEntryUIDs);
+        }
+        shouldTriggerSegmentationRender = true;
+    }
+    const renderMode = getViewportLabelmapRenderMode(viewport);
+    const defaultActorRenderMode = viewport.getDefaultActor()?.actorMapper
+        ?.renderMode;
+    derivedImageIds.forEach((derivedImageId) => {
+        const derivedImage = cache.getImage(derivedImageId);
+        if (!derivedImage) {
+            console.warn('No derived image found in the cache for segmentation representation', { segmentationId, derivedImageId });
+            return;
+        }
+        const segmentationActorEntry = getLabelmapActorEntries(viewport.id, segmentationId)?.find((actorEntry) => actorEntry.referencedId === derivedImageId);
+        if (!segmentationActorEntry) {
+            const representationUID = createLabelmapRepresentationUID({
+                segmentationId,
+                referencedId: derivedImage.imageId,
+            });
+            if (renderMode === 'image' &&
+                defaultActorRenderMode === ActorRenderMode.CPU_IMAGE) {
+                viewport.addImages([
+                    {
+                        dataId: representationUID,
+                        imageId: derivedImageId,
+                        reference: {
+                            kind: 'segmentation',
+                            segmentationId,
+                            representationUID,
+                            labelmapId: derivedImage.imageId,
+                        },
+                        representationUID,
+                    },
+                ]);
+            }
+            else {
+                const { dimensions, spacing, direction, origin } = viewport.getImageDataMetadata(derivedImage);
+                const constructor = derivedImage.voxelManager.getConstructor();
+                const newPixelData = derivedImage.voxelManager.getScalarData();
+                const values = new constructor(newPixelData);
+                const scalarArray = vtkDataArray.newInstance({
+                    dataType: vtkDataArray.getDataType(values),
+                    name: 'Pixels',
+                    numberOfComponents: 1,
+                    values,
+                });
+                const imageData = vtkImageData.newInstance();
+                imageData.setDimensions(dimensions[0], dimensions[1], 1);
+                imageData.setSpacing(spacing);
+                imageData.setDirection(direction);
+                imageData.setOrigin(origin);
+                imageData.getPointData().setScalars(scalarArray);
+                imageData.modified();
+                viewport.addImages([
+                    {
+                        dataId: representationUID,
+                        imageId: derivedImageId,
+                        reference: {
+                            kind: 'segmentation',
+                            segmentationId,
+                            representationUID,
+                            labelmapId: derivedImage.imageId,
+                        },
+                        representationUID,
+                        callback: ({ imageActor }) => {
+                            imageActor.getMapper().setInputData(imageData);
+                        },
+                    },
+                ]);
+            }
+            shouldTriggerSegmentationRender = true;
+            shouldRenderViewport = true;
+            return;
+        }
+        const actorMapper = segmentationActorEntry.actorMapper;
+        const mapper = actorMapper?.mapper
+            ? actorMapper.mapper
+            : segmentationActorEntry.actor.getMapper();
+        const segmentationImageData = mapper.getInputData();
+        segmentationImageData.modified();
+        if (segmentationImageData.setDerivedImage) {
+            segmentationImageData.setDerivedImage(derivedImage);
+        }
+        else {
+            utilities.updateVTKImageDataWithCornerstoneImage(segmentationImageData, derivedImage);
+            const { origin } = viewport.getImageDataMetadata(derivedImage);
+            segmentationImageData.setOrigin(origin);
+        }
+        shouldRenderViewport = true;
+    });
+    if (shouldTriggerSegmentationRender) {
+        triggerSegmentationRender(viewport.id);
+    }
+    if (shouldRenderViewport) {
+        viewport.render();
+    }
+}

--- a/Viewers/backup/esm/@cornerstonejs/tools/dist/esm/tools/displayTools/Labelmap/volumeLabelmapImageMapper.js
+++ b/Viewers/backup/esm/@cornerstonejs/tools/dist/esm/tools/displayTools/Labelmap/volumeLabelmapImageMapper.js
@@ -1,0 +1,291 @@
+import vtkImageMapper from '@kitware/vtk.js/Rendering/Core/ImageMapper';
+import vtkImageSlice from '@kitware/vtk.js/Rendering/Core/ImageSlice';
+import { ActorRenderMode, Enums } from '@cornerstonejs/core';
+import { canRenderVolumeViewportLabelmapAsImage } from '../../../stateManagement/segmentation/helpers/labelmapImageMapperSupport';
+import { getLabelmap, getOrCreateLabelmapVolume, getLabelmaps, getLabelmapForImageId, getLabelmapForVolumeId, } from '../../../stateManagement/segmentation/helpers/labelmapSegmentationState';
+import { createLabelmapRepresentationUID, isLabelmapRepresentationUID, } from './labelmapRepresentationUID';
+import { applyPlanarOverlayDepthOffset, createSliceImageData, getSliceRenderingCamera, getSliceState, } from './volumeLabelmapSliceData';
+// PROJECT OVERRIDE. The slice-mapper actor lives in a secondary overlay renderer
+// (`<viewportId>::labelmap-image-mapper-overlay`) that is drawn on every viewport render.
+// Upstream's removal path is gated on canRenderVolumeViewportLabelmapAsImage — which goes
+// FALSE the moment the viewport turns oblique (crosshair rotation), i.e. exactly when the
+// render plan flips to legacy-volume and needs the slice actor gone. The fallback removal
+// (Viewport.removeActors) only touches the BASE renderer and erases the viewport's actor
+// bookkeeping, leaving the slice actor untracked but still drawn in the overlay renderer,
+// frozen at its last orthogonal plane. Every oblique<->orthogonal round trip then adds one
+// more ghost copy of the segmentation. Two changes:
+//   1. removeVolumeLabelmapImageMapperActors gates on the overlay renderer's EXISTENCE, not
+//      on renderability, and additionally sweeps the overlay renderer for actors no longer
+//      tracked by the viewport — collecting ghosts orphaned before this code runs.
+//   2. addVolumeLabelmapImageMapperActors only moves an actor into the overlay renderer if
+//      viewport.addActor actually accepted it (it warns and returns on a duplicate UID;
+//      moving the refused actor would strand it in the overlay renderer untracked).
+const OVERLAY_RENDERER_SUFFIX = 'labelmap-image-mapper-overlay';
+function isPlanarSliceRenderingViewport(viewport) {
+    const compatibilityViewport = viewport;
+    return (compatibilityViewport.type === Enums.ViewportType.PLANAR_NEXT &&
+        typeof compatibilityViewport.addImages === 'function' &&
+        typeof compatibilityViewport.getCurrentImageId === 'function' &&
+        typeof compatibilityViewport.render === 'function');
+}
+function createActorEntry(args) {
+    const mapper = vtkImageMapper.newInstance();
+    mapper.setInputData(args.imageData);
+    const actor = vtkImageSlice.newInstance();
+    actor.setMapper(mapper);
+    return {
+        uid: args.representationUID,
+        actor,
+        actorMapper: {
+            actor,
+            mapper,
+            renderMode: ActorRenderMode.VTK_IMAGE,
+        },
+        referencedId: args.referencedId,
+        representationUID: args.representationUID,
+    };
+}
+function getOverlayRendererId(viewportId) {
+    return `${viewportId}::${OVERLAY_RENDERER_SUFFIX}`;
+}
+function getOrCreateOverlayRenderer(viewport) {
+    const renderingEngine = viewport.getRenderingEngine();
+    const offscreenMultiRenderWindow = renderingEngine.getOffscreenMultiRenderWindow(viewport.id);
+    const overlayRendererId = getOverlayRendererId(viewport.id);
+    const baseRenderer = viewport.getRenderer();
+    const baseViewport = baseRenderer.getViewport();
+    let overlayRenderer = offscreenMultiRenderWindow.getRenderer(overlayRendererId);
+    if (!overlayRenderer) {
+        const renderWindow = offscreenMultiRenderWindow.getRenderWindow();
+        if (renderWindow.getNumberOfLayers() < 2) {
+            renderWindow.setNumberOfLayers(2);
+        }
+        offscreenMultiRenderWindow.addRenderer({
+            viewport: baseViewport,
+            id: overlayRendererId,
+            background: [0, 0, 0],
+        });
+        overlayRenderer = offscreenMultiRenderWindow.getRenderer(overlayRendererId);
+        overlayRenderer.setLayer(1);
+        overlayRenderer.setPreserveDepthBuffer(false);
+    }
+    overlayRenderer.setActiveCamera(baseRenderer.getActiveCamera());
+    overlayRenderer.setViewport(baseViewport[0], baseViewport[1], baseViewport[2], baseViewport[3]);
+    return overlayRenderer;
+}
+function moveActorToOverlayRenderer(viewport, actorEntry) {
+    const baseRenderer = viewport.getRenderer();
+    const overlayRenderer = getOrCreateOverlayRenderer(viewport);
+    baseRenderer.removeActor(actorEntry.actor);
+    overlayRenderer.addActor(actorEntry.actor);
+}
+export function getVolumeLabelmapImageMapperRepresentationUIDs(viewport, segmentationId, segmentation) {
+    if (!canRenderVolumeViewportLabelmapAsImage(viewport)) {
+        return [];
+    }
+    const useStablePlanarUID = isPlanarSliceRenderingViewport(viewport);
+    return getLabelmaps(segmentation)
+        .map((layer) => {
+        const volume = getOrCreateLabelmapVolume(layer);
+        if (!volume) {
+            return;
+        }
+        const state = getSliceState(viewport, volume);
+        if (!state) {
+            return;
+        }
+        return createLabelmapRepresentationUID({
+            segmentationId,
+            referencedId: layer.labelmapId,
+            ...(useStablePlanarUID ? {} : { sliceStateKey: state.key }),
+        });
+    })
+        .filter((value) => !!value);
+}
+export async function addVolumeLabelmapImageMapperActors(args) {
+    const { viewport, segmentation, segmentationId } = args;
+    if (!canRenderVolumeViewportLabelmapAsImage(viewport)) {
+        return;
+    }
+    if (isPlanarSliceRenderingViewport(viewport)) {
+        await addPlanarLabelmapImageMapperActors({
+            viewport,
+            segmentation,
+            segmentationId,
+        });
+        return;
+    }
+    getLabelmaps(segmentation).forEach((layer) => {
+        const volume = getOrCreateLabelmapVolume(layer);
+        if (!volume) {
+            return;
+        }
+        const sliceData = createSliceImageData(volume, viewport);
+        if (!sliceData) {
+            return;
+        }
+        const representationUID = createLabelmapRepresentationUID({
+            segmentationId,
+            referencedId: layer.labelmapId,
+            sliceStateKey: sliceData.state.key,
+        });
+        const actorEntry = createActorEntry({
+            imageData: sliceData.imageData,
+            referencedId: layer.labelmapId,
+            representationUID,
+        });
+        viewport.addActor(actorEntry);
+        if (viewport.getActor(actorEntry.uid)?.actor === actorEntry.actor) {
+            moveActorToOverlayRenderer(viewport, actorEntry);
+        }
+    });
+}
+export function updateVolumeLabelmapImageMapperActors(args) {
+    const { viewport, segmentation, segmentationId, actorEntries } = args;
+    if (!canRenderVolumeViewportLabelmapAsImage(viewport)) {
+        return;
+    }
+    if (isPlanarSliceRenderingViewport(viewport)) {
+        updatePlanarLabelmapImageMapperActors({
+            viewport,
+            segmentation,
+            segmentationId,
+            actorEntries,
+        });
+        return;
+    }
+    const actorEntriesByLabelmapId = new Map((actorEntries ?? viewport.getActors())
+        .filter((actorEntry) => isLabelmapRepresentationUID(actorEntry.representationUID, segmentationId))
+        .map((actorEntry) => [actorEntry.referencedId, actorEntry]));
+    getLabelmaps(segmentation).forEach((layer) => {
+        const actorEntry = actorEntriesByLabelmapId.get(layer.labelmapId);
+        if (!actorEntry) {
+            return;
+        }
+        const volume = getOrCreateLabelmapVolume(layer);
+        if (!volume) {
+            return;
+        }
+        const sliceData = createSliceImageData(volume, viewport);
+        if (!sliceData) {
+            return;
+        }
+        const mapper = actorEntry.actor.getMapper();
+        mapper.setInputData(sliceData.imageData);
+        mapper.modified();
+        actorEntry.actor.modified?.();
+    });
+}
+export function removeVolumeLabelmapImageMapperActors(viewport, segmentationId) {
+    if (!(viewport.type === Enums.ViewportType.ORTHOGRAPHIC)) {
+        return;
+    }
+    const renderingEngine = viewport.getRenderingEngine();
+    const offscreenMultiRenderWindow = renderingEngine.getOffscreenMultiRenderWindow(viewport.id);
+    const overlayRenderer = offscreenMultiRenderWindow.getRenderer(getOverlayRendererId(viewport.id));
+    if (!overlayRenderer) {
+        return;
+    }
+    const trackedEntries = viewport.getActors();
+    trackedEntries
+        .filter((actorEntry) => isLabelmapRepresentationUID(actorEntry.representationUID, segmentationId))
+        .forEach((actorEntry) => {
+        overlayRenderer.removeActor(actorEntry.actor);
+    });
+    // An actor the viewport no longer tracks is unreachable by any other removal path, so it
+    // is garbage regardless of which segmentation minted it. Actors still tracked under a
+    // DIFFERENT segmentation are left alone.
+    const trackedActors = new Set(trackedEntries.map((actorEntry) => actorEntry.actor));
+    overlayRenderer
+        .getActors()
+        .filter((actor) => !trackedActors.has(actor))
+        .forEach((actor) => {
+        overlayRenderer.removeActor(actor);
+    });
+    if (!overlayRenderer.getActors().length) {
+        offscreenMultiRenderWindow.removeRenderer(getOverlayRendererId(viewport.id));
+    }
+}
+export function getLabelmapForActorReference(segmentation, referencedId) {
+    if (!referencedId) {
+        return;
+    }
+    return (getLabelmap(segmentation, referencedId) ??
+        getLabelmapForImageId(segmentation, referencedId) ??
+        getLabelmapForVolumeId(segmentation, referencedId) ??
+        getLabelmaps(segmentation).find((layer) => layer.volumeId === referencedId));
+}
+async function addPlanarLabelmapImageMapperActors(args) {
+    const { viewport, segmentation, segmentationId } = args;
+    for (const [index, layer] of getLabelmaps(segmentation).entries()) {
+        const volume = getOrCreateLabelmapVolume(layer);
+        if (!volume) {
+            continue;
+        }
+        const sliceData = createSliceImageData(volume, viewport);
+        if (!sliceData) {
+            continue;
+        }
+        const currentImageId = viewport.getCurrentImageId() ??
+            volume.imageIds[Math.min(Math.max(sliceData.state.sliceIndex, 0), Math.max(volume.imageIds.length - 1, 0))];
+        if (!currentImageId) {
+            continue;
+        }
+        const representationUID = createLabelmapRepresentationUID({
+            segmentationId,
+            referencedId: layer.labelmapId,
+        });
+        await viewport.addImages([
+            {
+                dataId: representationUID,
+                imageId: currentImageId,
+                imageData: sliceData.imageData,
+                reference: {
+                    kind: 'segmentation',
+                    segmentationId,
+                    representationUID,
+                    labelmapId: layer.labelmapId,
+                },
+                useWorldCoordinateImageData: true,
+                callback: ({ imageActor }) => {
+                    const mapper = imageActor.getMapper();
+                    const camera = getSliceRenderingCamera(viewport);
+                    mapper.setInputData(sliceData.imageData);
+                    mapper.modified();
+                    if (camera) {
+                        applyPlanarOverlayDepthOffset(imageActor, camera.viewPlaneNormal, index + 1);
+                    }
+                },
+            },
+        ]);
+    }
+    viewport.render();
+}
+function updatePlanarLabelmapImageMapperActors(args) {
+    const { viewport, segmentation, segmentationId, actorEntries } = args;
+    const actorEntriesByLabelmapId = new Map((actorEntries ?? viewport.getActors())
+        .filter((actorEntry) => isLabelmapRepresentationUID(actorEntry.representationUID, segmentationId))
+        .map((actorEntry) => [actorEntry.referencedId, actorEntry]));
+    getLabelmaps(segmentation).forEach((layer, index) => {
+        const actorEntry = actorEntriesByLabelmapId.get(layer.labelmapId);
+        if (!actorEntry) {
+            return;
+        }
+        const volume = getOrCreateLabelmapVolume(layer);
+        if (!volume) {
+            return;
+        }
+        const sliceData = createSliceImageData(volume, viewport);
+        if (!sliceData) {
+            return;
+        }
+        const mapper = actorEntry.actor.getMapper();
+        mapper.setInputData(sliceData.imageData);
+        mapper.modified();
+        const camera = getSliceRenderingCamera(viewport);
+        if (camera) {
+            applyPlanarOverlayDepthOffset(actorEntry.actor, camera.viewPlaneNormal, index + 1);
+        }
+        actorEntry.actor.modified?.();
+    });
+}

--- a/Viewers/backup/esm/@cornerstonejs/tools/dist/esm/utilities/segmentation/utilsForWorker.js
+++ b/Viewers/backup/esm/@cornerstonejs/tools/dist/esm/utilities/segmentation/utilsForWorker.js
@@ -67,9 +67,20 @@ export const getSegmentationDataForWorker = (segmentationId, segmentIndices) => 
         indices = [indices, 255];
     }
     const segImageIds = resolveSegImageIds(Labelmap, indices);
-    const isMultiBlock = Array.isArray(segImageIds) &&
-        Array.isArray(primaryImageIds) &&
-        segImageIds.length > primaryImageIds.length;
+    // Length comparison alone is blind to a single-segment query: one block's ids resolve to
+    // the same LENGTH as the primary block's (e.g. 160 > 160 is false), which routed the query
+    // into the reconstructable-volume branch — building a 40MB content-hash volume of the
+    // PRIMARY block (the wrong data entirely when the queried segment lives in a private
+    // block). Structural multi-block detection plus a first-id identity check close both holes;
+    // the first-id check also covers the registration window in which imageIds === allImageIds
+    // and isMultiBlockLabelmap is still false.
+    const isMultiBlock = isMultiBlockLabelmap(Labelmap) ||
+        (Array.isArray(segImageIds) &&
+            Array.isArray(primaryImageIds) &&
+            (segImageIds.length > primaryImageIds.length ||
+                (segImageIds.length > 0 &&
+                    primaryImageIds.length > 0 &&
+                    segImageIds[0] !== primaryImageIds[0])));
     const operationData = {
         segmentationId,
         volumeId: isMultiBlock ? undefined : segVolumeId,

--- a/Viewers/backup/esm/@cornerstonejs/tools/dist/esm/utilities/segmentation/utilsForWorker.js
+++ b/Viewers/backup/esm/@cornerstonejs/tools/dist/esm/utilities/segmentation/utilsForWorker.js
@@ -74,7 +74,14 @@ export const getSegmentationDataForWorker = (segmentationId, segmentIndices) => 
     // block). Structural multi-block detection plus a first-id identity check close both holes;
     // the first-id check also covers the registration window in which imageIds === allImageIds
     // and isMultiBlockLabelmap is still false.
-    const isMultiBlock = isMultiBlockLabelmap(Labelmap) ||
+    //
+    // `blocks` catches the remaining mint: a block-managed AI segmentation that still has only
+    // ONE block (stats fire right after the first segment is created). It is not structurally
+    // multi-block yet, so the volume path would mint a hash volume that nothing ever
+    // supersedes once the second block arrives — a permanent 40MB orphan per segmentation.
+    // Only this project's registration writes `blocks`; stock segmentations keep the volume path.
+    const isMultiBlock = (Array.isArray(Labelmap?.blocks) && Labelmap.blocks.length > 0) ||
+        isMultiBlockLabelmap(Labelmap) ||
         (Array.isArray(segImageIds) &&
             Array.isArray(primaryImageIds) &&
             (segImageIds.length > primaryImageIds.length ||

--- a/Viewers/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
+++ b/Viewers/extensions/cornerstone/src/services/SegmentationService/SegmentationService.ts
@@ -1558,6 +1558,24 @@ class SegmentationService extends PubSubService {
       return; // Volume Labelmap on Volume Viewport is natively supported
     }
 
+    // A multi-block (multi-layer) labelmap is already MPR-renderable: the render plan builds
+    // one correctly-positioned volume per layer from the layer's own imageIds. Converting it
+    // here would build an extra 40MB volume of the primary block alone under a fresh uuid,
+    // and the volumeId key that records it is deleted again on the next segmentation update
+    // (the legacy adapter syncs it from the primary stack layer, which has none) — orphaning
+    // that volume in a cache that never evicts volumes.
+    const labelmapData = segmentation.representationData[LABELMAP] as cstTypes.LabelmapSegmentationDataStack & {
+      labelmaps?: Record<string, unknown>;
+      allImageIds?: string[];
+    };
+    const layerCount = Object.keys(labelmapData?.labelmaps ?? {}).length;
+    const isMultiBlock =
+      layerCount > 1 ||
+      (labelmapData?.allImageIds?.length ?? 0) > (labelmapData?.imageIds?.length ?? 0);
+    if (isMultiBlock) {
+      return;
+    }
+
     const frameOfReferenceUID = viewport.getFrameOfReferenceUID();
     const imageIds = getLabelmapImageIds(segmentation.segmentationId);
     const segImage = cache.getImage(imageIds[0]);


### PR DESCRIPTION
## Problem

With a multi-block (z-cropped) segmentation in MPR, rotating the crosshairs caused two coupled failures:

- **Floating ghost copies of segments** appeared in both MPR and stack viewports, one more per oblique↔orthogonal round trip.
- **Duplicate 40MB labelmap volumes** accumulated in the volume cache (a content-hash-keyed copy and a bare-uuid copy of the primary block, alongside the two legitimate per-block volumes), never evicted — cornerstone's cache only LRU-evicts images, never volumes.

## Root causes

1. **Ghost actors.** Multi-block labelmaps render in MPR through a slice-mapper actor parked in a secondary overlay renderer. Upstream's removal path is gated on `canRenderVolumeViewportLabelmapAsImage` — which flips false the moment the viewport turns oblique (~0.06° of crosshair rotation), i.e. exactly when the render plan flips to legacy-volume and the actor must go. The fallback removal only touches the base renderer and erases the viewport's actor bookkeeping, leaving the slice actor untracked but permanently drawn, frozen at its last orthogonal plane.

2. **uuid volumes.** `SegmentationService` converted any labelmap without a `volumeId` key when adding it to an MPR viewport. Multi-block labelmaps never keep that key (the legacy adapter re-syncs it from the primary stack layer, which has none), so every MPR re-add minted a fresh uuid volume of the primary block, and the next segmentation update deleted the key again — orphaning the volume beyond the reach of any purge.

3. **hash volumes.** The stats worker's multi-block detection compared id-list lengths, which a single-segment query defeats (160 > 160 is false), routing it into the reconstructable-volume branch: a hash-keyed volume of the *primary* block — the wrong data entirely when the queried segment lives in a private block. A second mint window: stats fire right after segment 1 is created, when the segmentation genuinely has one block and isn't structurally multi-block yet.

4. **Positional-index ghost sites** of the class fixed earlier in the reference resolver: `syncStackLabelmapActors` stamped every layer's image with the current slice's origin, and the planar path clamped a viewport stack index into a block-local imageIds array.

## Fixes

- `volumeLabelmapImageMapper.js` (new override): gate removal on the overlay renderer's existence instead of renderability, sweep the overlay renderer for actors the viewport no longer tracks, and only move an actor into the overlay renderer when `viewport.addActor` actually accepted it.
- `imageChangeEventListener.js` (new override): fire one segmentation render when a viewport loses image-mapper capability — deferred behind a per-viewport 250ms settle timer, re-armed on every oblique camera frame, because remounting mid-drag visibly disrupted the rotation gesture.
- `SegmentationService.ts`: skip `convertStackToVolumeLabelmap` for multi-block labelmaps (already MPR-renderable via per-layer geometry volumes).
- `utilsForWorker.js`: detect multi-block structurally plus a first-id identity check, and recognize block-managed segmentations from the first segment via the representation's `blocks` descriptor (stock segmentations never carry it, so their behavior is unchanged).
- `syncStackLabelmapActors.js` / `planarGenericVolumeLabelmap.js` (new overrides): draw each layer's image at its own origin (create and update paths), and map the current source image through the layer's `referencedImageIds` instead of assuming the layer spans the stack.

## Verification

User-verified in the browser on the built container: no floating segments in MPR or stack across repeated oblique↔orthogonal crosshair rotations; rotation gesture smooth; segment statistics correct for private-block segments; volume census steady at exactly the two per-block volumes (80MB) with no hash or uuid entries at any point in the create→refine→add-segment→rotate flow. All overrides confirmed present in the builder-stage `node_modules` via discriminating greps; every touched file passes the tsc parse gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)