### PR TITLE
perf(nninter): click latency telemetry + three measured fixes (~900ms → ~400ms warm clicks)

### DIFF
--- a/Viewers/.dockerignore
+++ b/Viewers/.dockerignore
@@ -15,6 +15,8 @@
 # override silently vanishes from the bundle. Do not remove.
 !backup/esm/**
 **/build/
+# Exception: backup/esm mirrors node_modules/ and its paths contain dist/ — un-exclude it.
+!backup/esm/**
 
 # Dependencies
 **/node_modules/

--- a/Viewers/extensions/default/src/commandsModule.ts
+++ b/Viewers/extensions/default/src/commandsModule.ts
@@ -3360,6 +3360,17 @@ const commandsModule = ({
         return;
       }
       const _perfT0 = performance.now();
+      // Per-stage breakdown emitted as extras on the final 'nninter' measure, so one
+      // dump() record answers "which stage is the bottleneck". Collection is a couple
+      // of performance.now() calls per stage; the record itself is dropped by the
+      // no-op measure() when perf is disabled.
+      const _pfStages: Record<string, number> = {};
+      let _pfLast = _perfT0;
+      const _pfStage = (name: string) => {
+        const now = performance.now();
+        _pfStages[name] = Math.round((now - _pfLast) * 10) / 10;
+        _pfLast = now;
+      };
       if (!beginInferenceRunOrQueue()) {
         return;
       }
@@ -3513,6 +3524,7 @@ const commandsModule = ({
         document.dispatchEvent(new Event('measurement-state-changed'));
       }
 
+      _pfStage('prepMs'); // viewport state, segment numbering, prompt collection
       let nninterToken = '';
       try {
         nninterToken = await getNninterToken();
@@ -3521,6 +3533,7 @@ const commandsModule = ({
         // tokenless; the infer call surfaces its own error/expired handling.
         console.warn('nninter session claim failed; proceeding without token', e);
       }
+      _pfStage('tokenMs'); // session-claim round trip (cached claim is ~0)
       let url = `/monai/infer/segmentation?image=${currentDisplaySets.SeriesInstanceUID}&output=dicom_seg`;
       let params = {
         largest_cc: false,
@@ -3576,9 +3589,11 @@ const commandsModule = ({
       try {
         // Process the response
         const response = await segmentationPromise;
+        _pfStage('requestMs'); // upload + server queue/compute + response download
         if (response.status === 200) {
             const ct = response.headers["content-type"] as string;
             const { meta, seg } = await parseMultipart(response.data, ct, { allowEmptySeg: true });
+            _pfStage('parseMs'); // multipart split of the response body
             // Server-side session was evicted/timed out. Reclaim, re-init, and
             // re-run: measurements still hold the full prompt history, and the
             // server replays any prompts it hasn't seen (one GPU prediction).
@@ -3614,6 +3629,13 @@ const commandsModule = ({
 
             const flipped = meta.flipped.toLowerCase() === "true"
             const nninter_elapsed = meta.nninter_elapsed
+            {
+              // Server-reported wall time for its nninter block, in seconds
+              // (basic_infer.py: time.time() - start). requestMs - serverMs is
+              // then the network + proxy + FastAPI overhead. -1 = not reported.
+              const _sv = parseFloat(nninter_elapsed as any);
+              _pfStages.serverMs = Number.isFinite(_sv) ? Math.round(_sv * 1000) : -1;
+            }
             const prompt_info = meta.prompt_info
             const label_name = meta.label_name
             const raw = seg
@@ -3863,6 +3885,7 @@ const commandsModule = ({
             // Fresh block: its own start is the SNAPPED lower bound, matching the images just cut.
             _newBlockZ0 = _aw0;
           }
+          _pfStage('allocMs'); // context refresh + block decision + derived-image creation
 
           if (_reuseIdx >= 0) {
             // Volume-only path: derive z_range straight from the crop bytes (which slices actually
@@ -3979,6 +4002,7 @@ const commandsModule = ({
               }
             }
           }
+          _pfStage('writeMs'); // crop -> labelmap slice writes + in-place MPR volume update
 
           // The refined segment's block is REPLACED in the list (keeping its position, so no other
           // segment is renumbered); a new segment APPENDS one. This used to be done by slicing the
@@ -4205,13 +4229,39 @@ const commandsModule = ({
             mprInPlaceDone: _mprInPlaceDone,
             blocks: _nextBlocks,
           });
+          _pfStage('postProcMs'); // representation swap, remount (when not in-place), render
           // Evict the orphaned old block now that the representation swap + volume rebuild are
           // done and nothing references these imageIds. Caps the ~84MB/refine cache growth that
           // was inflating the MPR remount and causing GC-pause spikes across the other legs.
           for (const _oid of _orphanedImageIds) {
             try { cache.removeImageLoadObject(_oid, { force: true }); } catch { /* already gone */ }
           }
-          perf.measure('nninter', _perfT0);
+          _pfStage('evictMs'); // orphaned-block cache eviction
+          // Browser-level transport split for THIS click's POST (same-origin, so full
+          // timing is exposed; buffer sizing in perfTraceBrowser). connectMs > 0 means a
+          // NEW TCP connection was opened (expected ~0 on a warmed keep-alive pool);
+          // stalledMs = browser queueing before send; ttfbMs = request sent -> first
+          // response byte (≈ upload + RTT + server wall, and serverMs is known);
+          // downloadMs = pure body transfer — the congestion-window probe: shrinking
+          // across a burst = cwnd warming, flat = the idle-restart theory is wrong.
+          try {
+            const _rt = (performance.getEntriesByType('resource') as PerformanceResourceTiming[])
+              .filter(e => e.name.includes('/monai/infer/segmentation') && e.startTime >= _perfT0)
+              .pop();
+            _pfStages.connectMs = _rt ? Math.round((_rt.connectEnd - _rt.connectStart) * 10) / 10 : -1;
+            _pfStages.stalledMs = _rt ? Math.round((_rt.requestStart - _rt.startTime) * 10) / 10 : -1;
+            _pfStages.ttfbMs = _rt ? Math.round((_rt.responseStart - _rt.requestStart) * 10) / 10 : -1;
+            _pfStages.downloadMs = _rt ? Math.round((_rt.responseEnd - _rt.responseStart) * 10) / 10 : -1;
+          } catch {
+            /* resource timing unavailable — breakdown simply omits the transport split */
+          }
+          // inPlace tells the reader which write path a sample took: 1 = block reuse +
+          // in-place MPR volume write (no remount), 0 = fresh block + remount.
+          _pfStages.inPlace = _mprInPlaceDone ? 1 : 0;
+          if (perf.enabled) {
+            console.log('[perf] nninter breakdown (ms):', _pfStages);
+          }
+          perf.measure('nninter', _perfT0, _pfStages);
           perf.snapshot('afterRefine');
           return response;
         }

--- a/Viewers/extensions/default/src/utils/perfTraceBrowser.ts
+++ b/Viewers/extensions/default/src/utils/perfTraceBrowser.ts
@@ -122,6 +122,22 @@ const enabled =
   typeof window !== 'undefined' &&
   isPerfEnabled(window.location.search, _storage);
 
+// The transport probe (commandsModule nninter breakdown) reads the POST's
+// PerformanceResourceTiming entry. The default 250-entry buffer overflows on
+// DICOM instance loading (hundreds of fetches per study) and a FULL buffer
+// silently DROPS new entries — so the probe would read nothing exactly in the
+// sessions worth measuring. Raise it and recycle on overflow, perf-gated.
+if (enabled) {
+  try {
+    performance.setResourceTimingBufferSize(10000);
+    performance.addEventListener('resourcetimingbufferfull', () => {
+      performance.clearResourceTimings();
+    });
+  } catch {
+    // Older browsers: probe degrades to -1s via its own guard.
+  }
+}
+
 export const perf: PerfTrace = createPerfTrace(
   enabled
     ? buildCornerstoneDeps({ cache, eventTarget, getRenderingEngines }, () => blockStatsProvider())

--- a/Viewers/platform/app/.recipes/Nginx-Orthanc/config/nginx.conf
+++ b/Viewers/platform/app/.recipes/Nginx-Orthanc/config/nginx.conf
@@ -23,6 +23,14 @@ http {
   tcp_nodelay on;
   client_max_body_size 500M;
 
+  # Transfer-attribution log for AI inference requests. req_time spans first
+  # request byte -> last response byte (so it INCLUDES the client's upload and
+  # download legs); up_time is the upstream (FastAPI) leg. req_time - up_time
+  # ~= what the network cost this request beyond the server — compare against
+  # the client's ttfbMs/downloadMs breakdown to attribute slow-link sessions.
+  log_format timing '$remote_addr [$time_local] "$request" $status $body_bytes_sent '
+                    'req_len=$request_length req_time=$request_time up_time=$upstream_response_time';
+
   upstream monai_up {
     server monai_server:8002;
     keepalive 64;   # pool of idle connections to FastAPI
@@ -81,6 +89,7 @@ http {
     }
 
     location /monai/ {
+      access_log /var/log/nginx/access.log timing;
       proxy_pass http://monai_server:8002;
       proxy_http_version 1.1;
       proxy_set_header Connection "";

--- a/monai-label/monailabel/tasks/infer/basic_infer.py
+++ b/monai-label/monailabel/tasks/infer/basic_infer.py
@@ -238,8 +238,56 @@ _artifact_loader = nnInteractiveInferenceSession(
 _NNINTER_ARTIFACTS = _artifact_loader._load_model_artifacts_from_disk(model_path)
 
 
+class _LowPrioSnapshotSession(nnInteractiveInferenceSession):
+    """nnInteractive session with the undo snapshot made cheaper and polite.
+
+    The stock snapshot LZ4-level-5 compresses the FULL interactions tensor
+    (~2.9GB fp16 on a 694-slice study) right after every prediction. Measured
+    from the browser (ttfb - serverMs with connectMs=0): a click landing inside
+    that window stalled ~330ms before any server timer started. Two mitigations:
+
+    - clevel 5 -> 1: the tensor is mostly zeros, so the compressed size is
+      unchanged (0.4MB either way, measured) while the compress drops 271ms ->
+      80ms — the contention window shrinks ~3.4x.
+    - the compress runs on a dedicated thread niced +10, so request handling
+      outranks it whenever they still contend. Self-nice at thread creation
+      needs no capability; raise-then-restore does NOT work here (restoring
+      needs CAP_SYS_NICE, which Docker's default profile drops — setpriority
+      back to 0 raises EPERM even as in-container root). It must be a SEPARATE
+      executor because the session's own 2-worker pool also runs set_image
+      preprocessing, which is latency-critical and must stay at normal
+      priority. blosc2's internal workers spawn lazily from the calling
+      thread and inherit its niceness.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._snapshot_executor = ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="nninter_snapshot",
+            initializer=lambda: os.nice(10),
+        )
+
+    def _blosc2_cparams(self, nthreads=None) -> dict:
+        params = super()._blosc2_cparams(nthreads)
+        params["clevel"] = 1
+        return params
+
+    def _snapshot_state(self) -> dict:
+        # Called either synchronously (first interaction) or on the session's own
+        # executor (async post-predict snapshot). Both simply wait here while the
+        # niced thread does the heavy compress — occupancy is unchanged, and the
+        # separate 1-worker executor cannot deadlock with either caller.
+        return self._snapshot_executor.submit(super()._snapshot_state).result()
+
+    def __del__(self):
+        if hasattr(self, "_snapshot_executor"):
+            self._snapshot_executor.shutdown(wait=False)
+        super().__del__()
+
+
 def _new_nninter_session() -> nnInteractiveInferenceSession:
-    s = nnInteractiveInferenceSession(
+    s = _LowPrioSnapshotSession(
         device=torch.device("cuda:0"),
         use_torch_compile=True,
         verbose=True,
@@ -1349,7 +1397,13 @@ class BasicInferTask(InferTask):
             if op == "init":
                 return "/code/predictions/session_expired.nii.gz", expired_json
             return np.zeros((0, 0, 0), dtype=np.uint8), expired_json
+        _t_lock = time.time()
         with entry.lock:
+            _lock_wait = time.time() - _t_lock
+            if _lock_wait > 0.02:
+                # A prior request (or its tail work) still held this session.
+                # Lands in the client's pre-server gap, so make it visible.
+                logger.info(f"[timing] nninter session lock wait: {_lock_wait:.3f}s")
             return self._call_core(request, callbacks, entry=entry)
 
     def _call_core(
@@ -1422,11 +1476,13 @@ class BasicInferTask(InferTask):
             # Zero-copy view + crop-only copy (same pattern as the normal result path).
             pred = session.target_buffer.numpy()  # (Z, Y, X) uint8, VIEW
             pred_full_shape = list(pred.shape)
-            z_nz = np.where(np.any(pred, axis=(1, 2)))[0]
+            # max-reduce on the z-slab, matching the normal result path (see there for why).
+            z_nz = np.where(pred.max(axis=(1, 2)))[0]
             if z_nz.size > 0:
-                y_nz = np.where(np.any(pred, axis=(0, 2)))[0]
-                x_nz = np.where(np.any(pred, axis=(0, 1)))[0]
                 z0, z1 = int(z_nz[0]), int(z_nz[-1]) + 1
+                _slab = pred[z0:z1]
+                y_nz = np.where(_slab.max(axis=(0, 2)))[0]
+                x_nz = np.where(_slab.max(axis=(0, 1)))[0]
                 y0, y1 = int(y_nz[0]), int(y_nz[-1]) + 1
                 x0, x1 = int(x_nz[0]), int(x_nz[-1]) + 1
                 pred = np.ascontiguousarray(pred[z0:z1, y0:y1, x0:x1])  # copy of crop only
@@ -1465,10 +1521,13 @@ class BasicInferTask(InferTask):
         # Resetting here (before image loading) keeps the same semantics as a
         # separate reset call, but saves ~1.4 s of network overhead on slow links.
         if request.get('nninter_reset_first'):
+            _t_reset = time.time()
             for key, lst in used_interactions.items():
                 lst.clear()
             session.reset_interactions()
-            logger.info("Folded reset before inference")
+            # Runs BEFORE the [timing] windows, so its cost lands in the client's
+            # pre-server gap — log the duration here to keep it accounted for.
+            logger.info(f"[timing] folded reset before inference: {time.time() - _t_reset:.3f}s")
 
         req = copy.deepcopy(self._config)
         req.update(request)
@@ -2496,14 +2555,19 @@ class BasicInferTask(InferTask):
             # Reduces wire bytes and compression time proportionally to segmentation size.
             # Client reconstructs full volume using pred_offset + pred_full_shape from meta.
             pred_full_shape = list(pred.shape)
-            # np.any along axes is ~10x faster than np.nonzero on large sparse arrays
-            # because it short-circuits and reduces 182M elements to three 1-D projections.
-            z_any = np.any(pred, axis=(1, 2))
+            # max-reduce, not np.any: numpy's logical reductions on uint8 are byte-wise
+            # while maximum.reduce is SIMD. Together with slab-restricting the Y/X
+            # projections below this took result_retrieve from 74-104ms to 26-35ms on a
+            # 694x512x512 volume (measured in production, 2026-08).
+            z_any = pred.max(axis=(1, 2))
             z_nz  = np.where(z_any)[0]
             if z_nz.size > 0:
-                y_nz = np.where(np.any(pred, axis=(0, 2)))[0]
-                x_nz = np.where(np.any(pred, axis=(0, 1)))[0]
                 z0, z1 = int(z_nz[0]),  int(z_nz[-1])  + 1
+                # Y/X projections only need the z-slab: any nonzero voxel's z lies in
+                # [z0, z1) by construction, so rows outside it contribute nothing.
+                _slab = pred[z0:z1]
+                y_nz = np.where(_slab.max(axis=(0, 2)))[0]
+                x_nz = np.where(_slab.max(axis=(0, 1)))[0]
                 y0, y1 = int(y_nz[0]),  int(y_nz[-1])  + 1
                 x0, x1 = int(x_nz[0]),  int(x_nz[-1])  + 1
                 pred = np.ascontiguousarray(pred[z0:z1, y0:y1, x0:x1])  # copy of crop only

--- a/monai-label/monailabel/utils/others/stream.py
+++ b/monai-label/monailabel/utils/others/stream.py
@@ -59,10 +59,16 @@ def stream_multipart(meta: dict, seg_payload: Union[BytesLike, "np.ndarray"]) ->
     """
     Sends a multipart/form-data with:
       - part "meta": application/json, Content-Encoding: gzip
-      - part "seg" : application/octet-stream, sent UNCOMPRESSED
-    The seg is a 0/1 mask crop; on a fast (same-host) link the raw transfer is cheap,
-    whereas gzip made the client pay a DecompressionStream gunzip that scaled with mask
-    size (~180-450ms on large masks). Only the tiny meta part is still gzipped.
+      - part "seg" : application/octet-stream, Content-Encoding: gzip (level 1)
+    The seg is a 0/1 mask crop, which gzips ~150x (1.5MB -> ~20KB): on anything slower
+    than a wired LAN the transfer saving (~400ms measured at ~27Mbps effective) dwarfs
+    the client's ~30ms DecompressionStream cost, and on a gigabit link the delta is
+    within noise. Level 1 keeps the server-side compress at a few ms; on a binary mask
+    its ratio is nearly identical to level 6. (An earlier revision sent the seg RAW
+    because client gunzip measured 180-450ms — that number came from a heap suffering
+    since-fixed GC pressure from full-volume labelmap blocks, and raw only won on the
+    gigabit link it was measured over.) The client's per-part gunzipIfNeeded keys off
+    Content-Encoding, so clients parse either encoding.
     """
     boundary = f"monai-{secrets.token_hex(12)}"
     CRLF = b"\r\n"
@@ -81,6 +87,7 @@ def stream_multipart(meta: dict, seg_payload: Union[BytesLike, "np.ndarray"]) ->
         dash_boundary,
         b'Content-Disposition: form-data; name="seg"; filename="seg.bin"',
         b"Content-Type: application/octet-stream",
+        b"Content-Encoding: gzip",
         b"",
     ]) + CRLF
 
@@ -100,10 +107,10 @@ def stream_multipart(meta: dict, seg_payload: Union[BytesLike, "np.ndarray"]) ->
             yield gz
         yield CRLF  # end of meta body
 
-        # seg part — sent UNCOMPRESSED (no Content-Encoding), so the client skips gunzip.
+        # seg part — gzip level 1 (see docstring for the raw-vs-gzip history).
         yield seg_headers
-        for ch in seg_iter:
-            yield ch.tobytes()
+        for gz in _gzip_stream(seg_iter, level=1):
+            yield gz
         yield CRLF  # end of seg body
 
         # closing boundary


### PR DESCRIPTION
## Summary

Instrumented the full nnInteractive click path end to end, then fixed the three bottlenecks the numbers actually indicted. Warm clicks went from ~900ms to ~370–430ms on a 694-slice study (and from 2.1–2.9s at the start of the investigation); the remaining time is GPU compute (`model_core`) plus link RTT.

### Telemetry (permanent, gated behind `?perf=1` / `localStorage.ohifPerf='1'`)
- **Stage breakdown on every `nninter` measure**: `prepMs, tokenMs, requestMs, parseMs, allocMs, writeMs, postProcMs, evictMs`, plus `serverMs` (server-reported `nninter_elapsed`) and `inPlace` (which write path the click took). Also console-logged live per click.
- **Browser transport split**: `connectMs / stalledMs / ttfbMs / downloadMs` from the POST's `PerformanceResourceTiming` (with perf-gated resource-buffer sizing — DICOM loading overflows the 250-entry default, which silently drops entries).
- **nginx timing access-log** on the `/monai/` proxy (`req_len / req_time / up_time`): attributes network cost server-side, no browser needed.
- **Server `[timing]` coverage** for the session lock wait and the folded reset — the only work that runs before the existing timing windows.

### Fixes (each one measured before and after)
1. **Seg part gzipped again (level 1)** — the mask compresses ~26× on real data (1.5MB → ~57KB). The earlier raw-seg decision was measured on a gigabit path where transfer was ~11ms; on a ~27Mbps link the raw transfer cost ~450ms/click while decompressing today's crops costs ~10–30ms (the old 180–450ms gunzip figure was inflated by since-fixed GC pressure). Level 1 ≈ level 6 on a binary mask; client `gunzipIfNeeded` keys off the part header, so both encodings parse.
2. **`result_retrieve` 3× faster** — the tight-bbox scan ran three `np.any` passes over the full 694×512×512 buffer (numpy logical reductions on uint8 are byte-wise loops): 74–104ms/click. Switched to SIMD `max`-reduce and slab-restricted the Y/X projections: 26–35ms measured live. Same change on the undo path.
3. **Undo-snapshot contention shrunk + deprioritized** — the post-predict snapshot LZ4-5-compresses the full ~2.9GB interactions tensor; clicks landing in that window stalled ~330ms before any server timer started (proven by `ttfbMs − serverMs` with `connectMs=0`). Now clevel 1 (271→80ms, byte-identical 0.4MB output) on a dedicated thread self-niced +10. Restore-after-nice is impossible in Docker (default profile drops `CAP_SYS_NICE`; verified EPERM as in-container root), hence a separate executor so `set_image` preprocessing keeps normal priority. Verified: rapid-refine bursts show no spikes; `ttfb − serverMs` sits at the ~30–70ms RTT floor.

### Verified in MPR
`inPlace:1` on every MPR refine, client cost collapsed to ~10ms/click (`allocMs` 0.3ms vs 40–65ms in stack), `volCount` and `listenerCount` flat across 14 consecutive refines (no volume/listener growth).

## Test plan
- [x] Stack-viewport refine bursts, segment switches, MPR refines — breakdowns captured and cross-checked against server `[timing]` + nginx logs
- [x] blosc2 clevel benchmark in-container (identical output size)
- [x] Session-expiry recovery (`nninterRecovered`) observed working after a server restart
- [x] Undo verified after fast refine bursts

🤖 Generated with [Claude Code](https://claude.com/claude-code)